### PR TITLE
Fixed: Built Engine and MS do not start

### DIFF
--- a/src/engine/native/node/native-mdns/src/index.js
+++ b/src/engine/native/node/native-mdns/src/index.js
@@ -1,7 +1,7 @@
 /* eslint-disable class-methods-use-this */
 const NativeModule = require('@proceed/native-module');
-import Bonjour from 'bonjour-service';
-import exitHook from '@darkobits/adeiu';
+const Bonjour = require('bonjour-service').default;
+const exitHook = require('@darkobits/adeiu');
 
 const bonjour = new Bonjour({
   multicast: true, // use udp multicasting

--- a/src/engine/universal/webpack.universal.config.js
+++ b/src/engine/universal/webpack.universal.config.js
@@ -3,6 +3,7 @@ const path = require('path');
 module.exports = {
   entry: './core/src/module.js',
   mode: 'production',
+  target: 'node',
   output: {
     // eslint-disable-next-line no-undef
     path: path.resolve(__dirname, '../../../build/engine'),


### PR DESCRIPTION
<!--
  Thank you for your contribution to this project!

  Please provide the following information about your changes,
  in order for us to approve and merge your proposal as quickly as possible.
-->

## Summary

Fixed two errors that prevent built Engines and MSs from starting.

## Details

<!--
  A list of changes and any additional information that could be relevant for this pull request.

Example:
- Function foobar() now takes an optional third parameter
- The version of dependency dep-js was changed to 1.3.7
-->
- Removed mixed ESM and CommonJS in the mDns module. Fixes #42
- Specified the build target of the universal part of the engine to be `node` to prevent the `uuid` library from trying to use the browser `crypto` interface when the built engine is run in node