### PR TITLE
Fix: don't connect to redis when auth is disabled

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   "scripts": {
     "dev": "node --loader ts-node/esm --trace-warnings src/engine/native/node/index.ts",
     "dev-ms": "cd src/management-system-v2 && yarn dev",
-    "dev-ms-api": "cd src/management-system && cross-env process.env.API_ONLY=true yarn web:dev-start-backend",
+    "dev-ms-api": "cd src/management-system && cross-env process.env.API_ONLY=true USE_AUTHORIZATION=false yarn web:dev-start-backend",
     "dev-ms-old": "cd src/management-system && yarn web:dev",
     "dev-ms-iam": "cd src/management-system && yarn web:dev-iam",
     "dev-web": "yarn build && cd src/engine/native/web/server && yarn serve",

--- a/src/management-system/src/backend/server/iam/middleware/authorization.ts
+++ b/src/management-system/src/backend/server/iam/middleware/authorization.ts
@@ -4,9 +4,14 @@ import Ability from '../authorization/abilityHelper';
 
 import Redis from 'ioredis';
 
-const abilityCache = new Redis(config.redisRulesPort || 6380, config.redisHost || 'localhost', {
-  password: config.redisPassword || 'password',
-});
+let abilityCache: Redis;
+
+export function initialiazeRulesCache(msConfig: typeof config) {
+  if (msConfig.useAuthorization)
+    abilityCache = new Redis(config.redisRulesPort || 6380, config.redisHost || 'localhost', {
+      password: config.redisPassword || 'password',
+    });
+}
 
 /* const abilityCache = new LRUCache<string, Ability>({
   max: 500,

--- a/src/management-system/src/backend/server/index.js
+++ b/src/management-system/src/backend/server/index.js
@@ -21,7 +21,7 @@ import { getCertificate, handleLetsEncrypt } from './https-certificate-service/c
 import createConfig from './iam/utils/config.js';
 import getClient from './iam/authentication/client.js';
 import { getStorePath } from '../shared-electron-server/data/store.js';
-import { abilityMiddleware } from './iam/middleware/authorization';
+import { abilityMiddleware, initialiazeRulesCache } from './iam/middleware/authorization';
 
 const configPath =
   process.env.NODE_ENV === 'development'
@@ -54,7 +54,7 @@ async function init() {
     const file = await fse.readFile(configPath);
     if (file) {
       config = await createConfig(JSON.parse(file));
-      store = await createSessionStore(config);
+      if (config.useAuthorization) store = await createSessionStore(config);
     }
   } catch (e) {
     config = await createConfig();
@@ -128,6 +128,8 @@ async function init() {
     backendServer.use(loginSession);
   }
   backendServer.use(authRouter(config, client)); // separate authentication routes
+
+  initialiazeRulesCache(config);
   backendServer.use(abilityMiddleware);
 
   // allow requests for Let's Encrypt


### PR DESCRIPTION
The ms server was trying to connect to a redis instance when authorization was disabled. 