### PR TITLE
shallow copy of user is stored in token

### DIFF
--- a/src/management-system-v2/app/api/auth/[...nextauth]/auth-options.ts
+++ b/src/management-system-v2/app/api/auth/[...nextauth]/auth-options.ts
@@ -10,13 +10,16 @@ export const nextAuthOptions: AuthOptions = {
   providers: [],
   callbacks: {
     async jwt({ token, user: _user, trigger, account }) {
-      const user = _user as User;
+      if (trigger === 'signIn') token.csrfToken = randomUUID();
 
-      if (user) {
+      if (_user) {
+        token.user = { ..._user } as User;
         const provider = account?.provider ?? 'none';
-        const nameSpacedId = `${provider}:${user.id}`;
-        user.id = nameSpacedId;
+        const nameSpacedId = `${provider}:${_user.id}`;
+        token.user.id = nameSpacedId;
       }
+
+      const user = token.user;
 
       if (
         process.env.NODE_ENV === 'development' &&
@@ -46,8 +49,6 @@ export const nextAuthOptions: AuthOptions = {
           });
       }
 
-      if (trigger === 'signIn') token.csrfToken = randomUUID();
-      if (user) token.user = user as User;
       return token;
     },
     session(args) {


### PR DESCRIPTION
## Summary

The jwt handler in nextAuth modifies the id of a user, to namespace it to the oauth provider, by prefixing it with `<provider>:<id>`. This change modified an internal user object of nextauth, which was stored and reused when the account logged in again. This resulted in the prefix being added multiple times. 