### PR TITLE
Bugfixes

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -14,7 +14,7 @@
       "type": "node",
       "request": "launch",
       "name": "Launch PROCEED",
-      "program": "${workspaceFolder}/src/engine/native/node/index.js",
+      "program": "${workspaceFolder}/src/engine/native/node/index.ts",
       "autoAttachChildProcesses": true
     },
     {

--- a/src/engine/native/node/native-fs/src/__tests__/index.test.js
+++ b/src/engine/native/node/native-fs/src/__tests__/index.test.js
@@ -316,7 +316,7 @@ describe('Native-FS', () => {
         cb();
       });
       const res = nfs.write(['table.json', null]);
-      expect(res).resolves.toBeUndefined();
+      await expect(res).resolves.toBeUndefined();
       expect(fs.rm).toHaveBeenCalledWith(
         '/Path/To/Dir/data_files/table.json',
         { force: true, recursive: true },

--- a/src/engine/native/node/native-fs/src/__tests__/index.test.js
+++ b/src/engine/native/node/native-fs/src/__tests__/index.test.js
@@ -232,7 +232,7 @@ describe('Native-FS', () => {
       fs.statSync.mockReset();
       fs.readFile.mockReset();
       fs.writeFile.mockReset();
-      fs.unlink.mockReset();
+      fs.rm.mockReset();
     });
 
     it('Writes a value', async () => {
@@ -309,16 +309,17 @@ describe('Native-FS', () => {
       );
     });
 
-    it('Removes a table if it is set to null', () => {
+    it('Removes a table if it is set to null', async () => {
       const nfs = new NativeFS({ dir: '/Path/To/Dir' });
 
-      fs.unlink.mockImplementationOnce((path, cb) => {
+      fs.rm.mockImplementationOnce((path, options, cb) => {
         cb();
       });
       const res = nfs.write(['table.json', null]);
       expect(res).resolves.toBeUndefined();
-      expect(fs.unlink).toHaveBeenCalledWith(
+      expect(fs.rm).toHaveBeenCalledWith(
         '/Path/To/Dir/data_files/table.json',
+        { force: true, recursive: true },
         expect.any(Function)
       );
     });
@@ -364,7 +365,7 @@ describe('Native-FS', () => {
       const res4 = nfs.write(['table.json/test', null]);
       await expect(res4).rejects.toBeInstanceOf(Error);
 
-      fs.unlink.mockImplementationOnce((path, cb) => {
+      fs.rm.mockImplementationOnce((path, options, cb) => {
         const error = new Error();
         error.code = 'EISDIR';
         cb(error);

--- a/src/engine/native/node/native-fs/src/index.js
+++ b/src/engine/native/node/native-fs/src/index.js
@@ -65,8 +65,8 @@ class NativeFS extends NativeModule {
     let table = key;
 
     // cut out given attribute in json file
-    if (key.indexOf('.json/') !== -1) {
-      table = key.substr(0, key.indexOf('.json/'));
+    if (key.indexOf('.json') !== -1) {
+      table = key.substr(0, key.indexOf('.json'));
     }
 
     // Check mutex
@@ -161,8 +161,8 @@ class NativeFS extends NativeModule {
     let table = key;
 
     // cut out given attribute in json file
-    if (key.indexOf('.json/') !== -1) {
-      table = key.substr(0, key.indexOf('.json/'));
+    if (key.indexOf('.json') !== -1) {
+      table = key.substr(0, key.indexOf('.json'));
     }
 
     let succeed;

--- a/src/engine/native/node/native-fs/src/index.js
+++ b/src/engine/native/node/native-fs/src/index.js
@@ -216,27 +216,16 @@ class NativeFS extends NativeModule {
             succeed();
           });
         });
-
-        // delete file if no json with specific attribute inside is given
       } else {
+        // delete file (or directory) if no json with specific attribute inside is given
         const fullPath = `${this.path}/data_files/${key}`;
-        if (fs.existsSync(fullPath) && fs.lstatSync(fullPath).isDirectory()) {
-          fs.rmdir(fullPath, { recursive: true }, (err) => {
-            if (err && err.code !== 'ENOENT') {
-              fail(err);
-              return;
-            }
-            succeed();
-          });
-        } else {
-          fs.unlink(fullPath, (err) => {
-            if (err && err.code !== 'ENOENT') {
-              fail(err);
-              return;
-            }
-            succeed();
-          });
-        }
+        fs.rm(fullPath, { recursive: true, force: true }, (err) => {
+          if (err) {
+            fail(err);
+            return;
+          }
+          succeed();
+        });
       }
       // New val
     } else {

--- a/src/engine/universal/distribution/src/database/db.js
+++ b/src/engine/universal/distribution/src/database/db.js
@@ -301,8 +301,8 @@ module.exports = {
    * @param {String} definitionId
    */
   async deleteProcess(definitionId) {
-    await data.delete(definitionId);
     await data.delete(`processes.json/${definitionId}`);
+    await data.delete(definitionId);
   },
 
   /**

--- a/src/management-system/src/backend/shared-electron-server/network/process/deployment.js
+++ b/src/management-system/src/backend/shared-electron-server/network/process/deployment.js
@@ -96,7 +96,7 @@ async function removeDeploymentFromMachines(definitionId, machines) {
 export async function removeDeployment(processDefinitionsId) {
   const deployedTo = getDeployments()[processDefinitionsId].machines;
 
-  removeDeploymentFromMachines(processDefinitionsId, deployedTo);
+  await removeDeploymentFromMachines(processDefinitionsId, deployedTo);
 
   await removeStoredDeployment(processDefinitionsId);
 

--- a/src/management-system/src/backend/shared-electron-server/network/process/polling.js
+++ b/src/management-system/src/backend/shared-electron-server/network/process/polling.js
@@ -734,12 +734,14 @@ export function mergeInstanceInformation(storedInstanceData, machinesInstanceInf
     }
   });
 
-  storedInstanceData.instanceState.sort((firstState, secondState) => {
-    let firstStateIndex = statePrecedence.findIndex((state) => state === firstState);
-    let secondStateIndex = statePrecedence.findIndex((state) => state === secondState);
+  if (storedInstanceData) {
+    storedInstanceData.instanceState.sort((firstState, secondState) => {
+      let firstStateIndex = statePrecedence.findIndex((state) => state === firstState);
+      let secondStateIndex = statePrecedence.findIndex((state) => state === secondState);
 
-    return firstStateIndex - secondStateIndex;
-  });
+      return firstStateIndex - secondStateIndex;
+    });
+  }
 
   return storedInstanceData;
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,8 @@
     "allowJs": true,
     "moduleResolution": "node",
     "esModuleInterop": true,
-    "resolveJsonModule": true
+    "resolveJsonModule": true,
+    "target": "es6"
   },
   "include": ["src/**/*", "tests/**/*"]
 }


### PR DESCRIPTION
<!--
  Thank you for your contribution to this project!

  Please provide the following information about your changes,
  in order for us to approve and merge your proposal as quickly as possible.
-->


## Summary

<!--
  Please give a concise description of your proposal.
-->


- Fixed some bugs that lead to engine crashes
- Removed the usage of a function that is deprecated as of node v.16
- Fixed a bug that might lead to an ms crash if an engine does not respond to a request as expected
- Fixed a bug that prevents tasks with constraints to work in dev mode

## Details

<!--
  A list of changes and any additional information that could be relevant for this pull request.

Example:
- Function foobar() now takes an optional third parameter
- The version of dependency dep-js was changed to 1.3.7
-->

- Fixed: Mutex that should prevent file reads during writes does not work when a file is referenced once with `path/filename` and once with filename `path/filename/...`
- Fixed: Deleting a deployment on the engine will remove the deployment bpmn files before marking the process as deleted (by deleting the meta data) which can lead to an error when the deploment is requested before the second step happened
- Fixed: the MS does not wait for a deployment delete request to resolve before requesting updated deployment data
- Fixed: if the request for initial information of an instance fails the MS still tries to merge the missing information into its internal state leading to an error that crashes the MS backend
- Fixed: since no target is defined in the tsconfig the compiler used in dev mode [transpiles to ES3 by default](https://www.typescriptlang.org/tsconfig#target) leading to unexpected behaviour in code that depends on modern JS features => [this spread operator](https://github.com/PROCEED-Labs/proceed/blob/main/src/engine/universal/decider/hard_constraint_evaluation/hc-eval.js#L225) does not work correctly leading to constraints not working correctly which prevents any task with a constraint from being started
- Replaced the [deprecated](https://nodejs.org/docs/latest-v16.x/api/fs.html#fsrmdirpath-options-callback) usage of `fs.rmdir(path, {recursive: true}, cb)` with `fs.rm(path, {recursive: true, force: true}, cb)` to delete directories with their content (force prevents an error when the given path does not exist)
- Reusing the functionality used to delete directories to delete files instead of using `fs.unlink`