### PR TITLE
feat(ms2/create-organization): back button

### DIFF
--- a/src/management-system-v2/app/create-organization/client-page.tsx
+++ b/src/management-system-v2/app/create-organization/client-page.tsx
@@ -15,6 +15,7 @@ import { addOrganizationEnvironment } from '@/lib/data/environments';
 import { useRouter } from 'next/navigation';
 import { type createInactiveEnvironment } from './page';
 import Link from 'next/link';
+import { ArrowLeftOutlined } from '@ant-design/icons';
 
 const getCountryOption = (country: CountryCode) => {
   const imageUrl = ['SJ', 'AC', 'BQ', 'GF', 'IO', 'GP', 'XK'].includes(country)
@@ -114,6 +115,11 @@ const CreateOrganizationPage = ({
       }}
     >
       <Content
+        headerLeft={
+          <Button type="primary" icon={<ArrowLeftOutlined />} onClick={router.back}>
+            Back
+          </Button>
+        }
         headerCenter={
           breakpoint.xs ? undefined : (
             <Link


### PR DESCRIPTION
## Summary

Back button on create organization page. This button uses `router.back` which could also go back to a site that isn't proceed.

![image](https://github.com/user-attachments/assets/221dcc7d-2833-41bc-91bf-891bdd0f0170)

