### PR TITLE
Sort matches before highlighting text

### DIFF
--- a/src/management-system-v2/lib/useFuzySearch.tsx
+++ b/src/management-system-v2/lib/useFuzySearch.tsx
@@ -20,7 +20,9 @@ function highlightText<TObj>(
 
   const result: JSX.Element[] = [];
   let lastIndex = 0;
-  for (const [start, end] of matches.indices) {
+  const sortedMatches = matches.indices.toSorted((a, b) => a[0] - b[0]);
+
+  for (const [start, end] of sortedMatches) {
     if (lastIndex < start)
       result.push(<span key={lastIndex}>{value.slice(lastIndex, start)}</span>);
 


### PR DESCRIPTION
## Summary

useFuzySearch bug fix: Match indices returned by Fuse (fuzy search) weren't sorted, which resulted in the highlighted string's text being different to the original text.