### PR TITLE
Stop dev process if docker stops

### DIFF
--- a/src/management-system/dev-server.ts
+++ b/src/management-system/dev-server.ts
@@ -79,6 +79,8 @@ if (process.env.MODE === 'iam') {
     console.error('Redis', dataString);
   });
 
+  opaProcess.on('exit', (code) => process.exit(code));
+
   // when ctrl + c detected stop docker container
   process.on('SIGINT', () => {
     execSync('docker compose -f docker-compose-dev-iam.yml down');


### PR DESCRIPTION
## Summary

The development process of the management system stops if the docker container stops, as the other processes need the docker container.
This also helps, when docker isn't running, as the error message won't be buried in the logs of the other processes.