### PR TITLE
feat(ms2/folder-breadcrumbs): use next link

### DIFF
--- a/src/management-system-v2/app/(dashboard)/[environmentId]/processes/folder/[folderId]/page.tsx
+++ b/src/management-system-v2/app/(dashboard)/[environmentId]/processes/folder/[folderId]/page.tsx
@@ -47,18 +47,17 @@ const ProcessesPage = async ({
   })) satisfies ListItem[];
 
   const pathToFolder: ComponentProps<typeof EllipsisBreadcrumb>['items'] = [];
-  let currentFolder = folder;
-  while (currentFolder.parentId) {
+  let currentFolder: Folder | null = folder;
+  do {
     pathToFolder.push({
-      title: currentFolder.name,
-      href: spaceURL(activeEnvironment, `/processes/folder/${currentFolder.id}`),
+      title: (
+        <Link href={spaceURL(activeEnvironment, `/processes/folder/${currentFolder.id}`)}>
+          {currentFolder.parentId ? currentFolder.name : 'Processes'}
+        </Link>
+      ),
     });
-    currentFolder = getFolderById(currentFolder.parentId);
-  }
-  pathToFolder.push({
-    title: 'Processes',
-    href: spaceURL(activeEnvironment, `/processes/folder/${rootFolder.id}`),
-  });
+    currentFolder = currentFolder.parentId ? getFolderById(currentFolder.parentId) : null;
+  } while (currentFolder);
   pathToFolder.reverse();
 
   return (


### PR DESCRIPTION
## Summary

Use next link for breadcrumbs instead of regular anchor tags to avoid refreshing the whole page
