### PR TITLE
Fix Issue #76

### DIFF
--- a/src/management-system/src/frontend/components/processes/processForm/EditProcessForm.vue
+++ b/src/management-system/src/frontend/components/processes/processForm/EditProcessForm.vue
@@ -76,6 +76,7 @@ export default {
             name: process.name,
             bpmn,
             originalStoredProcessId: process.id,
+            shared: process.shared,
           };
           this.setProcessesData([processData]);
         }


### PR DESCRIPTION

## Summary

Bugfix for Issue #76.

## Details
When editing metainformation on a shared process, it was tried to move the process to the local storage. This was prevented by keeping the _shared_-attribute untouched when emitting changes.
