### PR TITLE
Supply chain communication

### DIFF
--- a/src/engine/e2e_tests/process/deployment/deployment.e2e.test.js
+++ b/src/engine/e2e_tests/process/deployment/deployment.e2e.test.js
@@ -2028,6 +2028,7 @@ describe('Test deploying a process', () => {
                   intermediateVariablesState: {},
                   milestones: {},
                   priority: 1,
+                  performers: [],
                 },
               ]);
 
@@ -2043,6 +2044,7 @@ describe('Test deploying a process', () => {
                 instanceID: instanceId,
                 attrs: expect.any(Object),
                 priority: 1,
+                performers: [],
                 progress: 0,
                 startTime: expect.any(Number),
                 endTime: null,
@@ -2096,6 +2098,7 @@ describe('Test deploying a process', () => {
                   intermediateVariablesState: {},
                   milestones: {},
                   priority: 1,
+                  performers: [],
                 },
               ]);
 
@@ -2119,6 +2122,7 @@ describe('Test deploying a process', () => {
                   instanceID: instanceId,
                   attrs: expect.any(Object),
                   priority: 1,
+                  performers: [],
                   progress: 0,
                   startTime: expect.any(Number),
                   endTime: null,
@@ -2129,6 +2133,7 @@ describe('Test deploying a process', () => {
                   instanceID: instanceId,
                   attrs: expect.any(Object),
                   priority: 1,
+                  performers: [],
                   progress: 0,
                   startTime: expect.any(Number),
                   endTime: null,
@@ -2163,6 +2168,7 @@ describe('Test deploying a process', () => {
                 progress: { value: 0, manual: false },
                 milestones: {},
                 priority: 1,
+                performers: [],
               });
 
               expect(instanceInfo.adaptationLog).toEqual([
@@ -2183,6 +2189,7 @@ describe('Test deploying a process', () => {
                   instanceID: instanceId,
                   attrs: expect.any(Object),
                   priority: 1,
+                  performers: [],
                   progress: 0,
                   startTime: expect.any(Number),
                   endTime: null,
@@ -2264,6 +2271,7 @@ describe('Test deploying a process', () => {
                 instanceID: instanceId,
                 attrs: expect.any(Object),
                 priority: 1,
+                performers: [],
                 progress: 0,
                 startTime: expect.any(Number),
                 endTime: null,
@@ -2474,6 +2482,7 @@ describe('Test deploying a process', () => {
                   intermediateVariablesState: {},
                   milestones: {},
                   priority: 1,
+                  performers: [],
                 },
               ]);
               expect(instanceInfo.log).toEqual([
@@ -2505,6 +2514,7 @@ describe('Test deploying a process', () => {
                   progress: { value: 100, manual: false },
                   milestones: {},
                   priority: 1,
+                  performers: [],
                 },
               ]);
 
@@ -2645,6 +2655,7 @@ describe('Test deploying a process', () => {
                   progress: { value: 0, manual: false },
                   milestones: {},
                   priority: 1,
+                  performers: [],
                 },
                 {
                   tokenId: expect.any(String),
@@ -2661,6 +2672,7 @@ describe('Test deploying a process', () => {
                   progress: { value: 100, manual: false },
                   milestones: {},
                   priority: 1,
+                  performers: [],
                 },
                 {
                   tokenId: expect.any(String),
@@ -2816,6 +2828,7 @@ describe('Test deploying a process', () => {
                   progress: { value: 0, manual: false },
                   milestones: {},
                   priority: 1,
+                  performers: [],
                 },
                 {
                   tokenId: expect.any(String),
@@ -2832,6 +2845,7 @@ describe('Test deploying a process', () => {
                   progress: { value: 100, manual: false },
                   milestones: {},
                   priority: 1,
+                  performers: [],
                 },
                 {
                   tokenId: expect.any(String),

--- a/src/engine/universal/core/src/engine/engine.js
+++ b/src/engine/universal/core/src/engine/engine.js
@@ -567,6 +567,7 @@ class Engine {
             machine: this.machineInformation,
             progress: token.currentFlowNodeProgress,
             priority: token.priority,
+            performers: token.performers,
           });
         }
       });
@@ -744,7 +745,12 @@ class Engine {
 
     const pendingUserTasksWithTokenInfo = pendingUserTasks.map((uT) => {
       const token = this.getToken(uT.processInstance.id, uT.tokenId);
-      return { ...uT, priority: token.priority, progress: token.currentFlowNodeProgress.value };
+      return {
+        ...uT,
+        priority: token.priority,
+        progress: token.currentFlowNodeProgress.value,
+        performers: token.performers,
+      };
     });
     return pendingUserTasksWithTokenInfo;
   }
@@ -765,6 +771,7 @@ class Engine {
         ...uT,
         priority: userTaskLogEntry.priority,
         progress: userTaskLogEntry.progress.value,
+        performers: userTaskLogEntry.performers,
       };
     });
     return inactiveUserTasksWithLogInfo;

--- a/src/engine/universal/core/src/engine/hookCallbacks.js
+++ b/src/engine/universal/core/src/engine/hookCallbacks.js
@@ -336,6 +336,13 @@ module.exports = {
             newInstance.updateToken(execution.tokenId, { priority: undefined });
           }
 
+          if (token.performers) {
+            newInstance.updateLog(execution.flowElementId, execution.tokenId, {
+              performers: token.performers,
+            });
+            newInstance.updateToken(execution.tokenId, { performers: undefined });
+          }
+
           const flowElement = newInstance.getFlowElement(execution.flowElementId);
           if (flowElement && flowElement.$type === 'bpmn:UserTask') {
             // update user task in list

--- a/src/engine/universal/core/src/engine/shouldActivateFlowNode.js
+++ b/src/engine/universal/core/src/engine/shouldActivateFlowNode.js
@@ -5,6 +5,7 @@ const {
   getMilestonesFromElementById,
   getMetaData,
   convertISODurationToMiliseconds,
+  getPerformersFromElementById,
 } = require('@proceed/bpmn-helper');
 
 /**
@@ -36,6 +37,7 @@ function onUserTask(engine, instance, tokenId, userTask) {
 
     const token = engine.getToken(instance.id, tokenId);
     const metaData = await getMetaData(bpmn, userTask.id);
+    const performers = await getPerformersFromElementById(bpmn, userTask.id);
 
     const startTime = token.currentFlowElementStartTime;
     let endTime = null;
@@ -72,6 +74,7 @@ function onUserTask(engine, instance, tokenId, userTask) {
     instance.updateToken(tokenId, {
       currentFlowNodeProgress: { value: 0, manual: false },
       priority: metaData.defaultPriority | 1,
+      performers,
     });
 
     const initializedMilestones = (await getMilestonesFromElementById(bpmn, userTask.id)).reduce(

--- a/src/engine/universal/core/src/management.js
+++ b/src/engine/universal/core/src/management.js
@@ -548,6 +548,7 @@ const Management = {
               ...uT,
               priority: userTaskToken.priority,
               progress: userTaskToken.currentFlowNodeProgress.value,
+              performers: userTaskToken.performers,
             };
           } else {
             const userTaskLogEntry = archivedInstance.log.find(
@@ -558,6 +559,7 @@ const Management = {
               ...uT,
               priority: userTaskLogEntry.priority,
               progress: userTaskLogEntry.progress.value,
+              performers: userTaskToken.performers,
             };
           }
         });

--- a/src/engine/universal/ui/src/display-items/tasklist/TaskList-DisplayItem.js
+++ b/src/engine/universal/ui/src/display-items/tasklist/TaskList-DisplayItem.js
@@ -38,6 +38,7 @@ class TaskListTab extends DisplayItem {
         attrs: task.attrs,
         state: task.state,
         priority: task.priority,
+        performers: task.performers,
         progress: task.progress,
         startTime: task.startTime,
         endTime: task.endTime,

--- a/src/engine/universal/ui/src/display-items/tasklist/index.js
+++ b/src/engine/universal/ui/src/display-items/tasklist/index.js
@@ -154,6 +154,7 @@ function showTaskList(tasks) {
     state: task.dataset.state,
     progress: task.dataset.progress,
     priority: task.dataset.priority,
+    performers: task.dataset.performers,
   }));
 
   tasks.forEach((task) => {

--- a/src/helper-modules/bpmn-helper/src/getters.js
+++ b/src/helper-modules/bpmn-helper/src/getters.js
@@ -697,6 +697,20 @@ async function getMilestonesFromElementById(bpmn, elementId) {
 }
 
 /**
+ * Get the performers for given element id
+ *
+ * @param {(string|object)} bpmn - the process definition as XML string or BPMN-Moddle Object
+ * @param {String} elementId the id of the element
+ * @returns {Array} array with all performers
+ */
+async function getPerformersFromElementById(bpmn, elementId) {
+  const bpmnObj = typeof bpmn === 'string' ? await toBpmnObject(bpmn) : bpmn;
+  const element = getElementById(bpmnObj, elementId);
+
+  return getPerformersFromElement(element);
+}
+
+/**
  * Parses the locations from a bpmn-moddle element
  *
  * @param {Object} element
@@ -865,6 +879,24 @@ function getResourcesFromElement(element) {
   return { consumableMaterial, tool, inspectionInstrument };
 }
 
+function getPerformersFromElement(element) {
+  if (element.resources) {
+    const potentialOwner = element.resources.find(
+      (resource) => resource.$type === 'bpmn:PotentialOwner'
+    );
+
+    if (
+      potentialOwner &&
+      potentialOwner.resourceAssignmentExpression &&
+      potentialOwner.resourceAssignmentExpression.expression &&
+      potentialOwner.resourceAssignmentExpression.expression.body
+    ) {
+      return JSON.parse(potentialOwner.resourceAssignmentExpression.expression.body);
+    }
+  }
+  return [];
+}
+
 /**
  * Parses ISO Duration String to number of years, months, days, hours, minutes and seconds
  * @param {String} isoDuration
@@ -975,6 +1007,8 @@ module.exports = {
   getMilestonesFromElementById,
   getResourcesFromElement,
   getLocationsFromElement,
+  getPerformersFromElement,
+  getPerformersFromElementById,
   parseISODuration,
   convertISODurationToMiliseconds,
 };

--- a/src/management-system/src/frontend/components/processes/editor/PropertiesPanel/PerformerForm.vue
+++ b/src/management-system/src/frontend/components/processes/editor/PropertiesPanel/PerformerForm.vue
@@ -168,17 +168,11 @@ export default {
         if (newModeler) {
           newModeler
             .get('eventBus')
-            .on('commandStack.element.updateProperties.postExecute', ({ context }) => {
-              const { element, additionalInfo } = context;
-              if (
-                element.id === this.selectedElement.id &&
-                additionalInfo &&
-                additionalInfo.performers
-              ) {
+            .on('commandStack.element.updatePerformers.postExecute', ({ context }) => {
+              const { element, performers } = context;
+              if (element.id === this.selectedElement.id && performers) {
                 // update the assigned performers when they change on the selected element
-                this.assignedPerformers = this.mapExpressionDataToFormData(
-                  additionalInfo.performers
-                );
+                this.assignedPerformers = this.mapExpressionDataToFormData(performers);
               }
             });
         }

--- a/src/management-system/src/frontend/components/processes/editor/PropertiesPanel/PerformerForm.vue
+++ b/src/management-system/src/frontend/components/processes/editor/PropertiesPanel/PerformerForm.vue
@@ -31,10 +31,13 @@
           label="Type"
           @change="
             index !== performerRows.length - 1
-              ? updatePerformer({
-                  name: performer.name,
-                  type: $event,
-                })
+              ? updatePerformer(
+                  {
+                    name: performer.name,
+                    type: $event,
+                  },
+                  performer.name
+                )
               : assignPerformer({ name: performer.name, type: $event })
           "
         ></v-autocomplete>

--- a/src/management-system/src/frontend/components/processes/editor/PropertiesPanel/PerformerForm.vue
+++ b/src/management-system/src/frontend/components/processes/editor/PropertiesPanel/PerformerForm.vue
@@ -1,0 +1,202 @@
+<template>
+  <v-container>
+    <p class="font-weight-medium">Performer</p>
+    <v-row v-for="(performer, index) in performerRows" :key="index">
+      <v-col cols="8">
+        <v-text-field
+          :key="index"
+          label="Name"
+          :rules="[noDuplicate(index)]"
+          :value="performer.name"
+          background-color="white"
+          @blur="
+            index !== performerRows.length - 1
+              ? updatePerformer(
+                  {
+                    name: $event.target.value,
+                    type: performer.type,
+                  },
+                  performer.name
+                )
+              : assignPerformer({ name: $event.target.value, type: performer.type })
+          "
+          filled
+        />
+      </v-col>
+      <v-col cols="3">
+        <v-autocomplete
+          :items="performerTypes"
+          :value="performer.type"
+          class="mt-3"
+          label="Type"
+          @change="
+            index !== performerRows.length - 1
+              ? updatePerformer({
+                  name: performer.name,
+                  type: $event,
+                })
+              : assignPerformer({ name: performer.name, type: $event })
+          "
+        ></v-autocomplete>
+      </v-col>
+      <v-col cols="1" class="d-flex justify-end" v-if="index !== performerRows.length - 1">
+        <v-btn class="my-4" icon color="error" @click="deletePerformer(performer.name)" small
+          ><v-icon>mdi-delete</v-icon></v-btn
+        >
+      </v-col>
+    </v-row>
+  </v-container>
+</template>
+<script>
+import { getPerformers } from '@/frontend/helpers/bpmn-modeler-events/getters.js';
+export default {
+  components: {},
+  props: [],
+  data() {
+    return {
+      assignedPerformers: [],
+      performerTypes: ['User', 'Group'],
+      newPerformerInfo: {
+        name: null,
+        type: 'User',
+      },
+    };
+  },
+  computed: {
+    modeler() {
+      return this.$store.getters['processEditorStore/modeler'];
+    },
+    selectedElement() {
+      return this.$store.getters['processEditorStore/selectedElement'];
+    },
+    performerRows() {
+      return [...this.assignedPerformers, this.newPerformerInfo];
+    },
+  },
+  methods: {
+    noDuplicate(index) {
+      const self = this;
+      return function (name) {
+        const duplicateIndex = self.performerRows.findIndex((row) => row.name === name);
+
+        if (name && name.length > 0 && duplicateIndex !== -1 && duplicateIndex !== index) {
+          return 'Name already exists';
+        }
+
+        return true;
+      };
+    },
+    validateInput(newPerformerInfo, oldPerformerName) {
+      if (!(newPerformerInfo && newPerformerInfo.name && newPerformerInfo.type)) {
+        return false;
+      }
+
+      if (
+        newPerformerInfo.name != oldPerformerName &&
+        this.assignedPerformers.find((performer) => performer.name === newPerformerInfo.name)
+      ) {
+        return false;
+      }
+
+      return true;
+    },
+    mapExpressionDataToFormData(expressionData) {
+      return expressionData.map((performer) => {
+        if (performer.meta.name) {
+          return { name: performer.meta.name, type: 'User' };
+        }
+
+        if (performer.meta.groupname) {
+          return { name: performer.meta.groupname, type: 'Group' };
+        }
+      });
+    },
+    assignPerformer(newPerformerInfo) {
+      this.newPerformerInfo.name = newPerformerInfo.name;
+      this.newPerformerInfo.type = newPerformerInfo.type;
+
+      if (this.validateInput(newPerformerInfo)) {
+        this.emitPerformers([
+          ...this.assignedPerformers,
+          {
+            name: newPerformerInfo.name,
+            type: newPerformerInfo.type,
+          },
+        ]);
+
+        this.newPerformerInfo.name = null;
+        this.newPerformerInfo.type = 'User';
+      }
+    },
+    updatePerformer(updatedPerformerInfo, oldPerformerName) {
+      if (this.validateInput(updatedPerformerInfo, oldPerformerName)) {
+        const updatedAssignedPerformers = [...this.assignedPerformers];
+
+        const updatedPerformerIndex = updatedAssignedPerformers.findIndex(
+          (performer) => performer.name === (oldPerformerName || updatedPerformerInfo.name)
+        );
+
+        updatedAssignedPerformers.splice(updatedPerformerIndex, 1, {
+          name: updatedPerformerInfo.name,
+          type: updatedPerformerInfo.type,
+        });
+
+        this.emitPerformers(updatedAssignedPerformers);
+      }
+    },
+    deletePerformer(performerName) {
+      const updatedAssignedPerformers = this.assignedPerformers.filter(
+        (performer) => performer.name !== performerName
+      );
+      this.emitPerformers(updatedAssignedPerformers);
+    },
+    emitPerformers(performers) {
+      const performersExpressionData = performers.map((performer) => {
+        if (performer.type === 'User') {
+          return { id: '', meta: { name: performer.name } };
+        }
+        if (performer.type === 'Group') {
+          return { id: '', meta: { groupname: performer.name } };
+        }
+      });
+      this.$emit('change', performersExpressionData);
+    },
+  },
+  watch: {
+    modeler: {
+      handler(newModeler) {
+        if (newModeler) {
+          newModeler
+            .get('eventBus')
+            .on('commandStack.element.updateProperties.postExecute', ({ context }) => {
+              const { element, additionalInfo } = context;
+              if (
+                element.id === this.selectedElement.id &&
+                additionalInfo &&
+                additionalInfo.performers
+              ) {
+                // update the assigned performers when they change on the selected element
+                this.assignedPerformers = this.mapExpressionDataToFormData(
+                  additionalInfo.performers
+                );
+              }
+            });
+        }
+      },
+      immediate: true,
+    },
+    selectedElement: {
+      handler(newSelection) {
+        // re-initialize the assigned performers when a new element is selected
+        if (newSelection) {
+          const performersExpressionData = getPerformers(newSelection);
+          this.assignedPerformers = this.mapExpressionDataToFormData(performersExpressionData);
+        } else {
+          this.assignedPerformers = [];
+        }
+      },
+      immediate: true,
+    },
+  },
+};
+</script>

--- a/src/management-system/src/frontend/components/processes/editor/PropertiesPanel/PropertiesPanel.vue
+++ b/src/management-system/src/frontend/components/processes/editor/PropertiesPanel/PropertiesPanel.vue
@@ -117,6 +117,7 @@
             ></time-planned-form>
           </div>
         </v-container>
+        <performer-form v-if="isUserTask" @change="applyPerformerChange"></performer-form>
 
         <MQTTForm
           v-if="isProcessElement"
@@ -154,6 +155,7 @@ import BooleanBpmnPropertyFormVue from './BooleanBpmnPropertyForm.vue';
 import MilestoneSelection from '@/frontend/components/processes/editor/PropertiesPanel/MilestoneSelection.vue';
 import TimePlannedForm from '@/frontend/components/processes/editor/PropertiesPanel/TimePlannedForm.vue';
 import MQTTForm from '@/frontend/components/processes/editor/PropertiesPanel/MQTTForm.vue';
+import PerformerForm from '@/frontend/components/processes/editor/PropertiesPanel/PerformerForm.vue';
 import ResourceForm from '@/frontend/components/processes/editor/PropertiesPanel/resources/ResourceForm.vue';
 import CustomPropertyForm from '@/frontend/components/processes/editor/PropertiesPanel/CustomPropertyForm.vue';
 import DocumentationForm from '@/frontend/components/processes/editor/PropertiesPanel/DocumentationForm.vue';
@@ -172,6 +174,7 @@ export default {
     MilestoneSelection,
     TimePlannedForm,
     MQTTForm,
+    PerformerForm,
     ResourceForm,
     CustomPropertyForm,
     BooleanBpmnPropertyFormVue,
@@ -275,7 +278,6 @@ export default {
   data() {
     return {
       showInstanceRecoveryFeature: enableInterruptedInstanceRecovery,
-
       windowMeasurements: {
         right: `${this.convertPixelToVw(12)}vw`, // set right value to align with toolbar (padding 12px)
         top: `${this.convertPixelToVh(128)}vh`, // set top value to prevent overlay of tabbar (height 48px) and toolbar (height 80px)
@@ -351,6 +353,9 @@ export default {
       }
 
       this.applyMetaData(metaData);
+    },
+    applyPerformerChange(performers) {
+      this.customModeling.setUserTaskPerformers(this.element.id, performers);
     },
     getOccurrenceProbabilityRule(value) {
       if (!value) {

--- a/src/management-system/src/frontend/components/userTasks/userTaskCard.vue
+++ b/src/management-system/src/frontend/components/userTasks/userTaskCard.vue
@@ -165,7 +165,7 @@ export default {
       const performers = this.userTask.performers.map(
         (performer) => performer.meta.name || performer.meta.groupname
       );
-      return performers.join(', ');
+      return performers.length > 0 ? performers.join(', ') : 'Not specified';
     },
     shortPerformers() {
       let performers = this.performers;

--- a/src/management-system/src/frontend/components/userTasks/userTaskCard.vue
+++ b/src/management-system/src/frontend/components/userTasks/userTaskCard.vue
@@ -47,10 +47,10 @@
             <template v-slot:activator="{ on, attrs }">
               <div v-bind="attrs" v-on="on">
                 <v-icon :color="isSelected || !isUserTaskActive ? 'white' : ''">mdi-account</v-icon>
-                <span class="name" v-bind="attrs" v-on="on"> {{ owner }}</span>
+                <span class="name" v-bind="attrs" v-on="on"> {{ performers }}</span>
               </div>
             </template>
-            <span> {{ `Owner of User Task: ${owner}` }}</span>
+            <span> {{ `Performers of User Task: ${performers}` }}</span>
           </v-tooltip>
         </div>
         <div class="priority">
@@ -161,15 +161,18 @@ export default {
       }
       return title;
     },
-    owner() {
-      return 'Max Mustermann';
+    performers() {
+      const performers = this.userTask.performers.map(
+        (performer) => performer.meta.name || performer.meta.groupname
+      );
+      return performers.join(', ');
     },
-    shortOwner() {
-      let owner = this.owner;
-      if (owner.length > 15) {
-        owner = owner.slice(0, 14) + '...';
+    shortPerformers() {
+      let performers = this.performers;
+      if (performers.length > 15) {
+        performers = performers.slice(0, 14) + '...';
       }
-      return owner;
+      return performers;
     },
   },
   methods: {

--- a/src/management-system/src/frontend/helpers/bpmn-modeler-events/command-handlers/update-performer-handler.js
+++ b/src/management-system/src/frontend/helpers/bpmn-modeler-events/command-handlers/update-performer-handler.js
@@ -1,0 +1,60 @@
+function UpdatePerformerHandler(elementRegistry, moddle) {
+  this.elementRegistry = elementRegistry;
+  this.moddle = moddle;
+}
+
+UpdatePerformerHandler.$inject = ['elementRegistry', 'moddle'];
+
+module.exports = UpdatePerformerHandler;
+
+/**
+ * Update the performer info in an element
+ *
+ * @param {Object} element the element to update
+ * @param {String} performers the performer string to emplace in the element
+ */
+UpdatePerformerHandler.prototype.setPerformers = function (element, performers) {
+  // create the moddle representation for the performers
+  const formalExpression = this.moddle.create('bpmn:Expression', {
+    body: JSON.stringify(performers),
+  });
+  const resourceAssignmentExpression = this.moddle.create('bpmn:ResourceAssignmentExpression', {
+    expression: formalExpression,
+  });
+
+  const potentialOwner = this.moddle.create('bpmn:PotentialOwner', {
+    resourceAssignmentExpression,
+  });
+
+  // add/update the performers of the element
+  if (!element.resources) {
+    element.resources = [];
+  }
+
+  // remove the current performers and add the new ones (if there are new performers)
+  element.resources = element.resources.filter(
+    (resource) => resource.$type !== 'bpmn:PotentialOwner'
+  );
+
+  if (performers.length) {
+    element.resources = [...element.resources, potentialOwner];
+  }
+};
+
+UpdatePerformerHandler.prototype.execute = function (context) {
+  const { elementId, performers } = context;
+
+  const userTask = this.elementRegistry.get(elementId);
+
+  if (!userTask) {
+    throw new Error(`Unable to find element with given id (${elementId})`);
+  }
+
+  if (userTask.type !== 'bpmn:UserTask') {
+    throw new Error(`Invalid element type for performer assignment! Type is ${userTask.$type}`);
+  }
+
+  this.setPerformers(userTask.businessObject, performers);
+
+  context.element = userTask;
+};

--- a/src/management-system/src/frontend/helpers/bpmn-modeler-events/custom-modeling.js
+++ b/src/management-system/src/frontend/helpers/bpmn-modeler-events/custom-modeling.js
@@ -66,7 +66,6 @@ class CustomModeling {
         ${constraintXML}
       </bpmn2:extensionElements>`;
       const constraintObj = await toBpmnObject(constraintXML, 'bpmn:ExtensionElements');
-
       // if there are constraints add them to the extensionsElement, (one entry is the type)
       if (Object.keys(constraintObj.values[0]).length > 1) {
         extensionElements.values.push(constraintObj.values[0]);
@@ -293,6 +292,31 @@ class CustomModeling {
       element: userTask,
       // make sure the property change is transmitted
       properties: { implementation },
+    });
+  }
+
+  setUserTaskPerformers(elementId, performers) {
+    const userTask = this.elementRegistry.get(elementId);
+
+    if (!userTask) {
+      return;
+    }
+
+    const formalExpression = this.moddle.create('bpmn:Expression', {
+      body: JSON.stringify(performers),
+    });
+    const resourceAssignmentExpression = this.moddle.create('bpmn:ResourceAssignmentExpression', {
+      expression: formalExpression,
+    });
+
+    const potentialOwner = this.moddle.create('bpmn:PotentialOwner', {
+      resourceAssignmentExpression,
+    });
+
+    this.commandStack.execute('element.updateProperties', {
+      element: userTask,
+      properties: { resources: [potentialOwner] },
+      additionalInfo: { performers: performers },
     });
   }
 

--- a/src/management-system/src/frontend/helpers/bpmn-modeler-events/custom-modeling.js
+++ b/src/management-system/src/frontend/helpers/bpmn-modeler-events/custom-modeling.js
@@ -4,6 +4,7 @@ const AddScriptHandler = require('./command-handlers/add-script-handler.js');
 const UpdateDocumentationHandler = require('./command-handlers/update-documentation.js');
 const UpdateEventDefinitionHandler = require('./command-handlers/update-event-definition.js');
 const UpdateProceedDataHandler = require('./command-handlers/update-proceed-data');
+const UpdatePerformersHandler = require('./command-handlers/update-performer-handler.js');
 
 const ConstraintParser = require('@proceed/constraint-parser-xml-json');
 const constraintParser = new ConstraintParser();
@@ -31,6 +32,7 @@ class CustomModeling {
     commandStack.registerHandler('element.updateDocumentation', UpdateDocumentationHandler);
     commandStack.registerHandler('element.updateEventDefinition', UpdateEventDefinitionHandler);
     commandStack.registerHandler('element.updateProceedData', UpdateProceedDataHandler);
+    commandStack.registerHandler('element.updatePerformers', UpdatePerformersHandler);
   }
 
   /**
@@ -296,27 +298,9 @@ class CustomModeling {
   }
 
   setUserTaskPerformers(elementId, performers) {
-    const userTask = this.elementRegistry.get(elementId);
-
-    if (!userTask) {
-      return;
-    }
-
-    const formalExpression = this.moddle.create('bpmn:Expression', {
-      body: JSON.stringify(performers),
-    });
-    const resourceAssignmentExpression = this.moddle.create('bpmn:ResourceAssignmentExpression', {
-      expression: formalExpression,
-    });
-
-    const potentialOwner = this.moddle.create('bpmn:PotentialOwner', {
-      resourceAssignmentExpression,
-    });
-
-    this.commandStack.execute('element.updateProperties', {
-      element: userTask,
-      properties: { resources: [potentialOwner] },
-      additionalInfo: { performers: performers },
+    this.commandStack.execute('element.updatePerformers', {
+      elementId,
+      performers,
     });
   }
 

--- a/src/management-system/src/frontend/helpers/bpmn-modeler-events/event-distribution.js
+++ b/src/management-system/src/frontend/helpers/bpmn-modeler-events/event-distribution.js
@@ -56,6 +56,7 @@ export function activateDistribution() {
     'element.updateProceedData',
     'element.updateDocumentation',
     'element.updateEventDefinition',
+    'element.updatePerformers',
     'elements.move',
     'connection.reconnect',
     'canvas.updateRoot',

--- a/src/management-system/src/frontend/helpers/bpmn-modeler-events/getters.js
+++ b/src/management-system/src/frontend/helpers/bpmn-modeler-events/getters.js
@@ -4,6 +4,7 @@ const {
   getMilestonesFromElement,
   getResourcesFromElement,
   getLocationsFromElement,
+  getPerformersFromElement,
 } = require('@proceed/bpmn-helper/');
 
 export function getMilestones({ businessObject }) {
@@ -28,6 +29,14 @@ export function getResources({ businessObject }) {
   }
 
   return getResourcesFromElement(businessObject);
+}
+
+export function getPerformers({ businessObject }) {
+  if (!businessObject) {
+    return;
+  }
+
+  return getPerformersFromElement(businessObject);
 }
 
 /**


### PR DESCRIPTION
## Summary

Enable setting of Performers (Users, Groups) in UserTasks and filtering for performers in Tasklist for UserTasks

## Details

- When creating a process, it can be set performers for a UserTask in the Property Panel which will be stored in the XML of the process under element _potentialOwner_
- In the Tasklist, for every UserTask it is shown the performers in the UserTask InfoCard
- It can be filtered for performers in the Tasklist to only show UserTasks with corresponding User or Group
