### PR TITLE
Tasklist bugfix

### DIFF
--- a/src/engine/native/node/native-vm2/package.json
+++ b/src/engine/native/node/native-vm2/package.json
@@ -8,6 +8,6 @@
   "dependencies": {
     "@proceed/native-module": "^1.0.0",
     "vm2": "^3.8.4",
-    "neo-bpmn-engine": "^8.0.1"
+    "neo-bpmn-engine": "^8.1.0"
   }
 }

--- a/src/engine/universal/core/package.json
+++ b/src/engine/universal/core/package.json
@@ -16,7 +16,7 @@
     "@proceed/system": "^1.0.0",
     "@proceed/ui": "^1.0.0",
     "bpmn-moddle": "^5.1.6",
-    "neo-bpmn-engine": "^8.0.1",
+    "neo-bpmn-engine": "^8.1.0",
     "vm2": "3.8.4"
   },
   "devDependencies": {

--- a/src/engine/universal/core/src/engine/engine.js
+++ b/src/engine/universal/core/src/engine/engine.js
@@ -842,6 +842,8 @@ class Engine {
         manual: false,
       });
     }
+
+    userTask.milestones = newMilestones;
   }
 
   updateIntermediateVariablesState(instanceID, userTaskID, variables) {
@@ -851,11 +853,13 @@ class Engine {
         uT.id === userTaskID &&
         (uT.state === 'READY' || uT.state === 'ACTIVE')
     );
-    const token = this.getToken(instanceID, userTask.tokenId);
 
     Object.entries(variables).forEach(([key, value]) =>
-      userTask.processInstance.setVariable(token.tokenId, key, value)
+      userTask.processInstance.setVariable(userTask.tokenId, key, value)
     );
+
+    const token = this.getToken(instanceID, userTask.tokenId);
+    userTask.variableChanges = { ...token.intermediateVariablesState };
   }
 
   setFlowNodeState(instanceId, tokenId, state, variables) {

--- a/src/engine/universal/ui/src/display-items/tasklist/TaskList-DisplayItem.js
+++ b/src/engine/universal/ui/src/display-items/tasklist/TaskList-DisplayItem.js
@@ -70,8 +70,22 @@ class TaskListTab extends DisplayItem {
       }
 
       definitionId = engine.definitionId;
-      variables = userTask.processInstance.getVariables(userTask.tokenId);
-      milestonesData = engine.getMilestones(query.instanceID, query.userTaskID);
+
+      if (userTask.state === 'READY' || userTask.state === 'ACTIVE') {
+        variables = userTask.processInstance.getVariables(userTask.tokenId);
+        milestonesData = engine.getMilestones(query.instanceID, query.userTaskID);
+      } else {
+        // get info of non-active userTask from logs
+        const logs = userTask.processInstance.getState().log;
+        const userTaskLogEntry = logs.find(
+          (logEntry) =>
+            logEntry.flowElementId === userTask.id &&
+            logEntry.tokenId === userTask.tokenId &&
+            logEntry.startTime === userTask.startTime
+        );
+        variables = userTask.processInstance.getVariables();
+        milestonesData = userTaskLogEntry.milestones;
+      }
     } else {
       const inactiveTasks = await this.management.getInactiveUserTasks();
       userTask = inactiveTasks.find(

--- a/src/engine/universal/ui/src/display-items/tasklist/TaskList-DisplayItem.js
+++ b/src/engine/universal/ui/src/display-items/tasklist/TaskList-DisplayItem.js
@@ -71,19 +71,17 @@ class TaskListTab extends DisplayItem {
       }
 
       definitionId = engine.definitionId;
-      if (userTask.variableChanges) {
-        // use the data in the user task if it exists (this is the case when the user task has already ended)
-        variables = userTask.variableChanges;
-      } else {
+
+      if (userTask.state === 'READY' || userTask.state === 'ACTIVE') {
         // get the data from the instance (will merge the instance and token data)
         variables = userTask.processInstance.getVariables(userTask.tokenId);
-      }
-      if (userTask.milestones) {
-        // use the data in the user task if it exists (this is the case when the user task has already ended)
-        milestonesData = userTask.milestones;
-      } else {
         // get the data from the instance (will look at the data of the token that currently resides on this user task)
         milestonesData = engine.getMilestones(query.instanceID, query.userTaskID);
+      } else {
+        // use the data in the user task if it exists (this is the case when the user task has already ended)
+        variables = userTask.variableChanges || {};
+        // use the data in the user task if it exists (this is the case when the user task has already ended)
+        milestonesData = userTask.milestones || {};
       }
     } else {
       const inactiveTasks = await this.management.getInactiveUserTasks();
@@ -93,8 +91,10 @@ class TaskListTab extends DisplayItem {
           task.id === query.userTaskID &&
           parseInt(task.startTime) === parseInt(query.startTime)
       );
-      const allInstances = await distribution.db.getArchivedInstances(userTask.definitionId);
-      const userTaskInstance = allInstances[query.instanceID];
+      const allArchivedUserTaskInstances = await distribution.db.getArchivedInstances(
+        userTask.definitionId
+      );
+      const userTaskInstance = allArchivedUserTaskInstances[query.instanceID];
       const userTaskToken = userTaskInstance.tokens.find(
         (token) => token.currentFlowElementId === query.userTaskID
       );

--- a/yarn.lock
+++ b/yarn.lock
@@ -14509,10 +14509,10 @@ neo-async@^2.5.0, neo-async@^2.6.0, neo-async@^2.6.1, neo-async@^2.6.2:
   resolved "https://registry.yarnpkg.com/neo-async/-/neo-async-2.6.2.tgz#b4aafb93e3aeb2d8174ca53cf163ab7d7308305f"
   integrity sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==
 
-neo-bpmn-engine@^8.0.1:
-  version "8.0.1"
-  resolved "https://registry.yarnpkg.com/neo-bpmn-engine/-/neo-bpmn-engine-8.0.1.tgz#4355d13f8672466a767cf8e22e9a0e49a9d497d0"
-  integrity sha512-kWaSrEbmlPNmqdb+UDdJFzsxYlpuyz5Bd5tA7/YjS7RcWfa/ycMPjWqskG/6dK7Dc3+Gp3EYxzpL71PA1agbog==
+neo-bpmn-engine@^8.1.0:
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/neo-bpmn-engine/-/neo-bpmn-engine-8.1.0.tgz#84f155db07375d8138e1a60d524903241973b63a"
+  integrity sha512-V6F2EySLfQQJhv/Ob8039j175D/zAI25WF9uLBbPrlM97LagLi5HjS2ktNTmE8D3fcRjfPQPIv7oHejlSxil5A==
   dependencies:
     bpmn-moddle "^6.0.0"
     iso8601-duration "^1.2.0"


### PR DESCRIPTION
## Summary

Fixed Tasklist for cases in which the process contains terminated userTasks or tokens who got removed having been on a userTask (e.g. parallel gateway merge). For these, the tasklist was trying to reconstruct information about the non-active userTask which was not possible because of the removed tokens. 
Also, the log entries were incomplete because the tokens were removed before the information could be logged. This was fixed with bumping the neo-bpmn-engine to the newest version.

## Details

- updated neo-bpmn-engine version
- store variablesChanges and milestones with every change in engine
- retrieve variablesChanges and milestone from stored object in engine when userTask is not active/ready
