### PR TITLE
ms2/ icon view: ctl key selection

### DIFF
--- a/src/management-system-v2/components/item-icon-view.tsx
+++ b/src/management-system-v2/components/item-icon-view.tsx
@@ -72,7 +72,7 @@ const ItemIconViewProps = <T extends { id: string }>({
     elementSelection &&
     ((event, item) => {
       if (event.ctrlKey) {
-        if (elementSelection.selectedElements.some(({ id }) => id !== item.id)) {
+        if (!elementSelection.selectedElements.find(({ id }) => id === item.id)) {
           elementSelection.setSelectionElements((prev) => [...prev, item]);
         } else {
           elementSelection.setSelectionElements((prev) => prev.filter(({ id }) => id !== item.id));


### PR DESCRIPTION
## Summary

ctl-click selection was faulty, instead of checking if the element wasn't in the selection I was checking if at least one element is different.
This would lead the code to believe that the element isn't in the current selection if there is at least one different item in the selection.