### PR TITLE
Removed "make process public" button

### DIFF
--- a/src/management-system/src/backend/server/process.js
+++ b/src/management-system/src/backend/server/process.js
@@ -244,12 +244,12 @@ export function setupProcessRequestHandlers(addListener, broadcast, sendCommand,
         .emit(event, ...data);
     }
 
-    socket.on('data_saveUserTaskHTML', async (taskId, html) => {
+    socket.on('data_saveUserTaskHTML', async (taskId, html, callback) => {
       logger.debug(
         `Request to save html for user task with id ${taskId} in process with id ${processDefinitionsId}.`
       );
       await saveUserTaskHTML(processDefinitionsId, taskId, html);
-
+      callback();
       broadcastToView('user_task_html_changed', taskId, html);
     });
 

--- a/src/management-system/src/frontend/components/processes/editor/CallActivityHandling.vue
+++ b/src/management-system/src/frontend/components/processes/editor/CallActivityHandling.vue
@@ -167,10 +167,8 @@ export default {
 
     async filterSelectableSubprocesses() {
       // only processes should be executed and be executed more that once so they are the only valid selection
-      // hide local subprocesses to avoid problems on deployment down the line
-      // local processes are not deployable since they are unknown to the backend
       this.selectableProcesses = this.$store.getters['processStore/processes'].filter((process) => {
-        return process.type === 'process' && process.shared;
+        return process.type === 'process';
       });
     },
     async selectCurrentSubprocess() {

--- a/src/management-system/src/frontend/components/processes/editor/MainEditorToolbar.vue
+++ b/src/management-system/src/frontend/components/processes/editor/MainEditorToolbar.vue
@@ -94,7 +94,7 @@
         <template #tooltip-text>Open Properties Panel</template>
         mdi-cog-off-outline
       </tooltip-button>
-      <tooltip-button v-if="!isElectron" :disabled="!isShared" @click="clipUrl">
+      <tooltip-button v-if="!isElectron" @click="share">
         <template #tooltip-text>Share</template>
         mdi-share-outline
       </tooltip-button>
@@ -215,7 +215,17 @@ export default {
     },
   },
   methods: {
-    clipUrl() {
+    async share() {
+      if (!this.isShared) {
+        // if the process is currently not stored in the backend => move it into the backend
+        await this.$store.dispatch('processStore/update', {
+          id: this.process.id,
+          changes: { shared: true },
+        });
+        // subscribe for editing events from other clients and inform the backend that this client is currently editing the process
+        await this.$store.dispatch('processEditorStore/startEditing');
+      }
+
       // Hacky workaround to copy the current url into the clipboard: https://stackoverflow.com/a/49618964
       const dummyInput = document.createElement('input');
       document.body.appendChild(dummyInput);

--- a/src/management-system/src/frontend/components/processes/editor/ProcessModal.vue
+++ b/src/management-system/src/frontend/components/processes/editor/ProcessModal.vue
@@ -128,11 +128,6 @@ export default {
         };
       });
 
-      // don't show local processes as deployable
-      if (this.isDeploymentMode && !process.env.IS_ELECTRON) {
-        processes = processes.filter((process) => process.shared);
-      }
-
       if (this.showFavoriteList) {
         processes = processes.filter((process) => process.isFavorite);
       }

--- a/src/management-system/src/frontend/components/processes/processForm/ProcessForm.vue
+++ b/src/management-system/src/frontend/components/processes/processForm/ProcessForm.vue
@@ -87,14 +87,6 @@
                     <small>*indicates required field</small>
                   </v-col>
                 </v-row>
-                <v-row v-if="canShareProcess && !storedInBackend">
-                  <v-col>
-                    <v-switch
-                      v-model="currentData.shared"
-                      :label="`Make process publicly accessible.`"
-                    ></v-switch>
-                  </v-col>
-                </v-row>
                 <fifth-industry-properties
                   :processType="processType"
                   :currentData="currentData"
@@ -175,9 +167,7 @@ import BpmnPreview from '@/frontend/components/bpmn/BpmnPreview.vue';
  * @vue-prop {String} action - the kind of action that is performed by the sorrounding form (used for header)
  * @vue-prop {String} processType - the kind of process that is manipulated (e.g. process, project, ...) (used for header)
  *
- * @vue-computed {boolean} canShareProcess - if the component is executed in a web client that allows sharing via the backend
  * @vue-computed {Process[]} storedProcesses - all processes from the vuex store
- * @vue-computed {Process[]} storedInBackend - all processes that are stored in the backend and not locally in the browser
  * @vue-computed {String[]} departmentNames - names of all possible departments
  * @vue-computed {*} departments - all possible departments
  * @vue-computed {number} currentIndex - the current displayed Page minus 1 (index in array)
@@ -222,16 +212,8 @@ export default {
     isProject() {
       return this.processType === 'project';
     },
-    canShareProcess() {
-      return !process.env.IS_ELECTRON && Storage;
-    },
     storedProcesses() {
       return this.$store.getters['processStore/processes'];
-    },
-    storedInBackend() {
-      const { id } = this.currentData;
-      const storedProcess = this.storedProcesses.find((p) => p.id === id);
-      return storedProcess && storedProcess.shared;
     },
     departmentNames() {
       return this.departments.map((department) => department.name);
@@ -365,7 +347,7 @@ export default {
     },
     // this will be called from a function in the mixin if a new entry is added
     initProcessData() {
-      return { type: this.processType, shared: false };
+      return { type: this.processType };
     },
     // this will be called from a function in the mixin if the bpmn of a processesDataEntry changes
     async initProcessDataFromBPMN(_, changes) {
@@ -382,7 +364,6 @@ export default {
 
       return {
         departments: [...existingProcess.departments],
-        shared: existingProcess.shared || false,
       };
     },
   },

--- a/src/management-system/src/frontend/components/universal/ProcessVersioning/helpers.js
+++ b/src/management-system/src/frontend/components/universal/ProcessVersioning/helpers.js
@@ -140,7 +140,7 @@ export async function createNewProcessVersion(store, bpmn, versionName, versionD
     bpmn: versionedBpmn,
   });
 
-  processInterface.updateProcessVersionBasedOn(definitionId, epochTime);
+  await processInterface.updateProcessVersionBasedOn(definitionId, epochTime);
 
   return epochTime;
 }

--- a/src/management-system/src/frontend/views/Deployments.vue
+++ b/src/management-system/src/frontend/views/Deployments.vue
@@ -274,6 +274,16 @@ export default {
         this.openPopup();
       } else {
         this.isCurrentlyDeploying = true;
+
+        // check if the process is already stored in the backend (otherwise the backend cannot deploy it)
+        if (!processToDeploy.shared) {
+          // if not => move it into the backend
+          await this.$store.dispatch('processStore/update', {
+            id: this.processToDeploy.id,
+            changes: { shared: true },
+          });
+        }
+
         try {
           await engineNetworkInterface.deployProcessVersion(processToDeploy.id, version, dynamic);
           this.popupData.body = 'Deployed process version successfully';


### PR DESCRIPTION
### Summary

- A user is not explicitly asked if a process should be stored locally or on the backend anymore
- A locally stored process will be automatically moved to the server in some circumstances

### Is this a major change of any component?
(Tick the ones that apply)

- [ ] Some API (JS, REST, Dispatcher, BPMN Server Event) is newly introduced
- [ ] Some API (JS, REST, Dispatcher, BPMN Server Event) has been completely reworked and is not backward compatible
- [ ] Major change of the underlying architecture
- [ ] A version of a dependency has been changed

### Details

- [x] Removed the button that asks if the process should be made public/stored on the server from process creation/editing form
- [x] The process will be stored locally for unauthenticated users and will be pushed to the server for authenticated users on creation
- [x] the process is pushed to the server automatically if the user selects to share it in the modeler or if the user tries to deploy it
- [x] If a process references other processes that are stored locally through  call-activities they are recursively pushed to the server to prevent problems for other users inspecting the process or for later deployments (the imports need to be present on the server when a user tries to look into the respective call activities or when the process is supposed to be deployed)    