### PR TITLE
Add playwright with tasklist scaffold

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,8 @@ package-lock.json
 # env configs
 ./src/management-system/src/backend/server/environment-configurations/
 ./src/backend/server/environment-configurations/
+
+# Playwright
+/test-results/
+/playwright-report/
+/playwright/.cache/

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "@babel/plugin-proposal-class-properties": "^7.5.0",
     "@babel/preset-env": "^7.5.2",
     "@open-wc/webpack-import-meta-loader": "0.4.7",
+    "@playwright/test": "^1.30.0",
     "@userfrosting/merge-package-dependencies": "^1.2.0",
     "babel-eslint": "^10.0.3",
     "babel-loader": "^8.0.6",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,94 @@
+import { defineConfig, devices } from '@playwright/test';
+
+/**
+ * Read environment variables from file.
+ * https://github.com/motdotla/dotenv
+ */
+// require('dotenv').config();
+
+/**
+ * See https://playwright.dev/docs/test-configuration.
+ */
+export default defineConfig({
+  testDir: './tests',
+  /* Maximum time one test can run for. */
+  timeout: 30 * 1000,
+  expect: {
+    /**
+     * Maximum time expect() should wait for the condition to be met.
+     * For example in `await expect(locator).toHaveText();`
+     */
+    timeout: 5000,
+  },
+  /* Run tests in files in parallel */
+  fullyParallel: true,
+  /* Fail the build on CI if you accidentally left test.only in the source code. */
+  forbidOnly: !!process.env.CI,
+  /* Retry on CI only */
+  retries: process.env.CI ? 2 : 0,
+  /* Opt out of parallel tests on CI. */
+  workers: process.env.CI ? 1 : undefined,
+  /* Reporter to use. See https://playwright.dev/docs/test-reporters */
+  reporter: 'html',
+  /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
+  use: {
+    /* Maximum time each action such as `click()` can take. Defaults to 0 (no limit). */
+    actionTimeout: 0,
+    /* Base URL to use in actions like `await page.goto('/')`. */
+    baseURL: 'https://localhost:33083',
+
+    /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
+    trace: 'on-first-retry',
+  },
+
+  /* Configure projects for major browsers */
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'], ignoreHTTPSErrors: true },
+    },
+
+    {
+      name: 'firefox',
+      use: { ...devices['Desktop Firefox'], ignoreHTTPSErrors: true },
+    },
+
+    {
+      name: 'webkit',
+      use: { ...devices['Desktop Safari'], ignoreHTTPSErrors: true },
+    },
+
+    /* Test against mobile viewports. */
+    // {
+    //   name: 'Mobile Chrome',
+    //   use: { ...devices['Pixel 5'] },
+    // },
+    // {
+    //   name: 'Mobile Safari',
+    //   use: { ...devices['iPhone 12'] },
+    // },
+
+    /* Test against branded browsers. */
+    // {
+    //   name: 'Microsoft Edge',
+    //   use: { channel: 'msedge' },
+    // },
+    // {
+    //   name: 'Google Chrome',
+    //   use: { channel: 'chrome' },
+    // },
+  ],
+
+  /* Folder for test artifacts such as screenshots, videos, traces, etc. */
+  // outputDir: 'test-results/',
+
+  // Run your local dev server before starting the tests */
+
+  // dev-ms-server takes too long before it can take requests, so you should
+  // start this manually.
+  /*webServer: {
+    command: 'yarn dev-ms-server',
+    port: 33083,
+    reuseExistingServer: !process.env.CI,
+  },*/
+});

--- a/tests/tasklist/tasklist.fixtures.ts
+++ b/tests/tasklist/tasklist.fixtures.ts
@@ -1,0 +1,26 @@
+import { test as base } from '@playwright/test';
+import { TasklistPage } from './tasklist.page';
+
+// Declare the types of your fixtures.
+type MyFixtures = {
+  tasklistPage: TasklistPage;
+};
+
+// Extend base test by providing "tasklistPage".
+// This new "test" can be used in multiple test files, and each of them will get the fixtures.
+export const test = base.extend<MyFixtures>({
+  tasklistPage: async ({ page }, use) => {
+    // Set up the fixture.
+    const tasklistPage = new TasklistPage(page);
+    await tasklistPage.createUsertaskProcess();
+    await tasklistPage.goto();
+
+    // Use the fixture value in the test.
+    await use(tasklistPage);
+
+    // Clean up the fixture.
+    await tasklistPage.removeAll();
+  },
+});
+
+export { expect } from '@playwright/test';

--- a/tests/tasklist/tasklist.page.ts
+++ b/tests/tasklist/tasklist.page.ts
@@ -1,0 +1,85 @@
+import { Locator, Page } from '@playwright/test';
+
+export class TasklistPage {
+  readonly page: Page;
+  readonly emptyTasklist: Locator;
+
+  constructor(page: Page) {
+    this.page = page;
+    this.emptyTasklist = page.getByText('There are currently no tasks in your queue.');
+  }
+
+  async goto() {
+    await this.page.goto('/#/tasklist');
+  }
+
+  async addTask() {
+    const page = this.page;
+
+    // Start instance.
+    await page.getByRole('link', { name: 'Executions' }).click();
+    await page
+      .getByRole('row', { name: 'My Process' })
+      .getByRole('button', { name: 'Show Instances' })
+      .click();
+    await page.locator('span:nth-child(4) > .v-btn').first().click();
+    await page.getByRole('link', { name: 'Tasklist' }).click();
+  }
+
+  async createUsertaskProcess() {
+    const page = this.page;
+    // TODO: reuse other page models for these set ups.
+    // Add a new process.
+    await page.goto('https://localhost:33083/#/process');
+    await page.getByRole('button', { name: 'Add' }).click();
+    await page.getByLabel('Name*').fill('My Process');
+    await page.getByLabel('Description').fill('Very important process!');
+    await page.getByLabel('Department', { exact: true }).click();
+    await page.getByRole('option', { name: 'Marketing' }).locator('i').click();
+    await page.getByRole('option', { name: 'Purchasing' }).locator('i').click();
+    await page.locator('div').filter({ hasText: 'Add Process' }).first().click();
+    await page.getByRole('button', { name: 'Add Process' }).click();
+
+    // Add Usertask.
+    await page.mouse.move(600, 200);
+    await page.mouse.down();
+    await page.mouse.move(300, 200);
+    await page.mouse.up();
+    await page.locator('svg').nth(3).click();
+    await page.locator('rect').first().click();
+    await page.getByTitle('Append Task').click();
+    await page.getByTitle('Append EndEvent').click();
+    await page.locator('g:nth-child(2) > .djs-element > .djs-hit').click();
+    await page.getByTitle('Change type').click();
+    await page.getByRole('listitem', { name: 'User Task' }).locator('span').first().click();
+
+    // Deploy.
+    await page.getByRole('link', { name: 'Executions' }).click();
+    await page.getByRole('button', { name: 'Deploy Process' }).click();
+    await page
+      .getByRole('row', { name: 'My Process' })
+      .getByRole('button', { name: 'dynamic' })
+      .click();
+    await page.getByLabel('Version Name').fill('1');
+    await page.getByLabel('Version Description').fill('1');
+    await page.getByRole('button', { name: 'Create Version' }).click();
+  }
+
+  async removeAll() {
+    const page = this.page;
+    await page.getByRole('link', { name: 'Executions' }).click();
+    await page.getByRole('button', { name: '󰆴' }).click();
+    await page.getByRole('button', { name: 'Delete Deployment' }).click();
+    await page.getByRole('link', { name: 'Processes' }).click();
+    await page
+      .getByRole('row', {
+        name: 'Name: Not sorted. Activate to sort ascending. Last Edited: Not sorted. Activate to sort ascending. Departments',
+      })
+      .locator('div')
+      .nth(2)
+      .click();
+    await page.getByRole('button', { name: 'Select Action' }).click();
+    await page.getByText('Delete').click();
+    await page.getByRole('button', { name: 'Delete Process' }).click();
+  }
+}

--- a/tests/tasklist/tasklist.spec.ts
+++ b/tests/tasklist/tasklist.spec.ts
@@ -1,0 +1,11 @@
+import { test, expect } from './tasklist.fixtures';
+
+test('shows the active tasks', async ({ tasklistPage }) => {
+  await expect(tasklistPage.emptyTasklist).toBeVisible();
+  await tasklistPage.addTask();
+  await tasklistPage.addTask();
+  await tasklistPage.addTask();
+  // Wait for task to propagate.
+  await tasklistPage.page.waitForTimeout(5000);
+  await expect(tasklistPage.emptyTasklist).not.toBeVisible();
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -1460,6 +1460,14 @@
   resolved "https://registry.yarnpkg.com/@panva/asn1.js/-/asn1.js-1.0.0.tgz#dd55ae7b8129e02049f009408b97c61ccf9032f6"
   integrity sha512-UdkG3mLEqXgnlKsWanWcgb6dOjUzJ+XC5f+aWw30qrtjxeNUSfKX1cd5FBzOaXQumoe9nIqeZUvrRJS03HCCtw==
 
+"@playwright/test@^1.30.0":
+  version "1.30.0"
+  resolved "https://registry.yarnpkg.com/@playwright/test/-/test-1.30.0.tgz#8c0c4930ff2c7be7b3ec3fd434b2a3b4465ed7cb"
+  integrity sha512-SVxkQw1xvn/Wk/EvBnqWIq6NLo1AppwbYOjNLmyU0R1RoQ3rLEBtmjTnElcnz8VEtn11fptj1ECxK0tgURhajw==
+  dependencies:
+    "@types/node" "*"
+    playwright-core "1.30.0"
+
 "@root/acme@^3.0.2":
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/@root/acme/-/acme-3.1.0.tgz#e40efbdd18efa6471fa1546d5ee26474ec2bfe27"
@@ -13404,6 +13412,11 @@ platform@^1.3.5:
   version "1.3.6"
   resolved "https://registry.yarnpkg.com/platform/-/platform-1.3.6.tgz#48b4ce983164b209c2d45a107adb31f473a6e7a7"
   integrity sha512-fnWVljUchTro6RiCFvCXBbNhJc2NijN7oIQxbwsyL0buWJPG85v81ehlHI9fXrJsMNgTofEoWIQeClKpgxFLrg==
+
+playwright-core@1.30.0:
+  version "1.30.0"
+  resolved "https://registry.yarnpkg.com/playwright-core/-/playwright-core-1.30.0.tgz#de987cea2e86669e3b85732d230c277771873285"
+  integrity sha512-7AnRmTCf+GVYhHbLJsGUtskWTE33SwMZkybJ0v6rqR1boxq2x36U7p1vDRV7HO2IwTZgmycracLxPEJI49wu4g==
 
 please-upgrade-node@^3.2.0:
   version "3.2.0"


### PR DESCRIPTION
## Summary
Adds playwright for e2e testing and gives test setup with a tasklist example.

## Details
- playwright dependency added.
- playwright config added.
- `tests/tasklist` folder with e2e testing setup added.