### PR TITLE
Deployment and instance information publishing

### DIFF
--- a/src/engine/native/node/native-config/src/config_default.json
+++ b/src/engine/native/node/native-config/src/config_default.json
@@ -34,6 +34,7 @@
   "messaging": {
     "serverAddress": "",
     "username": "",
-    "password": ""
+    "password": "",
+    "baseTopic": ""
   }
 }

--- a/src/engine/universal/core/src/engine/5thIndustry.js
+++ b/src/engine/universal/core/src/engine/5thIndustry.js
@@ -1,13 +1,5 @@
 const system = require('@proceed/system');
-const {
-  toBpmnObject,
-  getMetaData,
-  getProcessIds,
-  getElementsByTagName,
-  getMetaDataFromElement,
-  getProcessDocumentationByObject,
-  getMilestonesFromElement,
-} = require('@proceed/bpmn-helper');
+const { getMetaData, getProcessIds } = require('@proceed/bpmn-helper');
 
 let serviceAccountId;
 let serviceAccountSecret;
@@ -415,72 +407,7 @@ async function pollInspectionOrderProgress(engine, userTask, _5iInformation) {
   }, 10000);
 }
 
-/**
- * Will send data about all process steps to a messaging server if messaging server information is included in the bpmn
- *
- * @param {String} projectId
- * @param {String|Number} version
- * @param {String} bpmn
- * @param {Object} logging the logging object of the engine the process is executed in
- */
-async function sendProcessStepsInfoTo5thIndustry(projectId, version, bpmn, logging) {
-  const bpmnObj = await toBpmnObject(bpmn);
-  const [processObj] = getElementsByTagName(bpmnObj, 'bpmn:Process');
-
-  const { mqttServer, timePlannedOccurrence, timePlannedDuration, timePlannedEnd } =
-    getMetaDataFromElement(processObj);
-
-  // only try to send data if messaging server information is embedded in the bpmn
-  if (mqttServer) {
-    const { url, user, password, topic } = mqttServer;
-    // get all process steps
-    let tasks = getElementsByTagName(bpmnObj, 'bpmn:UserTask');
-    tasks = tasks.concat(getElementsByTagName(bpmnObj, 'bpmn:Task'));
-    tasks = tasks.concat(getElementsByTagName(bpmnObj, 'bpmn:ScriptTask'));
-
-    const stepsInfo = {
-      projectId,
-      version,
-      timeStart: timePlannedOccurrence,
-      timeDuration: timePlannedDuration,
-      timeEnd: timePlannedEnd,
-      processSteps: tasks.map((task) => {
-        // get the required information from all process steps
-        const {
-          timePlannedOccurrence,
-          timePlannedEnd,
-          timePlannedDuration,
-          costsPlanned,
-          ...rest
-        } = getMetaDataFromElement(task);
-        const description = getProcessDocumentationByObject(task);
-        const milestones = getMilestonesFromElement(task);
-
-        return {
-          stepId: task.id,
-          name: task.name,
-          taskType: task.$type,
-          timeStart: timePlannedOccurrence,
-          timeEnd: timePlannedEnd,
-          timeDuration: timePlannedDuration,
-          description,
-          costs: costsPlanned,
-          milestones,
-          ...rest,
-        };
-      }),
-    };
-    try {
-      // send the information to the requested messaging server
-      await system.messaging.publish(topic, stepsInfo, url, {}, { username: user, password });
-    } catch (err) {
-      logging.error(`Failed to send process step information.\n${err}`);
-    }
-  }
-}
-
 module.exports = {
   handle5thIndustryUserTask,
   setup5thIndustryEndpoints,
-  sendProcessStepsInfoTo5thIndustry,
 };

--- a/src/engine/universal/core/src/engine/__tests__/hookCallbacks.test.js
+++ b/src/engine/universal/core/src/engine/__tests__/hookCallbacks.test.js
@@ -9,6 +9,7 @@ jest.mock('../processForwarding.js');
 
 const { getNewInstanceHandler } = require('../hookCallbacks.js');
 const { db } = require('@proceed/distribution');
+const { getElementsByTagName, getMetaDataFromElement } = require('@proceed/bpmn-helper');
 const { abortInstanceOnNetwork } = require('../processForwarding.js');
 
 const { enableInterruptedInstanceRecovery } = require('../../../../../../../FeatureFlags.js');
@@ -42,6 +43,7 @@ describe('Test for the function that sets up callbacks for the different lifecyc
       userTasks: [],
       _versionProcessMapping: {},
       _instanceIdProcessMapping: {},
+      _versionBpmnMapping: {},
       getInstanceInformation: jest.fn().mockReturnValue({}),
       instanceEventHandlers: { onStarted, onEnded, onTokenEnded },
       _management: {
@@ -135,6 +137,9 @@ describe('Test for the function that sets up callbacks for the different lifecyc
     };
 
     instanceHandler = getNewInstanceHandler(mockEngine, undefined);
+
+    getElementsByTagName.mockReturnValue([{}]);
+    getMetaDataFromElement.mockReturnValue({});
 
     await instanceHandler(mockNewInstance);
     mockEngine._log.info.mockReset();

--- a/src/engine/universal/core/src/engine/__tests__/shouldPassToken.test.js
+++ b/src/engine/universal/core/src/engine/__tests__/shouldPassToken.test.js
@@ -7,6 +7,15 @@ jest.mock('@proceed/constraint-parser-xml-json/parser.js', () => {
 });
 
 jest.mock('@proceed/machine', () => ({
+  logging: {
+    getLogger: jest.fn().mockReturnValue({
+      info: jest.fn(),
+      debug: jest.fn,
+      error: jest.fn(),
+      warn: jest.fn(),
+      trace: jest.fn(),
+    }),
+  },
   config: {
     readConfig: jest.fn(),
   },

--- a/src/engine/universal/core/src/engine/publishStateUtils.ts
+++ b/src/engine/universal/core/src/engine/publishStateUtils.ts
@@ -1,0 +1,64 @@
+import { messaging } from '@proceed/system';
+
+import { toBpmnObject, getElementsByTagName, getMetaDataFromElement } from '@proceed/bpmn-helper';
+
+/**
+ * Will send the current instance information to the default messaging server and a user defined server if  one is defined in the bpmn of the running instance
+ *
+ * @param {Object} engine an instance of the proceed engine in which the process is executed in
+ * @param {Object} instance the instance for which we want to send information
+ */
+export async function publishCurrentInstanceState(engine, instance) {
+  try {
+    const instanceInformation = engine.getInstanceInformation(instance.id);
+
+    // send instance information to the default messaging server
+    try {
+      await messaging.publish(
+        `process/${instanceInformation.processId}/instance/${instance.id}`,
+        instanceInformation,
+        undefined,
+        { retain: true, prependDefaultTopic: true }
+      );
+    } catch (err) {
+      if (engine._log) {
+        engine._log.warn(
+          `Failed to publish the state of the instance (id: ${instance.id}) to the messaging server defined in the engine config.`
+        );
+      }
+    }
+
+    const bpmn = engine._versionBpmnMapping[instanceInformation.processVersion];
+    const bpmnObj = await toBpmnObject(bpmn);
+    const [processObj] = getElementsByTagName(bpmnObj, 'bpmn:Process');
+
+    const { mqttServer } = getMetaDataFromElement(processObj);
+
+    if (mqttServer) {
+      const { url, user, password, topic } = mqttServer;
+
+      // send data if messaging server information is embedded in the bpmn
+      if (mqttServer) {
+        try {
+          await messaging.publish(
+            `${topic}/instance`,
+            instanceInformation,
+            url,
+            { retain: true },
+            { username: user, password }
+          );
+        } catch (err) {
+          if (engine._log) {
+            engine._log.warn(
+              `Failed to publish the state of the instance (id: ${instance.id}) to the messaging server defined in the bpmn.`
+            );
+          }
+        }
+      }
+    }
+  } catch (err) {
+    if (engine._log) {
+      engine._log.debug(err);
+    }
+  }
+}

--- a/src/engine/universal/core/src/engine/publishStateUtils.ts
+++ b/src/engine/universal/core/src/engine/publishStateUtils.ts
@@ -12,14 +12,14 @@ export async function publishCurrentInstanceState(engine, instance) {
   try {
     const instanceInformation = engine.getInstanceInformation(instance.id);
 
+    const defaultTopic = `process/${instanceInformation.processId}/instance/${instance.id}`;
+
     // send instance information to the default messaging server
     try {
-      await messaging.publish(
-        `process/${instanceInformation.processId}/instance/${instance.id}`,
-        instanceInformation,
-        undefined,
-        { retain: true, prependDefaultTopic: true }
-      );
+      await messaging.publish(defaultTopic, instanceInformation, undefined, {
+        retain: true,
+        prependDefaultTopic: true,
+      });
     } catch (err) {
       if (engine._log) {
         engine._log.warn(
@@ -35,13 +35,19 @@ export async function publishCurrentInstanceState(engine, instance) {
     const { mqttServer } = getMetaDataFromElement(processObj);
 
     if (mqttServer) {
-      const { url, user, password, topic } = mqttServer;
+      let { url, user, password, topic } = mqttServer;
+
+      // We want to handle 3 situations
+      // 1. empty topic => set topic to default process/[definition-id]/versions/[version-id] (without preceding slash)
+      // 2. non-empty topic without trailing slash => append the default topic [user-defined-topic]/process/[definition-id]/versions/[version-id]
+      // 3. non-empty topic with trailing slash => append the default topic without adding another slash [user-defined-topic]/process/[definition-id]/versions/[version-id]
+      if (topic.length && !topic.endsWith('/')) topic += '/';
 
       // send data if messaging server information is embedded in the bpmn
       if (mqttServer) {
         try {
           await messaging.publish(
-            `${topic}/instance`,
+            `${topic}${defaultTopic}`,
             instanceInformation,
             url,
             { retain: true },

--- a/src/engine/universal/core/src/messaging-setup.js
+++ b/src/engine/universal/core/src/messaging-setup.js
@@ -9,7 +9,7 @@ module.exports = {
   async setupMessaging(messaging, configModule, machineModule, logger) {
     // get default values from the config and machine info modules that shall be used when the caller of the publish function does not provide specific data
     // this should prevent that all modules that want to publish data have to import the config and machine info modules and get these values themselves
-    const { serverAddress, username, password, baseTopic } = await configModule.readConfig(
+    let { serverAddress, username, password, baseTopic } = await configModule.readConfig(
       'messaging'
     );
     const { id: machineId } = await machineModule.getMachineInformation(['id']);

--- a/src/engine/universal/decider/__tests__/module.test.js
+++ b/src/engine/universal/decider/__tests__/module.test.js
@@ -1,5 +1,14 @@
 /* eslint-disable import/no-dynamic-require */
 jest.mock('@proceed/machine', () => ({
+  logging: {
+    getLogger: jest.fn().mockReturnValue({
+      info: jest.fn(),
+      debug: jest.fn,
+      error: jest.fn(),
+      warn: jest.fn(),
+      trace: jest.fn(),
+    }),
+  },
   information: {
     getMachineInformation: jest.fn(),
   },

--- a/src/engine/universal/distribution/src/database/__tests__/db.test.js
+++ b/src/engine/universal/distribution/src/database/__tests__/db.test.js
@@ -2,6 +2,9 @@ jest.mock('@proceed/system', () => {
   const original = jest.requireActual('@proceed/system');
 
   return {
+    messaging: {
+      publish: jest.fn(),
+    },
     data: {
       ...original.data,
       read: jest.fn(),
@@ -17,6 +20,15 @@ jest.mock('@proceed/system', () => {
 });
 
 jest.mock('@proceed/machine', () => ({
+  logging: {
+    getLogger: jest.fn().mockReturnValue({
+      info: jest.fn(),
+      debug: jest.fn,
+      error: jest.fn(),
+      warn: jest.fn(),
+      trace: jest.fn(),
+    }),
+  },
   information: {
     getMachineInformation: jest.fn().mockResolvedValue({ id: 'mockId', ip: 'mockIp' }),
   },

--- a/src/engine/universal/distribution/src/database/db.js
+++ b/src/engine/universal/distribution/src/database/db.js
@@ -10,6 +10,8 @@ const {
 
 const { getRequiredProcessFragments, getHTMLImagesToKnow } = require('./processFragmentCheck');
 
+const { publishDeployedVersionInfo } = require('./publishDeploymentUtils');
+
 module.exports = {
   /**
    * Checks if the file with process information exists
@@ -147,6 +149,8 @@ module.exports = {
 
     // save the bpmn
     await data.writeProcessVersionBpmn(bpmnDefinitionId, version, bpmn);
+
+    await publishDeployedVersionInfo(bpmnDefinitionId, version, bpmn);
 
     return {
       definitionId: bpmnDefinitionId,

--- a/src/engine/universal/distribution/src/database/publishDeploymentUtils.ts
+++ b/src/engine/universal/distribution/src/database/publishDeploymentUtils.ts
@@ -92,13 +92,21 @@ export async function publishDeployedVersionInfo(
     bpmnString: bpmn,
   };
 
+  const defaultTopic = `process/${processDefinitionsId}/versions/${version}`;
+
   // send the information to the requested messaging server (if one is set )
   if (mqttServer) {
-    const { url, user, password, topic } = mqttServer;
+    let { url, user, password, topic } = mqttServer;
+
+    // We want to handle 3 situations
+    // 1. empty topic => set topic to default process/[definition-id]/versions/[version-id] (without preceding slash)
+    // 2. non-empty topic without trailing slash => append the default topic [user-defined-topic]/process/[definition-id]/versions/[version-id]
+    // 3. non-empty topic with trailing slash => append the default topic without adding another slash [user-defined-topic]/process/[definition-id]/versions/[version-id]
+    if (topic.length && !topic.endsWith('/')) topic += '/';
 
     try {
       await messaging.publish(
-        topic,
+        `${topic}${defaultTopic}`,
         stepsInfo,
         url,
         { retain: true },
@@ -113,12 +121,10 @@ export async function publishDeployedVersionInfo(
 
   // send the information to the default messaging server
   try {
-    await messaging.publish(
-      `process/${processDefinitionsId}/versions/${version}`,
-      stepsInfo,
-      undefined,
-      { retain: true, prependDefaultTopic: true }
-    );
+    await messaging.publish(defaultTopic, stepsInfo, undefined, {
+      retain: true,
+      prependDefaultTopic: true,
+    });
   } catch (err) {
     logger.warn(
       `Failed on publishing the deployment of version ${version} of the process with id ${processDefinitionsId} to the messaging server defined in the engine config`

--- a/src/engine/universal/distribution/src/database/publishDeploymentUtils.ts
+++ b/src/engine/universal/distribution/src/database/publishDeploymentUtils.ts
@@ -1,0 +1,127 @@
+import { messaging } from '@proceed/system';
+
+import {
+  toBpmnObject,
+  getElementsByTagName,
+  getMetaDataFromElement,
+  getProcessDocumentationByObject,
+  getMilestonesFromElement,
+  getDefinitionsName,
+} from '@proceed/bpmn-helper';
+
+const { enableMessaging } = require('../../../../../../FeatureFlags');
+
+const { logging } = require('@proceed/machine');
+
+const configObject = {
+  moduleName: 'DISTRIBUTION',
+};
+
+const logger = logging.getLogger(configObject);
+
+/**
+ * Publishes information about a newly deployed process version both to the default messaging server as well as any messaging server defined in the version bpmn
+ *
+ * @param processDefinitionsId
+ * @param version
+ * @param bpmn
+ */
+export async function publishDeployedVersionInfo(
+  processDefinitionsId: string,
+  version: string | number,
+  bpmn: string
+) {
+  if (!enableMessaging) return;
+
+  const bpmnObj = await toBpmnObject(bpmn);
+  const [processObj] = getElementsByTagName(bpmnObj, 'bpmn:Process');
+  const processName = await getDefinitionsName(bpmnObj);
+
+  const {
+    mqttServer,
+    timePlannedOccurrence,
+    timePlannedDuration,
+    timePlannedEnd,
+    costsPlanned,
+    orderNumber,
+    orderCode,
+    customerId,
+    customerName,
+  } = getMetaDataFromElement(processObj);
+
+  // get all process steps
+  let tasks = getElementsByTagName(bpmnObj, 'bpmn:UserTask');
+  tasks = tasks.concat(getElementsByTagName(bpmnObj, 'bpmn:Task'));
+  tasks = tasks.concat(getElementsByTagName(bpmnObj, 'bpmn:ScriptTask'));
+
+  const stepsInfo = {
+    processId: processDefinitionsId,
+    processVersion: version,
+    processName,
+
+    timePlannedOccurrence,
+    timePlannedDuration,
+    timePlannedEnd,
+    costsPlanned,
+    orderNumber,
+    orderCode,
+    customerId,
+    customerName,
+
+    processSteps: tasks.map((task) => {
+      // get the required information from all process steps
+      const { timePlannedOccurrence, timePlannedEnd, timePlannedDuration, costsPlanned, ...rest } =
+        getMetaDataFromElement(task);
+      const description = getProcessDocumentationByObject(task);
+      const milestones = getMilestonesFromElement(task);
+
+      return {
+        stepId: task.id,
+        name: task.name,
+        taskType: task.$type,
+        description,
+        milestones,
+        timePlannedOccurrence,
+        timePlannedDuration,
+        timePlannedEnd,
+        costsPlanned,
+        ...rest,
+      };
+    }),
+
+    bpmnString: bpmn,
+  };
+
+  // send the information to the requested messaging server (if one is set )
+  if (mqttServer) {
+    const { url, user, password, topic } = mqttServer;
+
+    try {
+      await messaging.publish(
+        topic,
+        stepsInfo,
+        url,
+        { retain: true },
+        { username: user, password }
+      );
+    } catch (err) {
+      logger.warn(
+        `Failed on publishing the deployment of version ${version} of the process with id ${processDefinitionsId} to the messaging server defined in the bpmn`
+      );
+    }
+  }
+
+  // send the information to the default messaging server
+  try {
+    await messaging.publish(
+      `process/${processDefinitionsId}/versions/${version}`,
+      stepsInfo,
+      undefined,
+      { retain: true, prependDefaultTopic: true }
+    );
+  } catch (err) {
+    logger.warn(
+      `Failed on publishing the deployment of version ${version} of the process with id ${processDefinitionsId} to the messaging server defined in the engine config`
+    );
+  }
+}

--- a/src/engine/universal/system/src/__tests__/messaging.test.js
+++ b/src/engine/universal/system/src/__tests__/messaging.test.js
@@ -87,7 +87,7 @@ describe('Tests for the message interface of the dispatcher', () => {
 
       await expect(
         messaging.publish('test/123', 'Hello World', 'mqtt://localhost:1883')
-      ).rejects.toMatch('Failed to publish to mqtt://localhost:1883\nError Message');
+      ).rejects.toMatch('Failed to publish to mqtt://localhost:1883: Error Message');
     });
 
     it('automatically adds default login data (if it is available), if no other login data is given in the connection options', async () => {
@@ -182,7 +182,7 @@ describe('Tests for the message interface of the dispatcher', () => {
 
       expect(messaging.commandRequest).not.toHaveBeenCalled();
 
-      await messaging.init('mqtt://defaultAddress', 'user', 'password123', 'engineId', {
+      await messaging.init('mqtt://defaultAddress', 'user', 'password123', 'engineId', '', {
         debug: jest.fn(),
       });
 
@@ -219,11 +219,12 @@ describe('Tests for the message interface of the dispatcher', () => {
       ]);
     });
 
-    it('will prefix "engine/[engine-id]" to the given topic if requested', async () => {
+    it('will prefix "[baseTopic]/engine/[engine-id]" to the given topic if requested', async () => {
       messaging._username = 'user';
       messaging._password = 'password123';
       // this is what defines the engine id used in the prefix (will be passed to the messaging module on initialization)
       messaging._machineId = 'engineId';
+      messaging._baseTopic = 'base-topic/';
 
       await expect(
         messaging.publish('test/123', 'Hello World', 'mqtt://localhost:1883', {
@@ -235,7 +236,7 @@ describe('Tests for the message interface of the dispatcher', () => {
         'messaging_publish',
         [
           'mqtt://localhost:1883',
-          'engine/engineId/test/123',
+          'base-topic/engine/engineId/test/123',
           'Hello World',
           '{"prependDefaultTopic":true}',
           `{\"username\":\"user\",\"password\":\"password123\",\"clientId\":\"engineId|user\"}`,
@@ -265,7 +266,7 @@ describe('Tests for the message interface of the dispatcher', () => {
       });
 
       await expect(messaging.connect('mqtt://localhost:1883')).rejects.toMatch(
-        'Failed to connect to mqtt://localhost:1883\nError Message'
+        'Failed to connect to mqtt://localhost:1883: Error Message'
       );
     });
   });
@@ -331,7 +332,7 @@ describe('Tests for the message interface of the dispatcher', () => {
           { qos: 0 }
         )
       ).rejects.toMatch(
-        'Failed to subscribe to mqtt://some-url (Topic: test/topic)\nError Message'
+        'Failed to subscribe to mqtt://some-url (Topic: test/topic): Error Message'
       );
     });
 


### PR DESCRIPTION
<!--
  Thank you for your contribution to this project!

  Please provide the following information about your changes,
  in order for us to approve and merge your proposal as quickly as possible.
-->

## Summary

Added more publishing functionality

## Details

- Added a config value that can be used to prepend a specific path to the topics under which the engine publishes information
- Added publishing of instance information that is triggered each time the instance state changes (with a debounce) if a messaging server is defined in the engine config or in the process bpmn
- Process information with process steps is published on deployment instead of on instance start
- Process information is always deployed and not only when the 5thIndustry feature flag is set
