### PR TITLE
fix(ms2/selection-actions): removed fixed width

### DIFF
--- a/src/management-system-v2/components/selection-actions.module.scss
+++ b/src/management-system-v2/components/selection-actions.module.scss
@@ -7,7 +7,8 @@
   margin-left: 10px;
   align-items: center;
   justify-content: center;
-  width: 160px;
+  text-wrap: nowrap;
+  padding: 0 0.5rem;
 }
 
 .Icons {


### PR DESCRIPTION
## Summary

The fixed with in the component was causing it to be too wide, when there were few elements inside it:
![Screenshot from 2024-06-10 21-10-26](https://github.com/PROCEED-Labs/proceed/assets/5623598/dba5d2f2-c773-4f75-b5db-6b8e3a29073a)


I made the width adapt to the elements inside and added padding:
![image](https://github.com/PROCEED-Labs/proceed/assets/5623598/da23cc89-0f58-4414-b75a-846f3d4f98d0)
