### PR TITLE
Fix: Engine e2e test pipeline hangup

### DIFF
--- a/src/engine/e2e_tests/globalTeardown.js
+++ b/src/engine/e2e_tests/globalTeardown.js
@@ -3,7 +3,7 @@ const path = require('path');
 
 module.exports = () => {
   return new Promise((resolve) => {
-    global.__engineProcess__.on('close', () => {
+    global.__engineProcess__.on('exit', () => {
       resolve();
     });
     global.__engineProcess__.kill();


### PR DESCRIPTION
## Summary

- should fix the engine e2e tests never finishing

## Details

The function that tears down the engine started for the engine e2e tests would wait for the `close` event on the engine process after executing its kill function. This event does not exist so the tearDown function never resolves.
Changed `close` to `exit`
