### PR TITLE
fix(ms2/header-actions): anchor fills parent

### DIFF
--- a/src/management-system-v2/components/header-actions.tsx
+++ b/src/management-system-v2/components/header-actions.tsx
@@ -86,6 +86,7 @@ const HeaderActions: FC = () => {
                 label: (
                   <Tooltip title={name} placement="left">
                     <Link
+                      style={{ display: 'block' }}
                       href={spaceURL(
                         { spaceId: space?.id ?? '', isOrganization: space?.organization ?? false },
                         `/processes`,


### PR DESCRIPTION
## Fixed Bug

The anchor tag in the space select didn't take up the hole width of the select option.
This resulted in some clicks changing the state of the select, but not directing the user to the desired space.
