### PR TITLE
Bugfixes

### DIFF
--- a/src/engine/native/node/native-mqtt/src/index.js
+++ b/src/engine/native/node/native-mqtt/src/index.js
@@ -230,7 +230,7 @@ class NativeMQTT extends NativeModule {
       }
 
       // try to clean up the connection (will do nothing if the connection is kept open by another subscription or for another reason [e.g a will message])
-      this.disconnect(originalUrl, originalConnectionOptions);
+      await this.disconnect(originalUrl, originalConnectionOptions);
     }
   }
 }

--- a/src/engine/universal/core/src/__tests__/engine.test.js
+++ b/src/engine/universal/core/src/__tests__/engine.test.js
@@ -68,10 +68,15 @@ const userTaskBPMN = fs.readFileSync(path.resolve(__dirname, 'bpmn', 'userTask.b
 
 const taskBPMN = fs.readFileSync(path.resolve(__dirname, 'bpmn', 'task.bpmn'), 'utf-8');
 
+async function sleep(ms) {
+  await new Promise((resolve) => setTimeout(resolve, ms));
+}
+
 describe('ProceedEngine', () => {
   let engine;
   let resolver;
-  let flushPromise;
+  let hasEnded;
+
   const onStarted = jest.fn();
   const onTokenEnded = jest.fn();
   const onEnded = jest.fn().mockImplementation(() => resolver());
@@ -83,12 +88,15 @@ describe('ProceedEngine', () => {
   beforeEach(() => {
     engine = new ProceedEngine();
     distribution.db.getProcess.mockReset();
-    flushPromise = new Promise((resolve) => {
-      resolver = resolve;
-      setTimeout(resolve, 1000);
-    });
+    hasEnded = new Promise((resolve) => (resolver = resolve));
 
     jest.clearAllMocks();
+  });
+
+  // This should allow engines to finish all execution before the test ends
+  // Hotfix for the "A worker process has failed to exit gracefully [...]" warning from jest
+  afterAll(async () => {
+    await sleep(100);
   });
 
   it('calls given callbacks for executed process', async () => {
@@ -96,7 +104,8 @@ describe('ProceedEngine', () => {
 
     await engine.deployProcessVersion(0, 123);
     engine.startProcessVersion(123, {}, onStarted, onEnded, onTokenEnded);
-    await flushPromise;
+
+    await sleep(1000);
 
     expect(onStarted).toHaveBeenCalled();
     expect(onTokenEnded).toHaveBeenCalledTimes(1);
@@ -108,7 +117,8 @@ describe('ProceedEngine', () => {
 
     await engine.deployProcessVersion(0, 123);
     engine.startProcessVersion(123, {}, onStarted, onEnded, onTokenEnded);
-    await flushPromise;
+
+    await hasEnded;
 
     const instanceInformation = engine.getInstanceInformation(engine.instanceIDs[0]);
 
@@ -178,49 +188,57 @@ describe('ProceedEngine', () => {
   it('allows the creation of multiple instances of the same process version inside the same engine instance', async () => {
     distribution.db.getProcessVersion.mockResolvedValueOnce(scriptTaskBPMN);
 
+    let onEnded1;
+    const hasEnded1 = new Promise((resolve) => (onEnded1 = resolve));
+
     await engine.deployProcessVersion(0, 123);
-    engine.startProcessVersion(123, {}, onStarted, onEnded);
+    engine.startProcessVersion(123, {}, onStarted, onEnded1);
     expect(engine.instanceIDs.length).toBe(1);
 
-    await new Promise((resolve) => setTimeout(resolve, 1000));
+    await hasEnded1;
+
+    let onEnded2;
+    const hasEnded2 = new Promise((resolve) => (onEnded2 = resolve));
 
     expect(() => {
-      engine.startProcessVersion(123, {}, onStarted, onEnded);
+      engine.startProcessVersion(123, {}, onStarted, onEnded2);
     }).not.toThrow();
     expect(engine.instanceIDs.length).toBe(2);
 
-    await flushPromise;
+    await hasEnded2;
   });
 
   it('allows the creation of multiple instances of different process versions inside the same engine instance', async () => {
     distribution.db.getProcessVersion.mockResolvedValueOnce(taskBPMN);
 
+    let onEnded1;
+    const hasEnded1 = new Promise((resolve) => (onEnded1 = resolve));
+
     await engine.deployProcessVersion(0, 123);
-    const onStarted1 = jest.fn(),
-      onEnded1 = jest.fn();
+    const onStarted1 = jest.fn();
     engine.startProcessVersion(123, {}, onStarted1, onEnded1);
     expect(engine.instanceIDs.length).toBe(1);
 
-    await new Promise((resolve) => setTimeout(resolve, 1000));
+    await hasEnded1;
 
     distribution.db.getProcessVersion.mockResolvedValueOnce(taskBPMN);
 
+    let onEnded2;
+    const hasEnded2 = new Promise((resolve) => (onEnded2 = resolve));
+
     await engine.deployProcessVersion(0, 456);
-    const onStarted2 = jest.fn(),
-      onEnded2 = jest.fn();
+    const onStarted2 = jest.fn();
     engine.startProcessVersion(456, {}, onStarted2, onEnded2);
     expect(engine.instanceIDs.length).toBe(2);
 
-    await new Promise((resolve) => setTimeout(resolve, 1000));
+    await hasEnded2;
 
     expect(engine.instanceIDs.length).toBe(2);
 
     expect(Object.keys(engine._versionProcessMapping)).toEqual(['123', '456']);
 
     expect(onStarted1).toHaveBeenCalledTimes(1);
-    expect(onEnded1).toHaveBeenCalledTimes(1);
     expect(onStarted2).toHaveBeenCalledTimes(1);
-    expect(onEnded2).toHaveBeenCalledTimes(1);
   });
 
   it('calls given network-service in a script task', async () => {
@@ -228,8 +246,8 @@ describe('ProceedEngine', () => {
 
     await engine.deployProcessVersion(0, 123);
     engine.startProcessVersion(123, {}, onStarted, onEnded);
-    await flushPromise;
-    await new Promise((resolve) => setTimeout(resolve, 1000));
+
+    await hasEnded;
 
     expect(System.http.request).toHaveBeenCalledWith('https://example.org/123', { method: 'GET' });
   });
@@ -240,7 +258,8 @@ describe('ProceedEngine', () => {
 
     await engine.deployProcessVersion(0, 123);
     engine.startProcessVersion(123, {}, onStarted, onEnded);
-    await flushPromise;
+
+    await sleep(500);
 
     const { userTasks } = engine;
     expect(userTasks.length).toBe(1);
@@ -250,9 +269,13 @@ describe('ProceedEngine', () => {
     const instanceID = engine.userTasks[0].processInstance.id;
     engine.updateIntermediateVariablesState(instanceID, userTaskID, { a: 2 });
 
+    await sleep(50);
+
     const instanceInformation = engine.getInstanceInformation(instanceID);
     expect(instanceInformation.tokens[0].intermediateVariablesState).toStrictEqual({ a: 2 });
     expect(instanceInformation.variables).toStrictEqual({});
+
+    await engine.stopInstance(engine.instanceIDs[0]);
   });
 
   it('takes variables input on a userTask', async () => {
@@ -260,7 +283,8 @@ describe('ProceedEngine', () => {
 
     await engine.deployProcessVersion(0, 123);
     engine.startProcessVersion(123, {}, onStarted, onEnded);
-    await flushPromise;
+
+    await sleep(500);
 
     const { userTasks } = engine;
     expect(userTasks.length).toBe(1);
@@ -269,6 +293,8 @@ describe('ProceedEngine', () => {
     // Signal user input
     const instanceID = engine.userTasks[0].processInstance.id;
     engine.completeUserTask(instanceID, 'Task_1y4wd2q', { a: 2 });
+
+    await hasEnded;
 
     const instanceInformation = engine.getInstanceInformation(instanceID);
     expect(instanceInformation.variables).toStrictEqual({
@@ -286,13 +312,17 @@ describe('ProceedEngine', () => {
 
   it('can be stopped through api function', async () => {
     distribution.db.getProcessVersion.mockResolvedValueOnce(userTaskBPMN);
+
     await engine.deployProcessVersion(0, 123);
     engine.startProcessVersion(123, {}, onStarted, onEnded);
-    await flushPromise;
 
-    engine.stopInstance(engine.instanceIDs[0]);
-    const instanceInformation = engine.getInstanceInformation(engine.instanceIDs[0]);
-    expect(instanceInformation.instanceState).toEqual(['STOPPED']);
+    await sleep(500);
+
+    await engine.stopInstance(engine.instanceIDs[0]);
+
+    expect(distribution.db.archiveInstance.mock.calls[0][2].instanceState).toStrictEqual([
+      'STOPPED',
+    ]);
   });
 
   it('can be started somewhere inside the process flow using an instance', async () => {
@@ -312,10 +342,10 @@ describe('ProceedEngine', () => {
     };
 
     await engine.deployProcessVersion(0, 123);
-    engine.startProcessVersion(123, {}, instance, undefined, onEnded);
-    await flushPromise;
+    engine.startProcessVersion(123, {}, instance, onStarted, onEnded);
 
-    expect(onEnded).toHaveBeenCalled();
+    await hasEnded;
+
     expect(engine.instanceIDs).toStrictEqual(['0-123']);
   });
 });

--- a/src/engine/universal/core/src/engine/__tests__/hookCallbacks.test.js
+++ b/src/engine/universal/core/src/engine/__tests__/hookCallbacks.test.js
@@ -104,8 +104,8 @@ describe('Test for the function that sets up callbacks for the different lifecyc
       log: jest.fn().mockImplementation(function (log) {
         this.logCallback(log);
       }),
-      ended: jest.fn().mockImplementation(function () {
-        this.endedCallback();
+      ended: jest.fn().mockImplementation(async function () {
+        await this.endedCallback();
       }),
       aborted: jest.fn().mockImplementation(function () {
         this.abortedCallback();
@@ -161,14 +161,14 @@ describe('Test for the function that sets up callbacks for the different lifecyc
 
     describe('instance ended', () => {
       it('logs end of instance, calls optional external onEnded, archives instance', async () => {
-        mockNewInstance.ended();
+        await mockNewInstance.ended();
 
         expect(mockEngine._log.info).toHaveBeenCalled();
         expect(onEnded).toHaveBeenCalled();
         expect(mockEngine.archiveInstance).toHaveBeenCalledWith('newInstanceId');
       });
 
-      it('completed the call activity in the calling instance if this instance was started to execute that call activity', () => {
+      it('completed the call activity in the calling instance if this instance was started to execute that call activity', async () => {
         mockNewInstance.callingInstance = 'otherInstance';
         mockNewInstance.getVariables = jest.fn().mockReturnValue({ some: 'value' });
 
@@ -195,7 +195,7 @@ describe('Test for the function that sets up callbacks for the different lifecyc
 
         mockEngine._management.getEngineWithID.mockReturnValueOnce(mockOtherEngine);
 
-        mockNewInstance.ended();
+        await mockNewInstance.ended();
 
         expect(mockCallingInstance.completeActivity).toHaveBeenCalledWith(
           'targetCallActivityId',

--- a/src/engine/universal/core/src/engine/engine.js
+++ b/src/engine/universal/core/src/engine/engine.js
@@ -355,6 +355,11 @@ class Engine {
         (uT.state === 'READY' || uT.state === 'ACTIVE')
     );
 
+    const token = this.getToken(instanceID, userTask.tokenId);
+    // remember the changes made by this user task invocation
+    userTask.variableChanges = { ...token.intermediateVariablesState };
+    userTask.milestones = { ...token.milestones };
+
     userTask.processInstance.completeActivity(userTask.id, userTask.tokenId, variables);
   }
 
@@ -579,6 +584,14 @@ class Engine {
             performers: token.performers,
           });
         }
+      });
+
+      this.userTasks = this.userTasks.map((uT) => {
+        if (uT.processInstance === instance && (uT.state === 'READY' || uT.state === 'ACTIVE')) {
+          return { ...uT, state: 'STOPPED' };
+        }
+
+        return uT;
       });
 
       instance.stop();

--- a/src/engine/universal/core/src/engine/hookCallbacks.js
+++ b/src/engine/universal/core/src/engine/hookCallbacks.js
@@ -32,14 +32,14 @@ function getLogHandler(engine, instance) {
  * @param {Object} instance the process instance that ended
  */
 function getOnEndedHandler(engine, instance) {
-  return () => {
+  return async () => {
     engine._log.info({
       msg: `Process instance ended. Id = ${instance.id}`,
       instanceId: instance.id,
     });
 
     // archive the information for the finalized instance
-    engine.archiveInstance(instance.id);
+    await engine.archiveInstance(instance.id);
 
     if (typeof engine.instanceEventHandlers.onEnded === 'function') {
       engine.instanceEventHandlers.onEnded(instance);

--- a/src/engine/universal/core/src/messaging-setup.js
+++ b/src/engine/universal/core/src/messaging-setup.js
@@ -18,7 +18,8 @@ module.exports = {
         await messaging.connect(serverAddress, {
           username,
           password,
-          clientId: machineId,
+          // To support multiple connections with the same messaging server we have to use different client ids or new connections with the same id will lead to the previous connection being closed
+          clientId: machineId + (username ? `|${username}` : ''),
           // setting up a mqtt-specific mechanism that will automatically inform all subscribed clients when the connection between the engine and the mqtt server is closed unexpectedly
           will: {
             topic: `engine/${machineId}/status`,

--- a/src/engine/universal/distribution/src/database/db.js
+++ b/src/engine/universal/distribution/src/database/db.js
@@ -76,7 +76,7 @@ module.exports = {
     }
 
     // get all images stored for the process
-    const knownImages = await data.readImages(definitionId);
+    const knownImages = (await data.readImages(definitionId)) || [];
 
     // check if image files are missing
     if (!requirements.images.every((fileName) => knownImages.includes(fileName))) {

--- a/src/engine/universal/system/src/__tests__/messaging.test.js
+++ b/src/engine/universal/system/src/__tests__/messaging.test.js
@@ -13,6 +13,7 @@ describe('Tests for the message interface of the dispatcher', () => {
     messaging = new Messaging();
 
     messaging._defaultMessagingServerAddress = 'mqtt://defaultAddress';
+    messaging._machineId = 'machineId';
     messaging._initialized = true;
 
     // mock the functions that are used inside publish to ensure that publish is awaitable
@@ -30,7 +31,7 @@ describe('Tests for the message interface of the dispatcher', () => {
 
       expect(messaging.commandRequest).toHaveBeenCalledWith(expect.any(String), [
         'messaging_publish',
-        ['mqtt://localhost:1883', 'test/123', 'Hello World', '{}', '{}'],
+        ['mqtt://localhost:1883', 'test/123', 'Hello World', '{}', '{"clientId":"machineId"}'],
       ]);
     });
 
@@ -39,7 +40,7 @@ describe('Tests for the message interface of the dispatcher', () => {
 
       expect(messaging.commandRequest).toHaveBeenCalledWith(expect.any(String), [
         'messaging_publish',
-        ['mqtt://defaultAddress', 'test/123', 'Hello World', '{}', '{}'],
+        ['mqtt://defaultAddress', 'test/123', 'Hello World', '{}', '{"clientId":"machineId"}'],
       ]);
     });
 
@@ -48,7 +49,13 @@ describe('Tests for the message interface of the dispatcher', () => {
 
       expect(messaging.commandRequest).toHaveBeenCalledWith(expect.any(String), [
         'messaging_publish',
-        ['mqtt://localhost:1883', 'test/123', `{\"some\":\"data\"}`, '{}', '{}'],
+        [
+          'mqtt://localhost:1883',
+          'test/123',
+          `{\"some\":\"data\"}`,
+          '{}',
+          '{"clientId":"machineId"}',
+        ],
       ]);
     });
 
@@ -68,7 +75,7 @@ describe('Tests for the message interface of the dispatcher', () => {
           'test/123',
           'Hello World',
           `{\"retain\":true}`,
-          `{\"username\":\"engine\",\"password\":\"password123\"}`,
+          `{\"username\":\"engine\",\"password\":\"password123\",\"clientId\":\"machineId|engine\"}`,
         ],
       ]);
     });
@@ -99,7 +106,7 @@ describe('Tests for the message interface of the dispatcher', () => {
           'test/123',
           'Hello World',
           '{}',
-          `{\"username\":\"user\",\"password\":\"password123\",\"clientId\":\"engineId\"}`,
+          `{\"username\":\"user\",\"password\":\"password123\",\"clientId\":\"engineId|user\"}`,
         ],
       ]);
     });
@@ -126,7 +133,7 @@ describe('Tests for the message interface of the dispatcher', () => {
           'test/123',
           'Hello World',
           '{}',
-          `{\"username\":\"other user\",\"password\":\"other password\",\"clientId\":\"engineId\"}`,
+          `{\"username\":\"other user\",\"password\":\"other password\",\"clientId\":\"engineId|other user\"}`,
         ],
       ]);
     });
@@ -175,7 +182,9 @@ describe('Tests for the message interface of the dispatcher', () => {
 
       expect(messaging.commandRequest).not.toHaveBeenCalled();
 
-      await messaging.init('mqtt://defaultAddress', 'user', 'password123', 'engineId');
+      await messaging.init('mqtt://defaultAddress', 'user', 'password123', 'engineId', {
+        debug: jest.fn(),
+      });
 
       expect(messaging.commandRequest).toBeCalledTimes(3);
       expect(messaging.commandRequest).toHaveBeenCalledWith(expect.any(String), [
@@ -185,7 +194,7 @@ describe('Tests for the message interface of the dispatcher', () => {
           'test/123',
           'Hello World',
           '{}',
-          `{\"username\":\"user\",\"password\":\"password123\",\"clientId\":\"engineId\"}`,
+          `{\"username\":\"user\",\"password\":\"password123\",\"clientId\":\"engineId|user\"}`,
         ],
       ]);
       expect(messaging.commandRequest).toHaveBeenCalledWith(expect.any(String), [
@@ -195,7 +204,7 @@ describe('Tests for the message interface of the dispatcher', () => {
           'test/456',
           'Hello World',
           '{}',
-          `{\"username\":\"user\",\"password\":\"password123\",\"clientId\":\"engineId\"}`,
+          `{\"username\":\"user\",\"password\":\"password123\",\"clientId\":\"engineId|user\"}`,
         ],
       ]);
       expect(messaging.commandRequest).toHaveBeenCalledWith(expect.any(String), [
@@ -205,7 +214,7 @@ describe('Tests for the message interface of the dispatcher', () => {
           'test/789',
           'Hello World',
           '{}',
-          `{\"username\":\"user\",\"password\":\"password123\",\"clientId\":\"engineId\"}`,
+          `{\"username\":\"user\",\"password\":\"password123\",\"clientId\":\"engineId|user\"}`,
         ],
       ]);
     });
@@ -229,7 +238,7 @@ describe('Tests for the message interface of the dispatcher', () => {
           'engine/engineId/test/123',
           'Hello World',
           '{"prependDefaultTopic":true}',
-          `{\"username\":\"user\",\"password\":\"password123\",\"clientId\":\"engineId\"}`,
+          `{\"username\":\"user\",\"password\":\"password123\",\"clientId\":\"engineId|user\"}`,
         ],
       ]);
     });
@@ -283,7 +292,7 @@ describe('Tests for the message interface of the dispatcher', () => {
         [
           'mqtt://some-url',
           'test/topic',
-          '{"username":"user","password":"password456"}',
+          '{"username":"user","password":"password456","clientId":"machineId|user"}',
           expect.stringMatching(/{"qos":0,"subscriptionId":".*"}/),
         ],
       ]);
@@ -301,7 +310,7 @@ describe('Tests for the message interface of the dispatcher', () => {
         [
           'mqtt://defaultAddress',
           'test/topic',
-          '{"username":"user123","password":"password123","clientId":"engineId"}',
+          '{"username":"user123","password":"password123","clientId":"engineId|user123"}',
           expect.stringMatching(/{"subscriptionId":".*"}/),
           ,
         ],
@@ -394,7 +403,7 @@ describe('Tests for the message interface of the dispatcher', () => {
           'mqtt://some-url',
           'test/topic',
           subscriptionId,
-          '{"username":"user","password":"password456"}',
+          '{"username":"user","password":"password456","clientId":"machineId|user"}',
         ],
       ]);
     });

--- a/src/engine/universal/ui/src/display-items/tasklist/TaskList-DisplayItem.js
+++ b/src/engine/universal/ui/src/display-items/tasklist/TaskList-DisplayItem.js
@@ -71,8 +71,20 @@ class TaskListTab extends DisplayItem {
       }
 
       definitionId = engine.definitionId;
-      variables = userTask.processInstance.getVariables(userTask.tokenId);
-      milestonesData = engine.getMilestones(query.instanceID, query.userTaskID);
+      if (userTask.variableChanges) {
+        // use the data in the user task if it exists (this is the case when the user task has already ended)
+        variables = userTask.variableChanges;
+      } else {
+        // get the data from the instance (will merge the instance and token data)
+        variables = userTask.processInstance.getVariables(userTask.tokenId);
+      }
+      if (userTask.milestones) {
+        // use the data in the user task if it exists (this is the case when the user task has already ended)
+        milestonesData = userTask.milestones;
+      } else {
+        // get the data from the instance (will look at the data of the token that currently resides on this user task)
+        milestonesData = engine.getMilestones(query.instanceID, query.userTaskID);
+      }
     } else {
       const inactiveTasks = await this.management.getInactiveUserTasks();
       userTask = inactiveTasks.find(

--- a/src/management-system/src/backend/shared-electron-server/network/process/instance.js
+++ b/src/management-system/src/backend/shared-electron-server/network/process/instance.js
@@ -209,7 +209,7 @@ export async function stopInstance(processDefinitionsId, instanceId) {
         await stop5thIndustryPlan(metaData['_5i-Inspection-Plan-ID']);
       }
 
-      activelyExecutingMachines.forEach((machineId) => {
+      await asyncForEach(activelyExecutingMachines, async (machineId) => {
         const machine = deployment.machines.find((m) => m.id === machineId);
 
         if (!machine) {
@@ -220,7 +220,7 @@ export async function stopInstance(processDefinitionsId, instanceId) {
         }
 
         try {
-          processEndpoint.stopProcessInstance(machine, processDefinitionsId, instanceId);
+          await processEndpoint.stopProcessInstance(machine, processDefinitionsId, instanceId);
         } catch (err) {
           if (logger) {
             logger.error(`Failed to stop instance on ${machine.name}: ${err}.`);

--- a/src/management-system/src/frontend/views/ProjectOverview.vue
+++ b/src/management-system/src/frontend/views/ProjectOverview.vue
@@ -315,7 +315,7 @@ export default {
           await this.$store.dispatch('processStore/addVersion', {
             id: this.storedInstance.processId,
             bpmn: this.storedDeployment.versions.find(
-              ({ version }) => version === this.storedInstance.processVersion
+              ({ version }) => version == this.storedInstance.processVersion
             ).bpmn,
           });
         }
@@ -403,7 +403,9 @@ export default {
     async restartProject() {
       this.showRestartDialog = false;
       try {
-        await engineNetworkInterface.startInstance(this.project.id, this.latestVersion);
+        // remove the deployment and redeploy to get a completely clean project state
+        await this.deleteDeployment();
+        await this.startProject();
         this.popupData.body = 'Project restarted successfully';
         this.popupData.color = 'success';
       } catch (err) {


### PR DESCRIPTION
<!--
  Thank you for your contribution to this project!

  Please provide the following information about your changes,
  in order for us to approve and merge your proposal as quickly as possible.
-->

## Summary

Fixed multiple bugs.

## Details

- Fixed: awaiting the unsubscribe function does not wait until a potential disconnect from the mqtt server on which the engine was subscribed is completed which might cause problems when there is an immediate connection attempt
- Fixed: some instance execution tests have running logic still running in the background after the tests have finished leading to a jest warning (this was fixed but we should maybe improve how we tap into the execution lifecycle)
- Fixed: Requesting user task information will lead to errors if the token that has activated a user task was later removed by a gateway (this is only a hotfix that might not work when the token is removed before the user task is completed)
- Fixed: multiple connections to the same mqtt server will not work since a connection is closed when another connection is opened with the same client id
- Fixed: The import of deployed processes in the ms does not wait until all the data has been saved leading to problems when saving fails
- When saving of data on import fails all previous changes are rolled back
- Fixed: An error is not correctly caught if the request to stop an instance on an engine fails
- Fixed: the restart button for stopped project does not work