### PR TITLE
Ms2/context menu

### DIFF
--- a/src/management-system-v2/components/processes/context-menu.tsx
+++ b/src/management-system-v2/components/processes/context-menu.tsx
@@ -121,7 +121,8 @@ const ConextMenuArea: FC<
       });
 
     if (
-      selectedContextMenuItems.some(({ id }) => id === folder.parentId) &&
+      folder.parentId !== null &&
+      !selectedContextMenuItems.some(({ id }) => id === folder.parentId) &&
       canDeleteItems(selectedContextMenuItems, 'update', ability)
     )
       children.push({


### PR DESCRIPTION
## Summary

- Added options to context-menu in processes: open, open in new tab and copy link
- Fixed when move to parent option is shown in processes in context menu
