### PR TITLE
Added edge-case check for usercontrols

### DIFF
--- a/src/management-system-v2/lib/controls-store.ts
+++ b/src/management-system-v2/lib/controls-store.ts
@@ -21,6 +21,16 @@ type RegisteredCallback = {
   [key: string]: Array<[boolean, (event: any) => void, UUID]>;
 };
 
+const getDefaultCallbacks = () => {
+  return {
+    '1': [],
+    '2': [],
+    '3': [],
+    '4': [],
+    '5': [],
+  };
+};
+
 type RegisteredCallbacks = Record<string, RegisteredCallback>;
 
 type StoreControlsInterface = Record<string, RegisteredCallbacks>;
@@ -57,26 +67,14 @@ export const useControlStore = create<ControlsStore>()(
           state.areas.push(area);
           state.controls[area] = {};
           actions.forEach((action) => {
-            state.controls[area][action] = {
-              '1': [],
-              '2': [],
-              '3': [],
-              '4': [],
-              '5': [],
-            };
+            state.controls[area][action] = getDefaultCallbacks();
           });
         } else {
           /* If already registered, only overwrite not existing actions with default*/
           let alreadrRegisteredActions = get().controls[area];
           actions.forEach((action) => {
             if (!alreadrRegisteredActions[action]) {
-              state.controls[area][action] = {
-                '1': [],
-                '2': [],
-                '3': [],
-                '4': [],
-                '5': [],
-              };
+              state.controls[area][action] = getDefaultCallbacks();
             }
           });
         }
@@ -85,10 +83,16 @@ export const useControlStore = create<ControlsStore>()(
     addCallback: ({ id, area, action, callback, priority = 1, blocking = false }) => {
       set((state) => {
         // console.log(`Adding callback to ${area} for ${action} with priority ${priority}`);
+
         // Check that the control-area is registered
         if (!state.areas.includes(area)) {
           console.error(`Control-area ${area} is not registered.`);
           return; /* While this should not be possible anymore, when using the provided hooks, it does not harm to leave this check */
+        }
+
+        /* Edge case: Other callbacks are registered, but the controlarea is not registered, yet */
+        if (!state.controls[area][action]) {
+          state.controls[area][action] = getDefaultCallbacks();
         }
 
         /* Check for duplicates */


### PR DESCRIPTION
<!--
  Thank you for your contribution to this project!

  Please provide the following information about your changes,
  in order for us to approve and merge your proposal as quickly as possible.
-->

## Summary
- Closes #286
- Added check for edge case when adding shortcut / control callbacks


<!--
  Please give a concise description of your proposal.
-->

## Details
Control areas and respective callbacks can be added in arbitrary order. When adding callbacks to an area that was not registered (yet), the respective controlarea will be created. However, when callbacks are added at different points / times a racing condition occurred, where only one instance created such a controlarea. Now the first creates such entries, while whichever comes next, only updates it.

<!--
  A list of changes and any additional information that could be relevant for this pull request.

Example:
- Function foobar() now takes an optional third parameter
- The version of dependency dep-js was changed to 1.3.7
-->
