### PR TITLE
Fix favourites process list

### DIFF
--- a/src/management-system-v2/components/favouriteStar.tsx
+++ b/src/management-system-v2/components/favouriteStar.tsx
@@ -3,12 +3,12 @@ import { FC } from 'react';
 import { StarOutlined } from '@ant-design/icons';
 import useFavouriteProcesses from '@/lib/useFavouriteProcesses';
 
-type StartType = {
+type StarType = {
   id: string;
-  hovered?: boolean;
+  className?: string;
 };
 
-const FavouriteStar: FC<StartType> = ({ id, hovered }) => {
+const FavouriteStar: FC<StarType> = ({ id, className }) => {
   const { favourites: favs, updateFavouriteProcesses: updateFavs } = useFavouriteProcesses();
 
   return (
@@ -16,12 +16,14 @@ const FavouriteStar: FC<StartType> = ({ id, hovered }) => {
       <StarOutlined
         style={{
           color: favs?.includes(id) ? '#FFD700' : undefined,
-          opacity: hovered || favs?.includes(id) ? 1 : 0,
         }}
         onClick={(e) => {
           e.stopPropagation();
           updateFavs(id);
+          console.log(id);
+          console.log(favs);
         }}
+        className={favs?.includes(id) ? undefined : className}
       />
     </>
   );

--- a/src/management-system-v2/components/process-list.tsx
+++ b/src/management-system-v2/components/process-list.tsx
@@ -26,6 +26,8 @@ import { DraggableElementGenerator } from './processes/draggable-element';
 import Link from 'next/link';
 import { useColumnWidth } from '@/lib/useColumnWidth';
 import SpaceLink from './space-link';
+import useFavouriteProcesses from '@/lib/useFavouriteProcesses';
+import FavouriteStar from './favouriteStar';
 
 const DraggableRow = DraggableElementGenerator('tr', 'data-row-key');
 
@@ -59,10 +61,9 @@ const ProcessList: FC<ProcessListProps> = ({
   const selectedColumns = useUserPreferences.use['columns-in-table-view-process-list']();
 
   const addPreferences = useUserPreferences.use.addPreferences();
+  const { favourites: favProcesses } = useFavouriteProcesses();
 
   const setContextMenuItem = contextMenuStore((store) => store.setSelected);
-
-  const favourites = [0];
 
   const showMobileMetaData = () => {
     setShowMobileMetaData(true);
@@ -132,12 +133,13 @@ const ProcessList: FC<ProcessListProps> = ({
       key: 'Favorites',
       width: '40px',
       render: (id, _, index) =>
-        id !== folder.parentId && (
-          <StarOutlined
-            style={{ color: favourites?.includes(index) ? '#FFD700' : undefined }}
-            className={styles.HoverableTableCell}
-          />
-        ),
+        id !== folder.parentId && <FavouriteStar id={id} className={styles.HoverableTableCell} />,
+      sorter: (a, b) =>
+        favProcesses?.includes(a.id) && favProcesses?.includes(b.id)
+          ? 0
+          : favProcesses?.includes(a.id)
+            ? -1
+            : 1 /* Should be wrapped in folderAwareSort from #283 once it's merged */,
     },
     {
       title: 'Name',

--- a/src/management-system-v2/components/process-list.tsx
+++ b/src/management-system-v2/components/process-list.tsx
@@ -139,7 +139,7 @@ const ProcessList: FC<ProcessListProps> = ({
           ? 0
           : favProcesses?.includes(a.id)
             ? -1
-            : 1 /* Should be wrapped in folderAwareSort from #283 once it's merged */,
+            : 1 /* TODO: Should be wrapped in folderAwareSort from #283 once it's merged */,
     },
     {
       title: 'Name',


### PR DESCRIPTION
<!--
  Thank you for your contribution to this project!

  Please provide the following information about your changes,
  in order for us to approve and merge your proposal as quickly as possible.
-->

## Summary
The 'Star'-ing of processes used to work, however, the latest refactor of the process list seems to have reverted it back to the nonfunctional display. 
It now works again.

<!--
  Please give a concise description of your proposal.
-->

## Details

- [ ] TODO: Once #250 is merged, the sorter function of the Favourite-Column needs to be wrapped with the Folder-Aware wrapper.

<!--
  A list of changes and any additional information that could be relevant for this pull request.

Example:
- Function foobar() now takes an optional third parameter
- The version of dependency dep-js was changed to 1.3.7
-->
