### PR TITLE
Editor improvements (New MS)

### DIFF
--- a/src/management-system-v2/app/globals.css
+++ b/src/management-system-v2/app/globals.css
@@ -1,5 +1,12 @@
 .bpmn-js-modeler-with-toolbar .djs-palette {
-  top: 125px;
+  top: 70px;
+}
+
+.bpmn-js-modeler-with-toolbar .bjs-breadcrumbs {
+  top: unset;
+  left: 15px !important;
+  bottom: 10px;
+  font-size: 20px;
 }
 
 /* Workaround to make flex with breakpoints work. See: https://github.com/ant-design/ant-design/issues/28961#issuecomment-1712966521 */

--- a/src/management-system-v2/components/modeler-toolbar.tsx
+++ b/src/management-system-v2/components/modeler-toolbar.tsx
@@ -72,8 +72,15 @@ const ModelerToolbar: React.FC<ModelerToolbarProps> = ({ onOpenXmlEditor }) => {
 
   useEffect(() => {
     if (modeler) {
+      const commandStack = modeler.get('commandStack', false) as CommandStack;
+      // check if there is a commandStack (does not exist on the viewer used when editing is disabled)
+      if (commandStack) {
+        // init canUndo and canRedo
+        setCanUndo(commandStack.canUndo());
+        setCanRedo(commandStack.canRedo());
+      }
       modeler.on('commandStack.changed', () => {
-        const commandStack = modeler.get('commandStack') as CommandStack;
+        // update canUndo and canRedo when the state of the modelers commandStack changes
         setCanUndo(commandStack.canUndo());
         setCanRedo(commandStack.canRedo());
       });

--- a/src/management-system-v2/components/modeler-toolbar.tsx
+++ b/src/management-system-v2/components/modeler-toolbar.tsx
@@ -1,18 +1,19 @@
 'use client';
 
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 
 import type ElementRegistry from 'diagram-js/lib/core/ElementRegistry';
+import type CommandStack from 'diagram-js/lib/command/CommandStack';
 
-import { Row, Col, Tooltip, Button } from 'antd';
+import { Tooltip, Button, Space } from 'antd';
 import { Toolbar, ToolbarGroup } from './toolbar';
 
 import Icon, {
-  FormOutlined,
   ExportOutlined,
-  EyeOutlined,
   SettingOutlined,
   PlusOutlined,
+  UndoOutlined,
+  RedoOutlined,
 } from '@ant-design/icons';
 
 import { SvgXML, SvgShare } from '@/components/svg';
@@ -26,7 +27,7 @@ import ProcessExportModal from './process-export';
 
 import { createNewProcessVersion } from '@/lib/helpers/processVersioning';
 import VersionCreationButton from './version-creation-button';
-import { useQueryClient } from '@tanstack/react-query';
+
 import { useInvalidateAsset } from '@/lib/fetch-data';
 
 type ModelerToolbarProps = {
@@ -40,7 +41,11 @@ const ModelerToolbar: React.FC<ModelerToolbarProps> = ({ onOpenXmlEditor }) => {
   const [showPropertiesPanel, setShowPropertiesPanel] = useState(false);
   const [showProcessExportModal, setShowProcessExportModal] = useState(false);
 
+  const [canUndo, setCanUndo] = useState(false);
+  const [canRedo, setCanRedo] = useState(false);
+
   const modeler = useModelerStateStore((state) => state.modeler);
+  const editingDisabled = useModelerStateStore((state) => state.editingDisabled);
   const selectedElementId = useModelerStateStore((state) => state.selectedElementId);
 
   const { processId } = useParams();
@@ -64,6 +69,16 @@ const ModelerToolbar: React.FC<ModelerToolbarProps> = ({ onOpenXmlEditor }) => {
       ? elementRegistry.get(selectedElementId)!
       : elementRegistry.getAll().filter((el) => el.businessObject.$type === 'bpmn:Process')[0];
   }
+
+  useEffect(() => {
+    if (modeler) {
+      modeler.on('commandStack.changed', () => {
+        const commandStack = modeler.get('commandStack') as CommandStack;
+        setCanUndo(commandStack.canUndo());
+        setCanRedo(commandStack.canRedo());
+      });
+    }
+  }, [modeler]);
 
   const createProcessVersion = async (values: {
     versionName: string;
@@ -91,44 +106,60 @@ const ModelerToolbar: React.FC<ModelerToolbarProps> = ({ onOpenXmlEditor }) => {
 
   const selectedVersion = useSearchParams().get('version');
 
+  const handleUndo = () => {
+    if (modeler) (modeler.get('commandStack') as CommandStack).undo();
+  };
+
+  const handleRedo = () => {
+    if (modeler) (modeler.get('commandStack') as CommandStack).redo();
+  };
+
   return (
     <>
       <Toolbar>
-        <Row justify="end">
-          <Col>
-            <ToolbarGroup>
-              {/* <Button>Test</Button>
+        <Space style={{ width: '100%', justifyContent: 'end' }} wrap>
+          <ToolbarGroup>
+            {/* <Button>Test</Button>
               <Button
                 icon={showPropertiesPanel ? <EyeOutlined /> : <EyeInvisibleOutlined />}
                 onClick={handlePropertiesPanelToggle}
               /> */}
-              <Tooltip title="Show XML">
-                <Button icon={svgXML} onClick={onOpenXmlEditor}></Button>
+            <Tooltip title="Show XML">
+              <Button icon={svgXML} onClick={onOpenXmlEditor}></Button>
+            </Tooltip>
+            <Tooltip title="Export">
+              <Button icon={<ExportOutlined />} onClick={handleProcessExportModalToggle}></Button>
+            </Tooltip>
+            <Tooltip
+              title={showPropertiesPanel ? 'Close Properties Panel' : 'Open Properties Panel'}
+            >
+              <Button icon={<SettingOutlined />} onClick={handlePropertiesPanelToggle}></Button>
+            </Tooltip>
+            <Tooltip title="Create New Version">
+              <VersionCreationButton
+                icon={<PlusOutlined />}
+                createVersion={createProcessVersion}
+              ></VersionCreationButton>
+            </Tooltip>
+          </ToolbarGroup>
+          {!editingDisabled && modeler && (
+            <ToolbarGroup>
+              <Tooltip title="Undo">
+                <Button icon={<UndoOutlined />} onClick={handleUndo} disabled={!canUndo}></Button>
               </Tooltip>
-              <Tooltip title="Export">
-                <Button icon={<ExportOutlined />} onClick={handleProcessExportModalToggle}></Button>
-              </Tooltip>
-              <Tooltip
-                title={showPropertiesPanel ? 'Close Properties Panel' : 'Open Properties Panel'}
-              >
-                <Button icon={<SettingOutlined />} onClick={handlePropertiesPanelToggle}></Button>
-              </Tooltip>
-              <Tooltip title="Create New Version">
-                <VersionCreationButton
-                  icon={<PlusOutlined />}
-                  createVersion={createProcessVersion}
-                ></VersionCreationButton>
+              <Tooltip title="Redo">
+                <Button icon={<RedoOutlined />} onClick={handleRedo} disabled={!canRedo}></Button>
               </Tooltip>
             </ToolbarGroup>
-            {showPropertiesPanel && <div style={{ width: '650px' }}></div>}
-          </Col>
-          {/* {showPropertiesPanel && <Col></Col>} */}
-          {showPropertiesPanel && selectedElement && (
-            <>
-              <PropertiesPanel selectedElement={selectedElement} setOpen={setShowPropertiesPanel} />
-            </>
           )}
-        </Row>
+          {showPropertiesPanel && <div style={{ width: '378px' }}></div>}
+        </Space>
+        {/* {showPropertiesPanel && <Col></Col>} */}
+        {showPropertiesPanel && selectedElement && (
+          <>
+            <PropertiesPanel selectedElement={selectedElement} setOpen={setShowPropertiesPanel} />
+          </>
+        )}
       </Toolbar>
       {/* {showPropertiesPanel && selectedElement && (
         <PropertiesPanel selectedElement={selectedElement} setOpen={setShowPropertiesPanel} />

--- a/src/management-system-v2/components/modeler.tsx
+++ b/src/management-system-v2/components/modeler.tsx
@@ -48,6 +48,7 @@ const Modeler: FC<ModelerProps> = ({ minimized, ...props }) => {
 
   const setModeler = useModelerStateStore((state) => state.setModeler);
   const setSelectedElementId = useModelerStateStore((state) => state.setSelectedElementId);
+  const setEditingDisabled = useModelerStateStore((state) => state.setEditingDisabled);
 
   /// Derived State
   const selectedVersionId = query.get('version');
@@ -70,6 +71,7 @@ const Modeler: FC<ModelerProps> = ({ minimized, ...props }) => {
             proceed: schema,
           },
         });
+        setEditingDisabled(true);
       } else {
         modeler.current = new Modeler!({
           container: canvas.current!,
@@ -80,7 +82,7 @@ const Modeler: FC<ModelerProps> = ({ minimized, ...props }) => {
 
         // update process after change with 2 second debounce
         let timer: ReturnType<typeof setTimeout>;
-        modeler.current.on('commandStack.changed', async () => {
+        modeler.current.on('commandStack.changed', () => {
           clearTimeout(timer);
           timer = setTimeout(async () => {
             try {
@@ -95,6 +97,8 @@ const Modeler: FC<ModelerProps> = ({ minimized, ...props }) => {
             }
           }, 2000);
         });
+
+        setEditingDisabled(false);
       }
 
       // allow keyboard shortcuts like copy (strg+c) and paste (strg+v) etc.

--- a/src/management-system-v2/components/modeler.tsx
+++ b/src/management-system-v2/components/modeler.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React, { FC, useEffect, useRef, useState } from 'react';
+import 'bpmn-js/dist/assets/bpmn-js.css';
 import 'bpmn-js/dist/assets/diagram-js.css';
 import 'bpmn-js/dist/assets/bpmn-font/css/bpmn.css';
 import type ModelerType from 'bpmn-js/lib/Modeler';

--- a/src/management-system-v2/lib/use-modeler-state-store.ts
+++ b/src/management-system-v2/lib/use-modeler-state-store.ts
@@ -10,6 +10,7 @@ type ModelerStateStore = {
   editingDisabled: boolean;
   setModeler: (newModeler: Modeler | Viewer | null) => void;
   setSelectedElementId: (newId: null | string) => void;
+  setEditingDisabled: (isDisabled: boolean) => void;
 };
 
 const useModelerStateStore = create<ModelerStateStore>()(
@@ -24,6 +25,10 @@ const useModelerStateStore = create<ModelerStateStore>()(
     setSelectedElementId: (newId: null | string) =>
       set((state) => {
         state.selectedElementId = newId;
+      }),
+    setEditingDisabled: (isDisabled: boolean) =>
+      set((state) => {
+        state.editingDisabled = isDisabled;
       }),
   })),
 );


### PR DESCRIPTION
<!--
  Thank you for your contribution to this project!

  Please provide the following information about your changes,
  in order for us to approve and merge your proposal as quickly as possible.
-->

## Summary

Closes #168

- Undo and Redo buttons in the modeler toolbar
- Breadcrumb menu to show the current position and allow returning to the main process when editing in a collapsed sub-process

## Details

- fixed the css properties of the breadcrumb menu already provided by `bpmn-js` so it is correctly displayed in the bottom left of the modeler
- added the undo and redo buttons as a separate toolbar group
- changed the layout of the modeler toolbar from row+col to space to automatically space the two groups in the toolbar