### PR TITLE
Ms2/abilities bug

### DIFF
--- a/src/management-system-v2/app/(dashboard)/[environmentId]/layout.tsx
+++ b/src/management-system-v2/app/(dashboard)/[environmentId]/layout.tsx
@@ -20,6 +20,7 @@ import { enableNewMSExecution } from 'FeatureFlags';
 import { LuBoxes, LuTable2 } from 'react-icons/lu';
 import { spaceURL } from '@/lib/utils';
 import { adminRules } from '@/lib/ability/abilityHelper';
+import { RemoveReadOnly } from '@/lib/typescript-utils';
 
 const DashboardLayout = async ({
   children,
@@ -38,7 +39,7 @@ const DashboardLayout = async ({
   );
 
   const userRules = systemAdmin
-    ? adminRules
+    ? (adminRules as RemoveReadOnly<typeof adminRules>)
     : await getUserRules(userId, activeEnvironment.spaceId);
 
   const layoutMenuItems: MenuProps['items'] = [];

--- a/src/management-system-v2/components/auth.tsx
+++ b/src/management-system-v2/components/auth.tsx
@@ -44,9 +44,9 @@ export const getCurrentEnvironment = cache(
     const isOrganization = activeSpace !== userId;
 
     if (systemAdmin) {
-      const rules = adminRules;
-      if (!isOrganization) rules.push(...packRules<AbilityRule>(globalUserRules));
-      else rules.push(...packRules<AbilityRule>(globalOrganizationRules));
+      let rules;
+      if (!isOrganization) rules = adminRules.concat(packRules<AbilityRule>(globalUserRules));
+      else rules = adminRules.concat(packRules<AbilityRule>(globalOrganizationRules));
 
       return {
         ability: new Ability(rules, activeSpace),

--- a/src/management-system-v2/components/auth.tsx
+++ b/src/management-system-v2/components/auth.tsx
@@ -6,9 +6,10 @@ import nextAuthOptions from '@/app/api/auth/[...nextauth]/auth-options';
 import { isMember } from '@/lib/data/legacy/iam/memberships';
 import { getSystemAdminByUserId } from '@/lib/data/legacy/iam/system-admins';
 import Ability, { adminRules } from '@/lib/ability/abilityHelper';
-import { globalOrganizationRules, globalUserRules } from '@/lib/authorization/globalRules';
-import { packRules } from '@casl/ability/extra';
-import { AbilityRule } from '@/lib/ability/caslAbility';
+import {
+  packedGlobalOrganizationRules,
+  packedGlobalUserRules,
+} from '@/lib/authorization/globalRules';
 
 export const getCurrentUser = cache(async () => {
   const session = await getServerSession(nextAuthOptions);
@@ -45,8 +46,8 @@ export const getCurrentEnvironment = cache(
 
     if (systemAdmin) {
       let rules;
-      if (!isOrganization) rules = adminRules.concat(packRules<AbilityRule>(globalUserRules));
-      else rules = adminRules.concat(packRules<AbilityRule>(globalOrganizationRules));
+      if (isOrganization) rules = adminRules.concat(packedGlobalOrganizationRules);
+      else rules = adminRules.concat(packedGlobalUserRules);
 
       return {
         ability: new Ability(rules, activeSpace),

--- a/src/management-system-v2/lib/ability/abilityHelper.ts
+++ b/src/management-system-v2/lib/ability/abilityHelper.ts
@@ -82,9 +82,11 @@ export class UnauthorizedError extends Error {
   }
 }
 
-export const adminRules = packRules([
-  {
-    subject: 'All',
-    action: 'admin',
-  },
-] as AbilityRule[]);
+export const adminRules = Object.freeze(
+  packRules([
+    {
+      subject: 'All',
+      action: 'admin',
+    },
+  ] as AbilityRule[]),
+);

--- a/src/management-system-v2/lib/authorization/globalRules.ts
+++ b/src/management-system-v2/lib/authorization/globalRules.ts
@@ -1,13 +1,18 @@
 // The rules in this file will be applied to all abilities
 // By default everything is allowed and these rules restrict access
 
+import { packRules } from '@casl/ability/extra';
 import { AbilityRule, resourceAction } from '../ability/caslAbility';
+import { RemoveReadOnly } from '../typescript-utils';
 
 type SystemRules = (AbilityRule & { inverted: true })[];
 
 //TODO read global rules from config file
 
 export const globalOrganizationRules = Object.freeze([] satisfies SystemRules);
+export const packedGlobalOrganizationRules = packRules<AbilityRule>(
+  globalOrganizationRules as RemoveReadOnly<typeof globalOrganizationRules>,
+);
 
 export const globalUserRules = Object.freeze([
   {
@@ -16,3 +21,6 @@ export const globalUserRules = Object.freeze([
     subject: ['Role', 'RoleMapping', 'Machine', 'Execution', 'EnvConfig', 'User', 'Environment'],
   },
 ] satisfies SystemRules);
+export const packedGlobalUserRules = packRules<AbilityRule>(
+  globalUserRules as RemoveReadOnly<typeof globalUserRules>,
+);

--- a/src/management-system-v2/lib/authorization/globalRules.ts
+++ b/src/management-system-v2/lib/authorization/globalRules.ts
@@ -7,12 +7,12 @@ type SystemRules = (AbilityRule & { inverted: true })[];
 
 //TODO read global rules from config file
 
-export const globalOrganizationRules = [] satisfies SystemRules;
+export const globalOrganizationRules = Object.freeze([] satisfies SystemRules);
 
-export const globalUserRules = [
+export const globalUserRules = Object.freeze([
   {
     inverted: true,
     action: [...resourceAction],
     subject: ['Role', 'RoleMapping', 'Machine', 'Execution', 'EnvConfig', 'User', 'Environment'],
   },
-] satisfies SystemRules;
+] satisfies SystemRules);


### PR DESCRIPTION
## Summary

A fixed array with the admin permissions was being modified. Such that when an admin user visited a personal space, the personal space restrictions were added to the fixed adminPermissions array. When the admin then visited an organization, the personal space restrictions were also being applied because they were in the adminPermissions array.

I also froze some arrays that are supposed to be fixed, so that this doesn't happen again.
