### PR TITLE
Fix: handle overlapping match intervals

### DIFF
--- a/src/management-system-v2/lib/useFuzySearch.tsx
+++ b/src/management-system-v2/lib/useFuzySearch.tsx
@@ -22,16 +22,19 @@ function highlightText<TObj>(
   let lastIndex = 0;
   const sortedMatches = matches.indices.toSorted((a, b) => a[0] - b[0]);
 
-  for (const [start, end] of sortedMatches) {
-    if (lastIndex < start)
+  for (let [start, end] of sortedMatches) {
+    if (end <= lastIndex) continue;
+    if (start < lastIndex) start = lastIndex;
+
+    if (lastIndex < start) {
       result.push(<span key={lastIndex}>{value.slice(lastIndex, start)}</span>);
+    }
 
     result.push(
       <span key={start} style={{ color }}>
         {value.slice(start, end + 1)}
       </span>,
     );
-
     lastIndex = end + 1;
   }
   if (lastIndex !== value.length)


### PR DESCRIPTION
## Summary

Match indices returned by FuseJS have overlapping intervals ([issue](https://github.com/krisk/Fuse/issues/735)), the changes made account for that.