### PR TITLE
Images in export/import of processes

### DIFF
--- a/src/management-system/src/frontend/backend-api/ProcessInterface.js
+++ b/src/management-system/src/frontend/backend-api/ProcessInterface.js
@@ -291,6 +291,17 @@ class ProcessInterface {
    * @param {String} processDefinitionsId the id of the process
    * @returns {Object} - an object with the fileName as the keys and the related image as values
    */
+  async getImages(processDefinitionsId) {
+    const images = await api.getImages(processDefinitionsId);
+    return images;
+  }
+
+  /**
+   * Returns image in a process
+   *
+   * @param {String} processDefinitionsId the id of the process
+   * @returns {Object} - searched image
+   */
   async getImage(processDefinitionsId, imageFileName) {
     const image = await api.getImage(processDefinitionsId, imageFileName);
     return image;

--- a/src/management-system/src/frontend/backend-api/ms-api-electron/process.js
+++ b/src/management-system/src/frontend/backend-api/ms-api-electron/process.js
@@ -73,6 +73,7 @@ export default {
   getUserTasksHTML: backendProcesses.getProcessUserTasksHtml,
   saveUserTaskHTML: backendProcesses.saveProcessUserTask,
   deleteUserTaskHTML: backendProcesses.deleteProcessUserTask,
+  getImages: backendProcesses.getProcessImages,
   getImage: backendProcesses.getProcessImage,
   saveImage: backendProcesses.saveProcessImage,
   saveScriptTaskJS,

--- a/src/management-system/src/frontend/backend-api/ms-api-server/browser-storage.js
+++ b/src/management-system/src/frontend/backend-api/ms-api-server/browser-storage.js
@@ -329,6 +329,17 @@ export async function deleteUserTaskHTML(processDefinitionsId, taskFileName) {
 }
 
 /**
+ * Returns images in a process
+ *
+ * @param {String} processDefinitionsId
+ * @returns {Object} retrieved images from process
+ */
+export async function getImages(processDefinitionsId) {
+  const process = getProcess(processDefinitionsId);
+  return process.images;
+}
+
+/**
  * Returns image in a process
  *
  * @param {String} processDefinitionsId

--- a/src/management-system/src/frontend/backend-api/ms-api-server/process.js
+++ b/src/management-system/src/frontend/backend-api/ms-api-server/process.js
@@ -653,6 +653,18 @@ async function deleteUserTaskHTML(processDefinitionsId, taskFileName) {
   }
 }
 
+async function getImages(processDefinitionsId) {
+  let images;
+
+  if (browserStorage.hasProcess(processDefinitionsId)) {
+    images = browserStorage.getImages(processDefinitionsId);
+  } else {
+    images = await restRequest(`process/${processDefinitionsId}/images/`);
+  }
+
+  return images;
+}
+
 async function getImage(processDefinitionsId, imageFileName) {
   let image;
 
@@ -722,6 +734,7 @@ export default {
   getUserTasksHTML,
   saveUserTaskHTML,
   deleteUserTaskHTML,
+  getImages,
   getImage,
   saveImage,
   saveScriptTaskJS,

--- a/src/management-system/src/frontend/components/processes/ExportModal.vue
+++ b/src/management-system/src/frontend/components/processes/ExportModal.vue
@@ -32,10 +32,10 @@
         <v-col>
           <v-container>
             <v-checkbox
-              v-if="isUserTaskVisible"
+              v-if="isArtefactVisible"
               v-model="additionalBpmn"
-              :key="'withUserTasks'"
-              :label="'with User Tasks'"
+              :key="'withArtefacts'"
+              :label="'with Artefacts'"
               :value="!additionalBpmn"
             >
             </v-checkbox>
@@ -141,7 +141,7 @@ export default {
       bpmnOption: null,
       resolutionValue: 2,
       additionalParam: {},
-      isUserTaskVisible: false,
+      isArtefactVisible: false,
       isPDFTitleVisible: false,
       isResolutionVisible: false,
       isCallActivityVisible: false,
@@ -179,7 +179,7 @@ export default {
         switch (this.selectedOption.format) {
           case 'bpmn':
             this.additionalPdf = false;
-            this.isUserTaskVisible = true;
+            this.isArtefactVisible = true;
             this.isPDFTitleVisible = false;
             this.isResolutionVisible = false;
             this.isCallActivityVisible = true;
@@ -187,7 +187,7 @@ export default {
             break;
           case 'pdf':
             this.additionalBpmn = false;
-            this.isUserTaskVisible = false;
+            this.isArtefactVisible = false;
             this.isPDFTitleVisible = true;
             this.isResolutionVisible = true;
             this.isCallActivityVisible = true;
@@ -198,7 +198,7 @@ export default {
             this.additionalBpmn = false;
             this.additionalPdf = false;
             this.additionalParam.resolution = this.resolutionValue;
-            this.isUserTaskVisible = false;
+            this.isArtefactVisible = false;
             this.isPDFTitleVisible = false;
             this.isResolutionVisible = true;
             this.isCallActivityVisible = true;
@@ -207,7 +207,7 @@ export default {
           default:
             this.additionalBpmn = false;
             this.additionalPdf = false;
-            this.isUserTaskVisible = false;
+            this.isArtefactVisible = false;
             this.isPDFTitleVisible = false;
             this.isResolutionVisible = false;
             this.isCallActivityVisible = true;
@@ -218,7 +218,7 @@ export default {
         this.exportOption.additionalParam = this.additionalParam;
 
         if (this.selectedOption.format == 'bpmn' && this.additionalBpmn == true) {
-          this.exportOption.additionalParam.format = 'withUserTasks';
+          this.exportOption.additionalParam.format = 'withArtefacts';
         }
         if (this.selectedOption.format == 'pdf' && this.additionalPdf == true) {
           this.exportOption.additionalParam.format = 'pdfwh';

--- a/src/management-system/src/frontend/components/processes/processForm/ImportProcessForm.vue
+++ b/src/management-system/src/frontend/components/processes/processForm/ImportProcessForm.vue
@@ -132,10 +132,11 @@ export default {
         // deduce information needed for import from provided information and existing/stored information
         processesData = await asyncMap(
           processesData,
-          async ({ fileName, bpmnFileAsXml, bpmnFileAsObject, htmlData }) => {
+          async ({ fileName, bpmnFileAsXml, bpmnFileAsObject, htmlData, imageData }) => {
             const processData = await analyseBPMNFile(
               bpmnFileAsObject,
               htmlData,
+              imageData,
               this.$store,
               this.type,
               fileName

--- a/src/management-system/src/frontend/components/processes/processForm/process-import.js
+++ b/src/management-system/src/frontend/components/processes/processForm/process-import.js
@@ -97,10 +97,11 @@ export async function getProcessFiles(file) {
  *
  * @param {(string|object)} bpmn - the process definition as XML string or BPMN-Moddle Object
  * @param {(undefined|Map<String, HtmlInfo>)} htmlData - the html data that was provided alongside the bpmn
+ * @param {(undefined|object)} imageData - the image data that was provided alongside the bpmn
  * @param {*} $store - the vuex store to look up processes
- * @returns { Promise.<{ processData: {id: string, name: string, description: string, departments: Array, userTasks: UserTaskInfo, htmlData: HtmlInfo } }>} - the process info needed for an import
+ * @returns { Promise.<{ processData: {id: string, name: string, description: string, departments: Array, userTasks: UserTaskInfo, htmlData: HtmlInfo, imageData: object } }>} - the process info needed for an import
  */
-export async function analyseBPMNFile(bpmn, htmlData, $store, type, defaultName = '') {
+export async function analyseBPMNFile(bpmn, htmlData, imageData, $store, type, defaultName = '') {
   const bpmnObj = typeof bpmn === 'string' ? await toBpmnObject(bpmn) : bpmn;
   let definitionsId = await getDefinitionsId(bpmnObj);
   const name = (await getDefinitionsName(bpmnObj)) || defaultName.replace(/(\.bpmn|\.xml)$/gm, '');
@@ -128,6 +129,7 @@ export async function analyseBPMNFile(bpmn, htmlData, $store, type, defaultName 
     id: possibleOverrideProcess || possibleDerivedProcesses.length ? '' : definitionsId,
     name,
     htmlData,
+    imageData,
     possibleOverrideProcess,
     possibleDerivedProcesses,
   };
@@ -161,7 +163,7 @@ function readFileAsText(file) {
  * @summary Read zip files and searches for bpmn files and user tasks for each bpmn file
  *
  * @param {Blob} zipBlob - zip file containing several bpmn files
- * @returns {Promise<Array<{ fileName: string, bpmnFileAsXml: string, htmlData: HtmlInfo }>>} - array containing all the provided information about the contained processes
+ * @returns {Promise<Array<{ fileName: string, bpmnFileAsXml: string, htmlData: HtmlInfo, imageData: object }>>} - array containing all the provided information about the contained processes
  */
 export async function readZipAsync(zipBlob) {
   const zip = await JSZip.loadAsync(zipBlob);
@@ -198,6 +200,26 @@ export async function readZipAsync(zipBlob) {
       });
     }
 
+    // generate folder name like 'Delivery-Proces-604fdef1/images/'
+    const imageDir = bpmnFile.name.replace(bpmnFileName, 'images/');
+
+    // list all image files inside the images folder which is in the same folder like the current bpmn file
+    const imageFiles = Object.values(zip.files).filter(
+      (file) => file.name.startsWith(imageDir) && file.name !== imageDir
+    );
+
+    const imageData = {};
+    for (const imageFile of imageFiles) {
+      const imageFileName = imageFile.name.split('/').pop();
+      const imageFileType = imageFileName.split('.').pop();
+      // resolves the content of the file in buffer and convert to file
+      const imageFileContent = await imageFile.async('arraybuffer');
+      const file = new File([imageFileContent], imageFileName, {
+        type: imageFileType,
+      });
+      imageData[imageFileName] = file;
+    }
+
     // resolves the content of the file in a string
     const bpmnFileContent = await bpmnFile.async('string');
 
@@ -205,6 +227,7 @@ export async function readZipAsync(zipBlob) {
       fileName: bpmnFileName,
       bpmnFileAsXml: bpmnFileContent,
       htmlData,
+      imageData,
     });
   }
 

--- a/src/management-system/src/frontend/components/processes/processForm/userTasks.vue
+++ b/src/management-system/src/frontend/components/processes/processForm/userTasks.vue
@@ -277,6 +277,19 @@ export default {
           });
         }
       });
+
+      if (processData.imageData) {
+        await asyncForEach(
+          Object.entries(processData.imageData),
+          async ([imageFileName, image]) => {
+            await this.$store.dispatch('processStore/saveImage', {
+              processDefinitionsId: processData.id,
+              imageFileName,
+              image,
+            });
+          }
+        );
+      }
     },
   },
 };

--- a/src/management-system/src/frontend/helpers/process-export/export-preparation.js
+++ b/src/management-system/src/frontend/helpers/process-export/export-preparation.js
@@ -2,6 +2,7 @@ import { processInterface } from '@/frontend/backend-api/index.js';
 import { flattenSubprocesses } from '@/shared-frontend-backend/helpers/process-hierarchy.js';
 import { getSubprocessContent } from '@proceed/bpmn-helper';
 import { getProcessHierarchy } from '@/shared-frontend-backend/helpers/process-hierarchy.js';
+import { asyncForEach } from '../../../shared-frontend-backend/helpers/javascriptHelpers';
 /**
  * @param {Object} process
  * @returns - Returns xml for a process from the store
@@ -28,6 +29,28 @@ export async function getUserTasksByProcess(process) {
   return userTasks;
 }
 
+/**
+ * @param {Object} process
+ * @returns - Returns images for a process from the store
+ */
+export async function getImagesByProcess(process) {
+  if (!process.id || !process.name) {
+    console.warn('Try to retrieve images for invalid process: ', process);
+    return null;
+  }
+  const images = await processInterface.getImages(process.id);
+  await asyncForEach(Object.keys(images), async (imageFileName) => {
+    let image = images[imageFileName];
+    if (typeof image === 'string') {
+      const blob = await fetch(image).then((res) => res.blob());
+      const file = new File([blob], { type: blob.type });
+      image = file;
+    }
+    images[imageFileName] = image;
+  });
+  return images;
+}
+
 export function getCleanedUpName(name) {
   return name
     .replace(/[`@^()_={}[\]|;!=&/\\#,+()$~%.'":*?<>{}]/g, '')
@@ -38,7 +61,7 @@ export function getCleanedUpName(name) {
 
 /**
  * Retrieve every subprocess and subprocesses of call activities for the
- * processes to export and their meta information, bpmn and user tasks
+ * processes to export and their meta information, bpmn, user tasks and images
  *
  * @param {Object[]} allProcesses all known processes to search for referenced call activities
  * @param {Object[]} processesToExport - all processes that need to be exported
@@ -50,8 +73,9 @@ export async function prepareProcesses(allProcesses, processesToExport, options)
       ...process,
       bpmn: await getXmlByProcess(process),
     };
-    if (options.additionalParam.format === 'withUserTasks') {
+    if (options.additionalParam.format === 'withArtefacts') {
       augmentedProcess.userTasks = await getUserTasksByProcess(process);
+      augmentedProcess.images = await getImagesByProcess(process);
     }
 
     if (options.additionalParam.includeCallActivityProcess) {
@@ -60,7 +84,7 @@ export async function prepareProcesses(allProcesses, processesToExport, options)
         allProcesses,
         augmentedProcess,
         [],
-        options.additionalParam.format === 'withUserTasks',
+        options.additionalParam.format === 'withArtefacts',
         options.additionalParam.includeCollapsedSubprocess
       );
     } else if (options.additionalParam.includeCollapsedSubprocess) {
@@ -108,14 +132,14 @@ export async function prepareProcesses(allProcesses, processesToExport, options)
  * @param {Object[]} allProcesses all known processes to search for referenced call activities
  * @param {Object} currentProcess current selected process of the hierarchy
  * @param {Object[]} includedProcesses container containing all (nested) call activities
- * @param {Boolean} [addUserTasks] if we want to get the user tasks of the called processes
+ * @param {Boolean} [addArtefacts] if we want to get the user tasks and images of the called processes
  * @param {Boolean} includeCollapsed - signal if also collapsed subprocesses should be retrieved
  */
 export async function getAllSubprocesses(
   allProcesses,
   currentProcess,
   includedProcesses,
-  addUserTasks,
+  addArtefacts,
   includeCollapsed
 ) {
   currentProcess.subprocesses = await getProcessHierarchy(currentProcess.bpmn);
@@ -141,8 +165,9 @@ export async function getAllSubprocesses(
         callActivityProcess = { ...callActivityProcess };
 
         callActivityProcess.bpmn = await getXmlByProcess(callActivityProcess);
-        if (addUserTasks) {
+        if (addArtefacts) {
           callActivityProcess.userTasks = await getUserTasksByProcess(callActivityProcess);
+          callActivityProcess.images = await getImagesByProcess(callActivityProcess);
         }
         // check if process was in recursive loop before
         if (!includedProcesses.some((process) => process.id === callActivityProcess.id)) {
@@ -151,7 +176,7 @@ export async function getAllSubprocesses(
             allProcesses,
             callActivityProcess,
             includedProcesses,
-            addUserTasks,
+            addArtefacts,
             includeCollapsed
           );
         }

--- a/src/management-system/src/frontend/helpers/process-export/process-export.js
+++ b/src/management-system/src/frontend/helpers/process-export/process-export.js
@@ -64,6 +64,10 @@ function needZipExport(processesToExport, options) {
   if (exportProcess.userTasks && Object.keys(exportProcess.userTasks).length) {
     return true;
   }
+  // we need to use a zip if we want to export images along with the process bpmn
+  if (exportProcess.images && Object.keys(exportProcess.images).length) {
+    return true;
+  }
   // we don't import callActivities and subprocesses into the directory of the process containing them on a bpmn export
   // call activities are imported into their own directory and should lead to the first check being true
   if (options.format !== 'bpmn') {
@@ -207,7 +211,7 @@ async function addFile(container, process, viewer, options) {
 }
 
 /**
- * Adds optional content to the pdf/directory (e.g. User Tasks for bpmn export or called processes for image exports)
+ * Adds optional content to the pdf/directory (e.g. User Tasks or Images for bpmn export or called processes for image exports)
  *
  * @param {Object} container a pdf or zip directory
  * @param {*} process
@@ -217,6 +221,7 @@ async function addFile(container, process, viewer, options) {
 async function addAdditionalContent(container, process, viewer, options) {
   if (options.format === 'bpmn') {
     createUserTasks(container, process);
+    createImages(container, process);
   } else {
     // create image files for all subprocesses and callActivities
     if (process.collapsedSubprocesses && Array.isArray(process.collapsedSubprocesses)) {
@@ -498,6 +503,31 @@ export function createUserTasks(processFolder, process) {
     //Combining Process with its supporting files
     for (const userTaskId of userTaskIds) {
       userTaskFolder.file(`${userTaskId}.html`, userTasks[userTaskId]);
+    }
+  }
+}
+
+/**
+ * Creates image directory and files in zip
+ *
+ * @param {Object} processFolder the directory in the zip to write to
+ */
+export function createImages(processFolder, process) {
+  const { images } = process;
+
+  if (!images) {
+    return;
+  }
+
+  const imageFileNames = Object.keys(images);
+  //Combining Process with its supporting files
+  if (imageFileNames.length > 0) {
+    //If its multi download then attach files to its specific folder else direct to zipObject
+    const imagesFolder = processFolder.folder('images');
+
+    //Combining Process with its supporting files
+    for (const imageFileName of imageFileNames) {
+      imagesFolder.file(`${imageFileName}`, images[imageFileName]);
     }
   }
 }


### PR DESCRIPTION
<!--
  Thank you for your contribution to this project!

  Please provide the following information about your changes,
  in order for us to approve and merge your proposal as quickly as possible.
-->

## Summary

Including images in export & import of processes. Images get zipped together with bpmn-process and other artefacts (e.g. userTask HTML). 

## Details

- include images in export when selecting bpmn with artefacts
- include images in process when importing with images contained in folder
