### PR TITLE
MQTT Server Definition

### DIFF
--- a/src/helper-modules/bpmn-helper/customSchema.json
+++ b/src/helper-modules/bpmn-helper/customSchema.json
@@ -144,6 +144,31 @@
       ]
     },
     {
+      "name": "mqttServer",
+      "properties": [
+        {
+          "name": "url",
+          "isAttr": true,
+          "type": "String"
+        },
+        {
+          "name": "topic",
+          "isAttr": true,
+          "type": "String"
+        },
+        {
+          "name": "user",
+          "isAttr": true,
+          "type": "String"
+        },
+        {
+          "name": "password",
+          "isAttr": true,
+          "type": "String"
+        }
+      ]
+    },
+    {
       "name": "Meta",
       "superClass": ["Element"],
       "properties": [
@@ -216,6 +241,11 @@
           "name": "defaultPriority",
           "isMany": false,
           "type": "defaultPriority"
+        },
+        {
+          "name": "mqttServer",
+          "isMany": false,
+          "type": "mqttServer"
         }
       ]
     },

--- a/src/helper-modules/bpmn-helper/src/getters.js
+++ b/src/helper-modules/bpmn-helper/src/getters.js
@@ -623,6 +623,15 @@ function getMetaDataFromElement(element) {
             meta[attribute].forEach((property) => {
               properties[property.name] = property.value;
             });
+          } else if (attribute === 'mqttServer') {
+            const { url, topic, user, password } = meta[attribute];
+
+            properties[attribute] = {
+              url,
+              topic,
+              user,
+              password,
+            };
           } else {
             properties[attribute] = meta[attribute].value;
           }

--- a/src/helper-modules/bpmn-helper/src/proceedExtensions.js
+++ b/src/helper-modules/bpmn-helper/src/proceedExtensions.js
@@ -37,6 +37,7 @@ const proceedExtensionElements = {
   Tool: { parent: 'tool', identifier: 'id' },
   inspectionInstrument: { parent: 'Resources' },
   InspectionInstrument: { parent: 'inspectionInstrument', identifier: 'id' },
+  mqttServer: { parent: 'Meta', identifier: 'url' },
 };
 
 /**

--- a/src/management-system/src/frontend/components/processes/editor/PropertiesPanel/CustomPropertyForm.vue
+++ b/src/management-system/src/frontend/components/processes/editor/PropertiesPanel/CustomPropertyForm.vue
@@ -91,6 +91,7 @@ export default {
         isUsing5i,
         overviewImage,
         defaultPriority,
+        mqttServer,
         '_5i-Inspection-Plan-ID': inspectionPlanId,
         '_5i-Inspection-Plan-Title': inspectionPlanTitle,
         '_5i-API-Address': apiAddress,

--- a/src/management-system/src/frontend/components/processes/editor/PropertiesPanel/MQTTForm.vue
+++ b/src/management-system/src/frontend/components/processes/editor/PropertiesPanel/MQTTForm.vue
@@ -1,0 +1,143 @@
+<template>
+  <v-container>
+    <p class="font-weight-medium">MQTT Server</p>
+    <v-row>
+      <v-col cols="12">
+        <v-row>
+          <v-col cols="6">
+            <v-text-field
+              label="Server URL"
+              :value="currentServerInfo.url"
+              :rules="[inputRules.notEmpty, inputRules.validURL]"
+              background-color="white"
+              @blur="
+                updateServer({
+                  ...currentServerInfo,
+                  url: $event.target.value,
+                })
+              "
+              filled
+            />
+          </v-col>
+          <v-col cols="6">
+            <v-text-field
+              label="Topic"
+              :value="currentServerInfo.topic"
+              :rules="[inputRules.notEmpty]"
+              background-color="white"
+              @blur="
+                updateServer({
+                  ...currentServerInfo,
+                  topic: $event.target.value,
+                })
+              "
+              filled
+            />
+          </v-col>
+        </v-row>
+        <v-row>
+          <v-col cols="6">
+            <v-text-field
+              label="User"
+              :value="currentServerInfo.user"
+              :rules="[inputRules.notEmpty]"
+              background-color="white"
+              @blur="
+                updateServer({
+                  ...currentServerInfo,
+                  user: $event.target.value,
+                })
+              "
+              filled
+            />
+          </v-col>
+          <v-col cols="6">
+            <v-text-field
+              label="Password"
+              :value="currentServerInfo.password"
+              background-color="white"
+              @blur="
+                updateServer({
+                  ...currentServerInfo,
+                  password: $event.target.value,
+                })
+              "
+              filled
+            />
+          </v-col>
+        </v-row>
+      </v-col>
+    </v-row>
+  </v-container>
+</template>
+<script>
+export default {
+  components: {},
+  props: ['storedServerInfo'],
+  data() {
+    return {
+      currentServerInfo: {
+        url: '',
+        topic: '',
+        user: '',
+        password: '',
+      },
+      inputRules: {
+        notEmpty: (v) => !!v || 'Value must not be empty',
+        validURL: (url) => {
+          try {
+            const URLObj = new URL(url);
+            if (URLObj.protocol !== 'mqtt:' && URLObj.protocol !== 'mqtts:') {
+              return 'MQTT URL is not valid';
+            }
+          } catch (err) {
+            return 'MQTT URL is not valid';
+          }
+          return true;
+        },
+      },
+    };
+  },
+  computed: {},
+  methods: {
+    validateInput(currentServerInfo) {
+      if (
+        !currentServerInfo ||
+        !currentServerInfo.url ||
+        currentServerInfo.url.length === 0 ||
+        !currentServerInfo.user ||
+        currentServerInfo.user.length === 0 ||
+        !currentServerInfo.topic ||
+        currentServerInfo.topic.length === 0
+      ) {
+        return false;
+      }
+
+      try {
+        const URLObj = new URL(currentServerInfo.url);
+        if (URLObj.protocol !== 'mqtt:' && URLObj.protocol !== 'mqtts:') {
+          return false;
+        }
+      } catch (err) {
+        return false;
+      }
+
+      return true;
+    },
+    updateServer(updatedServerInfo) {
+      this.currentServerInfo = { ...updatedServerInfo };
+      if (this.validateInput(updatedServerInfo)) {
+        this.$emit('change', updatedServerInfo);
+      }
+    },
+  },
+  watch: {
+    storedServerInfo: {
+      immediate: true,
+      handler(updatedServerInfo) {
+        this.currentServerInfo = { ...updatedServerInfo };
+      },
+    },
+  },
+};
+</script>

--- a/src/management-system/src/frontend/components/processes/editor/PropertiesPanel/PropertiesPanel.vue
+++ b/src/management-system/src/frontend/components/processes/editor/PropertiesPanel/PropertiesPanel.vue
@@ -118,6 +118,18 @@
           </div>
         </v-container>
 
+        <MQTTForm
+          v-if="isProcessElement"
+          :storedServerInfo="metaCopy.mqttServer"
+          @change="
+            applyMetaData({
+              mqttServer: {
+                attributes: { ...$event },
+              },
+            })
+          "
+        ></MQTTForm>
+
         <resource-form :process="process" />
 
         <custom-property-form
@@ -141,6 +153,7 @@ import inspectionOrderSelection from '@/frontend/components/5thIndustry/inspecti
 import BooleanBpmnPropertyFormVue from './BooleanBpmnPropertyForm.vue';
 import MilestoneSelection from '@/frontend/components/processes/editor/PropertiesPanel/MilestoneSelection.vue';
 import TimePlannedForm from '@/frontend/components/processes/editor/PropertiesPanel/TimePlannedForm.vue';
+import MQTTForm from '@/frontend/components/processes/editor/PropertiesPanel/MQTTForm.vue';
 import ResourceForm from '@/frontend/components/processes/editor/PropertiesPanel/resources/ResourceForm.vue';
 import CustomPropertyForm from '@/frontend/components/processes/editor/PropertiesPanel/CustomPropertyForm.vue';
 import DocumentationForm from '@/frontend/components/processes/editor/PropertiesPanel/DocumentationForm.vue';
@@ -158,6 +171,7 @@ export default {
     inspectionOrderSelection,
     MilestoneSelection,
     TimePlannedForm,
+    MQTTForm,
     ResourceForm,
     CustomPropertyForm,
     BooleanBpmnPropertyFormVue,
@@ -221,6 +235,7 @@ export default {
         customerId,
         isUsing5i,
         defaultPriority,
+        mqttServer,
         '_5i-Inspection-Plan-ID': inspectionPlanId,
         '_5i-Inspection-Plan-Title': inspectionPlanTitle,
         '_5i-API-Address': apiAddress,

--- a/src/management-system/src/frontend/components/processes/editor/PropertiesPanel/resources/ProcessStepResourceForm.vue
+++ b/src/management-system/src/frontend/components/processes/editor/PropertiesPanel/resources/ProcessStepResourceForm.vue
@@ -16,6 +16,7 @@
       </v-col>
       <v-col cols="3">
         <v-text-field
+          class="mt-n3"
           :disabled="disableEditing"
           :value="resource.quantity"
           :key="`quantity-${resource.id}`"


### PR DESCRIPTION
## Summary

Enable setting MQTT server for process in property panel

## Details

When creating a process, in the property panel there can be now set an MQTT server to communicate after deployment of the process. The config for a MQTT server includes its URL, a topic, a user and optionally a password. All of the provided information will be stored in the BPMN XML of the process.
