### PR TITLE
fix(ms2): wrong import

### DIFF
--- a/src/management-system-v2/lib/authorization/caslRules.ts
+++ b/src/management-system-v2/lib/authorization/caslRules.ts
@@ -1,5 +1,5 @@
 import { SHARE_TYPE, sharedWitOrByhUser } from './shares';
-import { packRules } from '@casl/ability-v6/extra';
+import { packRules } from '@casl/ability/extra';
 import {
   AbilityRule,
   CaslAbility,


### PR DESCRIPTION
The package was importing a dependency that was installed by the old-ms
