### PR TITLE
Use authorization for UI

### DIFF
--- a/src/management-system-v2/app/(dashboard)/layout.tsx
+++ b/src/management-system-v2/app/(dashboard)/layout.tsx
@@ -36,6 +36,8 @@ import cn from 'classnames';
 import Content from '@/components/content';
 import HeaderMenu from '@/components/content-based-header';
 import HeaderActions from '@/components/header-actions';
+import { useAuthStore } from '@/lib/iam';
+import { AuthCan } from '@/lib/iamComponents';
 
 type AuthLayoutProps = PropsWithChildren<{
   headerContent: React.ReactNode | undefined;
@@ -45,6 +47,8 @@ const AuthLayout: FC<PropsWithChildren> = ({ children }) => {
   const router = useRouter();
   const activeSegment = usePathname().split('/')[1] || 'processes';
   const [collapsed, setCollapsed] = useState(false);
+  const ability = useAuthStore((state) => state.ability);
+  const loggedIn = useAuthStore((state) => state.loggedIn);
 
   // keys need to be unique <identifier>:<path>
   // identifier can be left out if the path is unique
@@ -243,62 +247,79 @@ const AuthLayout: FC<PropsWithChildren> = ({ children }) => {
           trigger={null}
           breakpoint="md"
         >
-          <Menu
-            theme="light"
-            mode="inline"
-            selectedKeys={[activeSegment]}
-            onClick={({ key }) => {
-              const path = key.split(':').at(-1);
-              router.push(`/${path}`);
-            }}
-          >
-            <ItemGroup key="processes" title="Processes">
-              <SubMenu
-                key="processes"
-                title={
-                  <span
-                    onClick={() => {
-                      router.push(`/processes`);
-                    }}
-                  >
-                    Process List
-                  </span>
-                }
-                className={activeSegment === 'processes' ? 'SelectedSegment' : ''}
-                icon={
-                  <EditOutlined
-                    onClick={() => {
-                      router.push(`/processes`);
-                    }}
-                  />
-                }
-              >
-                <Item key="newProcess" icon={<FileAddOutlined />}>
-                  New Process
+          {loggedIn ? (
+            <Menu
+              theme="light"
+              mode="inline"
+              selectedKeys={[activeSegment]}
+              onClick={({ key }) => {
+                const path = key.split(':').at(-1);
+                router.push(`/${path}`);
+              }}
+            >
+              {ability.can('view', 'Process') || ability.can('view', 'Template') ? (
+                <>
+                  <ItemGroup key="processes" title="Processes">
+                    {ability.can('view', 'Process') ? (
+                      <SubMenu
+                        key="processes"
+                        title={
+                          <span
+                            onClick={() => {
+                              router.push(`/processes`);
+                            }}
+                          >
+                            Process List
+                          </span>
+                        }
+                        className={activeSegment === 'processes' ? 'SelectedSegment' : ''}
+                        icon={
+                          <EditOutlined
+                            onClick={() => {
+                              router.push(`/processes`);
+                            }}
+                          />
+                        }
+                      >
+                        <Item
+                          key="newProcess"
+                          icon={<FileAddOutlined />}
+                          hidden={!ability.can('create', 'Process')}
+                        >
+                          New Process
+                        </Item>
+                        <Item key="processFavorites" icon={<StarOutlined />}>
+                          Favorites
+                        </Item>
+                      </SubMenu>
+                    ) : null}
+
+                    {ability.can('view', 'Template') ? (
+                      <SubMenu key="templates" title="Templates" icon={<ProfileOutlined />}>
+                        <Item key="newTemplate" icon={<FileAddOutlined />}>
+                          New Template
+                        </Item>
+                        <Item key="templateFavorites" icon={<StarOutlined />}>
+                          Favorites
+                        </Item>
+                      </SubMenu>
+                    ) : null}
+                  </ItemGroup>
+
+                  <Divider />
+                </>
+              ) : null}
+
+              <ItemGroup key="settings" title="Settings">
+                <Item key="generalSettings" icon={<SettingOutlined />}>
+                  General Settings
                 </Item>
-                <Item key="processFavorites" icon={<StarOutlined />}>
-                  Favorites
+                <Item key="plugins" icon={<ApiOutlined />}>
+                  Plugins
                 </Item>
-              </SubMenu>
-              <SubMenu key="templates" title="Templates" icon={<ProfileOutlined />}>
-                <Item key="newTemplate" icon={<FileAddOutlined />}>
-                  New Template
-                </Item>
-                <Item key="templateFavorites" icon={<StarOutlined />}>
-                  Favorites
-                </Item>
-              </SubMenu>
-            </ItemGroup>
-            <Divider />
-            <ItemGroup key="settings" title="Settings">
-              <Item key="generalSettings" icon={<SettingOutlined />}>
-                General Settings
-              </Item>
-              <Item key="plugins" icon={<ApiOutlined />}>
-                Plugins
-              </Item>
-            </ItemGroup>
-          </Menu>
+              </ItemGroup>
+            </Menu>
+          ) : null}
           {/* <Menu
             theme="light"
             mode="inline"

--- a/src/management-system-v2/app/(dashboard)/layout.tsx
+++ b/src/management-system-v2/app/(dashboard)/layout.tsx
@@ -296,7 +296,11 @@ const AuthLayout: FC<PropsWithChildren> = ({ children }) => {
 
                     {ability.can('view', 'Template') ? (
                       <SubMenu key="templates" title="Templates" icon={<ProfileOutlined />}>
-                        <Item key="newTemplate" icon={<FileAddOutlined />}>
+                        <Item
+                          key="newTemplate"
+                          icon={<FileAddOutlined />}
+                          hidden={!ability.can('create', 'Template')}
+                        >
                           New Template
                         </Item>
                         <Item key="templateFavorites" icon={<StarOutlined />}>

--- a/src/management-system-v2/app/(dashboard)/processes/[processId]/page.tsx
+++ b/src/management-system-v2/app/(dashboard)/processes/[processId]/page.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { FC } from 'react';
 import Page from './_page';
 import DashboardLayout from '../../layout';
+import Auth from '@/lib/AuthCanWrapper';
 
 type ProcessProps = {
   params: { processId: string };
@@ -13,4 +14,11 @@ const Processes: FC<ProcessProps> = ({ params: { processId } }) => {
   return <Page params={{ processId }} />;
 };
 
-export default Processes;
+export default Auth(
+  {
+    action: 'view',
+    resource: 'Process',
+    fallbackRedirect: '/processes',
+  },
+  Processes,
+);

--- a/src/management-system-v2/app/(dashboard)/processes/header-actions.tsx
+++ b/src/management-system-v2/app/(dashboard)/processes/header-actions.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { AuthCan } from '@/lib/iamComponents';
 import { ImportOutlined, PlusOutlined } from '@ant-design/icons';
 import { Button, Space } from 'antd';
 import { FC } from 'react';
@@ -10,9 +11,12 @@ const HeaderActions: FC = () => {
       <Button>
         <ImportOutlined /> Import
       </Button>
-      <Button type="primary">
-        <PlusOutlined /> Create
-      </Button>
+
+      <AuthCan action="create" resource="Process">
+        <Button type="primary">
+          <PlusOutlined /> Create
+        </Button>
+      </AuthCan>
     </Space>
   );
 };

--- a/src/management-system-v2/app/(dashboard)/processes/page.tsx
+++ b/src/management-system-v2/app/(dashboard)/processes/page.tsx
@@ -5,9 +5,9 @@ import Content from '@/components/content';
 import Space from '@/components/_space';
 import HeaderActions from './header-actions';
 import { login } from '@/lib/iam';
-import { Auth } from '@/lib/iamComponents';
 import { Button, Result } from 'antd';
 import { LoginOutlined } from '@ant-design/icons';
+import Auth from '@/lib/AuthCanWrapper';
 
 const ProcessesPage: FC = () => {
   return (

--- a/src/management-system-v2/app/(dashboard)/projects/page.tsx
+++ b/src/management-system-v2/app/(dashboard)/projects/page.tsx
@@ -4,6 +4,7 @@ import ProjectStats from './project-stats';
 import Space from '@/components/_space';
 import Content from '@/components/content';
 import HeaderActions from './header-actions';
+import Auth from '@/lib/AuthCanWrapper';
 
 const Projects: FC = () => {
   return (
@@ -16,4 +17,4 @@ const Projects: FC = () => {
   );
 };
 
-export default Projects;
+export default Auth({ action: 'view', resource: 'Project', fallbackRedirect: '/' }, Projects);

--- a/src/management-system-v2/components/userProfile.tsx
+++ b/src/management-system-v2/components/userProfile.tsx
@@ -28,7 +28,7 @@ import {
   useDeleteAsset,
 } from '@/lib/fetch-data';
 import { RightOutlined } from '@ant-design/icons';
-import { Auth } from '@/lib/iamComponents';
+import Auth from '@/lib/AuthCanWrapper';
 
 type modalInputField = {
   userDataField: keyof ApiData<'/users/{id}', 'get'>;

--- a/src/management-system-v2/lib/AuthCanWrapper.tsx
+++ b/src/management-system-v2/lib/AuthCanWrapper.tsx
@@ -1,0 +1,14 @@
+import { ComponentProps } from 'react';
+import { AuthCan, AuthCanProps } from './iamComponents';
+
+export default function Auth(authOptions: AuthCanProps, Component: FC<any>) {
+  function wrappedComponent(props: ComponentProps<typeof Component>) {
+    return (
+      <AuthCan {...authOptions}>
+        <Component {...props} />
+      </AuthCan>
+    );
+  }
+
+  return wrappedComponent;
+}

--- a/src/management-system-v2/lib/iam.ts
+++ b/src/management-system-v2/lib/iam.ts
@@ -2,8 +2,13 @@
 
 import { create } from 'zustand';
 import Ability from 'proceed-management-system/src/backend/server/iam/authorization/abilityHelper';
-import { PackedRulesForUser } from 'proceed-management-system/src/backend/server/iam/authorization/caslRules';
+import {
+  PackedRulesForUser,
+  adminRules,
+} from 'proceed-management-system/src/backend/server/iam/authorization/caslRules';
 import { ResourceType } from 'proceed-management-system/src/backend/server/iam/authorization/permissionHelpers';
+import { packRules } from '@casl/ability/extra';
+import { AbilityRule } from 'proceed-management-system/src/backend/server/iam/authorization/caslAbility';
 
 const BACKEND_URL = process.env.BACKEND_URL;
 
@@ -54,8 +59,8 @@ type AuthStoreType = (
 } & Pick<AuthResponse, 'user' | 'csrfToken'>;
 
 export const useAuthStore = create<AuthStoreType>((set) => ({
-  oauthCallbackPerformed: false,
-  loggedIn: false,
+  oauthCallbackPerformed: false || !process.env.NEXT_PUBLIC_USE_AUTH,
+  loggedIn: false || !process.env.NEXT_PUBLIC_USE_AUTH,
   logout() {
     set({ loggedIn: false });
   },
@@ -77,7 +82,11 @@ export const useAuthStore = create<AuthStoreType>((set) => ({
     sid: '',
     nonce: '',
   },
-  ability: new Ability([]),
+  ability: new Ability(
+    process.env.NEXT_PUBLIC_USE_AUTH
+      ? []
+      : packRules([{ action: 'admin', subject: 'All' }] as AbilityRule),
+  ),
   csrfToken: '',
   oauthCallback(obj: AuthResponse | undefined) {
     if (typeof obj === 'object' && obj.isLoggedIn) {

--- a/src/management-system-v2/lib/iamComponents.tsx
+++ b/src/management-system-v2/lib/iamComponents.tsx
@@ -107,9 +107,11 @@ export const AuthCan: FC<AuthCanProps> = ({
     }
   }, [fallbackRedirect, oauthCallbackPerformed, allow, router]);
 
+  if (!process.env.NEXT_PUBLIC_USE_AUTH) return children;
+
   if (!oauthCallbackPerformed) return loadingAuth || null;
 
-  if (!process.env.NEXT_PUBLIC_USE_AUTH || allow) return children;
+  if (allow) return children;
 
   if (!loggedIn && notLoggedIn) return notLoggedIn;
 

--- a/src/management-system-v2/lib/iamComponents.tsx
+++ b/src/management-system-v2/lib/iamComponents.tsx
@@ -60,7 +60,7 @@ export const AuthCallbackListener: FC = () => {
   return null;
 };
 
-type AuthCanProps = PropsWithChildren<{
+export type AuthCanProps = PropsWithChildren<{
   action: ResourceActionType | ResourceActionType[];
   resource: ResourceType | ResourceType[];
   notLoggedIn?: ReactNode;
@@ -115,15 +115,3 @@ export const AuthCan: FC<AuthCanProps> = ({
 
   return fallback || null;
 };
-
-export function Auth(authOptions: AuthCanProps, Component: FC) {
-  function wrappedComponent(props: ComponentProps<typeof Component>) {
-    return (
-      <AuthCan {...authOptions}>
-        <Component {...props} />
-      </AuthCan>
-    );
-  }
-
-  return wrappedComponent;
-}


### PR DESCRIPTION
## Summary

The UI in the new MS now adapts according to the users permission

## Details

- moved the Auth component to a separate file, so it can be server rendered
- used AuthCan and Auth throughout the new MS to adapt the UI to the user's roles
- src/management-system-v2/app/(dashboard)/layout.tsx AuthCan didn't work, the AntDesign indents were thrown off