### PR TITLE
Bugfixed mqtt publish on instance start

### DIFF
--- a/src/engine/native/node/native-mqtt/src/index.js
+++ b/src/engine/native/node/native-mqtt/src/index.js
@@ -7,9 +7,9 @@ class NativeMQTT extends NativeModule {
     this.commands = ['messaging_publish'];
   }
 
-  executeCommand(command, args) {
+  async executeCommand(command, args) {
     if (command === 'messaging_publish') {
-      return this.publish(args);
+      return await this.publish(args);
     }
     return undefined;
   }

--- a/src/engine/universal/core/src/engine/5thIndustry.js
+++ b/src/engine/universal/core/src/engine/5thIndustry.js
@@ -472,7 +472,7 @@ async function sendProcessStepsInfoTo5thIndustry(projectId, version, bpmn, loggi
     };
     try {
       // send the information to the requested messaging server
-      system.messaging.publish(topic, stepsInfo, url, {}, { user, password });
+      await system.messaging.publish(topic, stepsInfo, url, {}, { username: user, password });
     } catch (err) {
       logging.error(`Failed to send process step information.\n${err}`);
     }


### PR DESCRIPTION
<!--
  Thank you for your contribution to this project!

  Please provide the following information about your changes,
  in order for us to approve and merge your proposal as quickly as possible.
-->

## Summary

Fixed a bug where sending data to a mqtt server defined in a process bpmn does not work when the server requires user authentication.

<!--
  Please give a concise description of your proposal.
-->

## Details

<!--
  A list of changes and any additional information that could be relevant for this pull request.

Example:
- Function foobar() now takes an optional third parameter
- The version of dependency dep-js was changed to 1.3.7
-->
- using the correct attribute `username` instead of the wrongly used `user` to provide log in data on calling the publish function
- awaiting functions to prevent an uncaught exception when connecting or sending to an mqtt server fails
