### PR TITLE
data hooks: use all params for react query key

### DIFF
--- a/src/management-system-v2/lib/fetch-data.ts
+++ b/src/management-system-v2/lib/fetch-data.ts
@@ -133,13 +133,8 @@ export type ApiData<
 function getKeys(path: any, params: any) {
   const keys = [path];
 
-  if (
-    typeof params === 'object' &&
-    'params' in params &&
-    typeof params.params === 'object' &&
-    'path' in params.params
-  ) {
-    keys.push(params.params.path as any);
+  if (typeof params === 'object' && 'params' in params && typeof params.params === 'object') {
+    keys.push(params.params as any);
   }
 
   return keys;


### PR DESCRIPTION
## Summary

Fetch data hooks weren't taking into account query parameters, so that `/process?noBpmn=true` and `/process?noBpmn=false` were returning the same data.