### PR TITLE
feat(engine): types for modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,7 @@ dataEval.json
 
 # Ignore generated credentials from google-github-actions/auth
 gha-creds-*.json
+
+# Turborepo
+.turbo
+@types

--- a/jest.config.js
+++ b/jest.config.js
@@ -5,6 +5,7 @@ const ignorePaths = [
   '<rootDir>/.yarn-cache',
   '<rootDir>/src/management-system',
   '<rootDir>/src/management-system-v2/.next/',
+  '@types',
 ];
 
 let projects = [

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "private": true,
+  "name": "PROCEED",
   "workspaces": {
     "packages": [
       "src/engine/universal/*",
@@ -44,6 +45,7 @@
     "dev-web": "yarn build && cd src/engine/native/web/server && yarn serve",
     "dev-many": "node src/engine/e2e_tests/process/deployment/startEngines.js",
     "build": "cd src/engine/native/node && webpack --config webpack.native.config.js && webpack --config webpack.injector.config.ts && ts-node ./build-injector.js && cd ../../universal && NODE_OPTIONS=--openssl-legacy-provider webpack --config webpack.universal.config.js",
+    "build-engine-types": "turbo build --filter \"./src/engine/**/\"",
     "build-ms": "cd src/management-system-v2 && yarn build",
     "build-web": "yarn build && cd src/engine/native/web/server && yarn build",
     "docker:run": "docker container run --publish 33029:33029 --rm --network host --detach --name engine proceed/engine:latest",
@@ -112,6 +114,7 @@
     "webpack-dev-server": "^3.2.1"
   },
   "dependencies": {
-    "react-resizable": "^3.0.5"
+    "react-resizable": "^3.0.5",
+    "turbo": "2.1.1"
   }
 }

--- a/src/config-server/package.json
+++ b/src/config-server/package.json
@@ -26,5 +26,8 @@
     "express": "^4.17.1",
     "request": "^2.88.0"
   },
-  "devDependencies": {}
+  "scripts": {
+    "build": "tsc",
+    "dev": "tsc --watch"
+  }
 }

--- a/src/config-server/tsconfig.json
+++ b/src/config-server/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.json",
+  "include": ["./**/*"],
+  "compilerOptions": {
+    "declarationDir": "./@types",
+    "emitDeclarationOnly": true
+  }
+}

--- a/src/engine/native/espruino/package.json
+++ b/src/engine/native/espruino/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "description": "",
   "main": "espruino.js",
+  "types": "./@types/espruino.d.ts",
   "scripts": {
     "dev": "nodemon src/dev.js --watch src",
     "build:pixl": "uglifyjs src/pixl.js --compress --mangle -o ./build/bundle.js ",
@@ -34,5 +35,9 @@
     "webpack-bundle-analyzer": "^3.3.2",
     "webpack-cli": "^3.3.5"
   },
-  "dependencies": {}
+  "dependencies": {},
+  "scripts": {
+    "build": "tsc",
+    "dev": "tsc --watch"
+  }
 }

--- a/src/engine/native/espruino/tsconfig.json
+++ b/src/engine/native/espruino/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../../../tsconfig.json",
+  "include": ["./**/*"],
+  "compilerOptions": {
+    "declarationDir": "./@types",
+    "emitDeclarationOnly": true
+  }
+}

--- a/src/engine/native/node/native-capabilities/package.json
+++ b/src/engine/native/node/native-capabilities/package.json
@@ -2,10 +2,15 @@
   "name": "@proceed/native-capabilities",
   "version": "1.0.0",
   "description": "Native module that implements the `capability` command.",
-  "main": "src/index.js",
+  "main": "./src/index.js",
+  "types": "./@types/src/index.d.ts",
   "author": "PROCEED Project",
   "license": "MIT",
   "dependencies": {
     "@proceed/native-module": "^1.0.0"
+  },
+  "scripts": {
+    "build": "tsc",
+    "dev": "tsc --watch"
   }
 }

--- a/src/engine/native/node/native-capabilities/tsconfig.json
+++ b/src/engine/native/node/native-capabilities/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../../../../tsconfig.json",
+  "include": ["./src"],
+  "compilerOptions": {
+    "declarationDir": "./@types",
+    "emitDeclarationOnly": true
+  }
+}

--- a/src/engine/native/node/native-config/package.json
+++ b/src/engine/native/node/native-config/package.json
@@ -2,10 +2,15 @@
   "name": "@proceed/native-config",
   "version": "1.0.0",
   "description": "Native module that implements the `config` command.",
-  "main": "src/index.js",
+  "main": "./src/index.js",
+  "types": "./@types/src/index.d.ts",
   "author": "PROCEED Project",
   "license": "MIT",
   "dependencies": {
     "@proceed/native-module": "^1.0.0"
+  },
+  "scripts": {
+    "build": "tsc",
+    "dev": "tsc --watch"
   }
 }

--- a/src/engine/native/node/native-config/tsconfig.json
+++ b/src/engine/native/node/native-config/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../../../../tsconfig.json",
+  "include": ["./src", "./src/config_default.json"],
+  "compilerOptions": {
+    "declarationDir": "./@types",
+    "emitDeclarationOnly": true
+  }
+}

--- a/src/engine/native/node/native-console/package.json
+++ b/src/engine/native/node/native-console/package.json
@@ -2,10 +2,15 @@
   "name": "@proceed/native-console",
   "version": "1.0.0",
   "description": "Native module that implements the `console_log` command.",
-  "main": "src/index.js",
+  "main": "./src/index.js",
+  "types": "./@types/src/index.d.ts",
   "author": "PROCEED Project",
   "license": "MIT",
   "dependencies": {
     "@proceed/native-module": "^1.0.0"
+  },
+  "scripts": {
+    "build": "tsc",
+    "dev": "tsc --watch"
   }
 }

--- a/src/engine/native/node/native-console/tsconfig.json
+++ b/src/engine/native/node/native-console/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../../../../tsconfig.json",
+  "include": ["./**/*"],
+  "compilerOptions": {
+    "declarationDir": "./@types",
+    "emitDeclarationOnly": true
+  }
+}

--- a/src/engine/native/node/native-express/package.json
+++ b/src/engine/native/node/native-express/package.json
@@ -2,7 +2,8 @@
   "name": "@proceed/native-express",
   "version": "1.0.0",
   "description": "Native module that implements the `serve` and `respond` commands.",
-  "main": "src/index.js",
+  "main": "./src/index.js",
+  "types": "./@types/src/index.d.ts",
   "author": "PROCEED Project",
   "license": "MIT",
   "dependencies": {
@@ -12,5 +13,9 @@
     "busboy": "^0.3.1",
     "body-parser": "^1.19.0",
     "stoppable": "^1.1.0"
+  },
+  "scripts": {
+    "build": "tsc",
+    "dev": "tsc --watch"
   }
 }

--- a/src/engine/native/node/native-express/tsconfig.json
+++ b/src/engine/native/node/native-express/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../../../../tsconfig.json",
+  "include": ["./**/*"],
+  "compilerOptions": {
+    "declarationDir": "./@types",
+    "emitDeclarationOnly": true
+  }
+}

--- a/src/engine/native/node/native-fs/package.json
+++ b/src/engine/native/node/native-fs/package.json
@@ -2,7 +2,8 @@
   "name": "@proceed/native-fs",
   "version": "1.0.0",
   "description": "Native module that implements the `read` and `write`commands.",
-  "main": "src/index.js",
+  "main": "./src/index.js",
+  "types": "./@types/src/index.d.ts",
   "author": "PROCEED Project",
   "license": "MIT",
   "dependencies": {
@@ -11,5 +12,9 @@
   },
   "devDependencies": {
     "@types/jest": "^25.1.3"
+  },
+  "scripts": {
+    "build": "tsc",
+    "dev": "tsc --watch"
   }
 }

--- a/src/engine/native/node/native-fs/tsconfig.json
+++ b/src/engine/native/node/native-fs/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../../../../tsconfig.json",
+  "include": ["./src"],
+  "compilerOptions": {
+    "declarationDir": "./@types",
+    "emitDeclarationOnly": true
+  }
+}

--- a/src/engine/native/node/native-koa/package.json
+++ b/src/engine/native/node/native-koa/package.json
@@ -2,7 +2,8 @@
   "name": "@proceed/native-koa",
   "version": "1.0.0",
   "description": "Native module that implements the `serve` and `respond` commands.",
-  "main": "src/index.js",
+  "main": "./src/index.js",
+  "types": "./@types/src/index.d.ts",
   "author": "PROCEED Project",
   "license": "MIT",
   "dependencies": {
@@ -13,5 +14,9 @@
     "koa-bodyparser": "^4.2.1",
     "busboy": "0.3.1",
     "stoppable": "^1.1.0"
+  },
+  "scripts": {
+    "build": "tsc",
+    "dev": "tsc --watch"
   }
 }

--- a/src/engine/native/node/native-koa/tsconfig.json
+++ b/src/engine/native/node/native-koa/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../../../../tsconfig.json",
+  "include": ["./**/*"],
+  "compilerOptions": {
+    "declarationDir": "./@types",
+    "emitDeclarationOnly": true
+  }
+}

--- a/src/engine/native/node/native-machine/package.json
+++ b/src/engine/native/node/native-machine/package.json
@@ -2,7 +2,8 @@
   "name": "@proceed/native-machine",
   "version": "1.0.0",
   "description": "Native module that implements the `read_device_info` command.",
-  "main": "src/index.js",
+  "main": "./src/index.js",
+  "types": "./@types/src/index.d.ts",
   "author": "PROCEED Project",
   "license": "MIT",
   "dependencies": {
@@ -10,5 +11,9 @@
     "machine-uuid": "^1.2.0",
     "systeminformation": "^4.30.1",
     "ping": "^0.3.0"
+  },
+  "scripts": {
+    "build": "tsc",
+    "dev": "tsc --watch"
   }
 }

--- a/src/engine/native/node/native-machine/tsconfig.json
+++ b/src/engine/native/node/native-machine/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../../../../tsconfig.json",
+  "include": ["./**/*"],
+  "compilerOptions": {
+    "declarationDir": "./@types",
+    "emitDeclarationOnly": true
+  }
+}

--- a/src/engine/native/node/native-mdns/package.json
+++ b/src/engine/native/node/native-mdns/package.json
@@ -2,12 +2,17 @@
   "name": "@proceed/native-mdns",
   "version": "1.0.0",
   "description": "Native module that implements the `discover` and `publish` commands.",
-  "main": "src/index.js",
+  "main": "./src/index.js",
+  "types": "./@types/src/index.d.ts",
   "author": "PROCEED Project",
   "license": "MIT",
   "dependencies": {
     "@proceed/native-module": "^1.0.0",
     "bonjour-service": "1.1.1",
     "@darkobits/adeiu": "0.3.1"
+  },
+  "scripts": {
+    "build": "tsc",
+    "dev": "tsc --watch"
   }
 }

--- a/src/engine/native/node/native-mdns/tsconfig.json
+++ b/src/engine/native/node/native-mdns/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../../../../tsconfig.json",
+  "include": ["./**/*"],
+  "compilerOptions": {
+    "declarationDir": "./@types",
+    "emitDeclarationOnly": true
+  }
+}

--- a/src/engine/native/node/native-module/package.json
+++ b/src/engine/native/node/native-module/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "description": "Native module class for use in the @proceed/native part",
   "main": "src/index.js",
+  "types": "./@types/src/index.d.ts",
   "author": "PROCEED Project",
   "license": "MIT"
 }

--- a/src/engine/native/node/native-module/tsconfig.json
+++ b/src/engine/native/node/native-module/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../../../../tsconfig.json",
+  "include": ["./**/*"],
+  "compilerOptions": {
+    "declarationDir": "./@types",
+    "emitDeclarationOnly": true
+  }
+}

--- a/src/engine/native/node/native-mqtt/package.json
+++ b/src/engine/native/node/native-mqtt/package.json
@@ -2,11 +2,16 @@
   "name": "@proceed/native-mqtt",
   "version": "1.0.0",
   "description": "Native module that implements the `publish`, `subscribe` and 'unsubscribe' commands.",
-  "main": "src/index.js",
+  "main": "./src/index.js",
+  "types": "./@types/src/index.d.ts",
   "author": "PROCEED Project",
   "license": "MIT",
   "dependencies": {
     "@proceed/native-module": "^1.0.0",
     "async-mqtt": "^2.6.3"
+  },
+  "scripts": {
+    "build": "tsc",
+    "dev": "tsc --watch"
   }
 }

--- a/src/engine/native/node/native-mqtt/tsconfig.json
+++ b/src/engine/native/node/native-mqtt/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../../../../tsconfig.json",
+  "include": ["./**/*"],
+  "compilerOptions": {
+    "declarationDir": "./@types",
+    "emitDeclarationOnly": true
+  }
+}

--- a/src/engine/native/node/native-vm2/package.json
+++ b/src/engine/native/node/native-vm2/package.json
@@ -2,12 +2,20 @@
   "name": "@proceed/native-vm2",
   "version": "1.0.0",
   "description": "Native module that provides a vm2 script executor for the engine.",
-  "main": "src/index.js",
+  "main": "./src/index.js",
+  "types": "./@types/src/index.d.ts",
   "author": "PROCEED Project",
   "license": "MIT",
   "dependencies": {
     "@proceed/native-module": "^1.0.0",
     "vm2": "^3.8.4",
     "neo-bpmn-engine": "^8.2.2"
+  },
+  "devDependencies": {
+    "@proceed/core": "^1.0.0"
+  },
+  "scripts": {
+    "build": "tsc",
+    "dev": "tsc --watch"
   }
 }

--- a/src/engine/native/node/native-vm2/tsconfig.json
+++ b/src/engine/native/node/native-vm2/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../../../../tsconfig.json",
+  "include": ["./**/*"],
+  "compilerOptions": {
+    "declarationDir": "./@types",
+    "emitDeclarationOnly": true
+  }
+}

--- a/src/engine/native/node/native/package.json
+++ b/src/engine/native/node/native/package.json
@@ -2,11 +2,16 @@
   "name": "@proceed/native",
   "version": "1.0.0",
   "description": "Native part for the PROCEED engine implemented in NodeJS.",
-  "main": "src/index.js",
+  "main": "./src/index.js",
+  "types": "./@types/src/index.d.ts",
   "author": "PROCEED Project",
   "license": "MIT",
   "dependencies": {
     "@proceed/core": "^1.0.0",
     "is-valid-path": "^0.1.1"
+  },
+  "scripts": {
+    "build": "tsc",
+    "dev": "tsc --watch"
   }
 }

--- a/src/engine/native/node/native/tsconfig.json
+++ b/src/engine/native/node/native/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../../../../tsconfig.json",
+  "include": ["./**/*"],
+  "compilerOptions": {
+    "declarationDir": "./@types",
+    "emitDeclarationOnly": true
+  }
+}

--- a/src/engine/native/node/package.json
+++ b/src/engine/native/node/package.json
@@ -21,8 +21,13 @@
     "url": "https://github.com/PROCEED-Labs/proceed.git",
     "directory": "src/management-system/"
   },
-  "main": "index.js",
+  "main": "./index.js",
+  "types": "./@types/index.d.ts",
   "dependencies": {
     "vm2": "3.9.2"
+  },
+  "scripts": {
+    "build": "tsc",
+    "dev": "tsc --watch"
   }
 }

--- a/src/engine/native/node/tsconfig.json
+++ b/src/engine/native/node/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../../../tsconfig.json",
+  "include": ["./**/*"],
+  "compilerOptions": {
+    "declarationDir": "./@types",
+    "emitDeclarationOnly": true
+  }
+}

--- a/src/engine/native/node/webpack.injector.config.ts
+++ b/src/engine/native/node/webpack.injector.config.ts
@@ -28,7 +28,16 @@ module.exports = {
     rules: [
       {
         test: /\.tsx?$/,
-        use: 'ts-loader',
+        use: [
+          {
+            loader: 'ts-loader',
+            options: {
+              compilerOptions: {
+                emitDeclarationOnly: false,
+              },
+            },
+          },
+        ],
         exclude: /node_modules/,
       },
     ],

--- a/src/engine/native/node/webpack.native.config.js
+++ b/src/engine/native/node/webpack.native.config.js
@@ -15,7 +15,16 @@ module.exports = {
     rules: [
       {
         test: /\.tsx?$/,
-        use: 'ts-loader',
+        use: [
+          {
+            loader: 'ts-loader',
+            options: {
+              compilerOptions: {
+                emitDeclarationOnly: false,
+              },
+            },
+          },
+        ],
         exclude: /node_modules/,
       },
     ],

--- a/src/engine/native/web/server/package.json
+++ b/src/engine/native/web/server/package.json
@@ -2,12 +2,14 @@
   "name": "web",
   "version": "0.0.1",
   "description": "Native part of PROCEED engine for web browser.",
-  "main": "index.js",
+  "main": "./src/index.js",
+  "types": "./@types/src/index.d.ts",
   "author": "PROCEED Project",
   "license": "MIT",
   "scripts": {
-    "build": "webpack --config webpack.config.js",
-    "serve": "webpack --config webpack.config.js && node server.js"
+    "build": "webpack --config webpack.config.js && tsc",
+    "serve": "webpack --config webpack.config.js && node server.js",
+    "dev": "tsc --watch"
   },
   "dependencies": {
     "@proceed/native-capabilities": "^1.0.0",

--- a/src/engine/native/web/server/tsconfig.json
+++ b/src/engine/native/web/server/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../../../../tsconfig.json",
+  "include": ["src", "**/*.json"],
+  "compilerOptions": {
+    "declarationDir": "./@types",
+    "emitDeclarationOnly": true
+  }
+}

--- a/src/engine/universal/capabilities/package.json
+++ b/src/engine/universal/capabilities/package.json
@@ -2,12 +2,15 @@
   "name": "@proceed/capabilities",
   "version": "1.0.0",
   "description": "",
-  "main": "module.js",
+  "main": "./module.js",
+  "types": "./@types/module.d.ts",
   "author": "PROCEED Project",
   "license": "MIT",
   "scripts": {
     "test": "jest",
-    "lint": "eslint ."
+    "lint": "eslint .",
+    "build": "tsc",
+    "dev": "tsc --watch"
   },
   "dependencies": {
     "jsonld": "^1.6.2",

--- a/src/engine/universal/capabilities/tsconfig.json
+++ b/src/engine/universal/capabilities/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../../../tsconfig.json",
+  "include": ["./**/*"],
+  "compilerOptions": {
+    "declarationDir": "./@types",
+    "emitDeclarationOnly": true
+  }
+}

--- a/src/engine/universal/core/package.json
+++ b/src/engine/universal/core/package.json
@@ -2,10 +2,13 @@
   "name": "@proceed/core",
   "version": "1.0.0",
   "main": "./src/module.js",
+  "types": "./@types/src/module.d.ts",
   "author": "PROCEED Project",
   "license": "MIT",
   "scripts": {
-    "start": "echo 'Do not start the engine module directly!\nInstead do yarn dev.'"
+    "start": "echo 'Do not start the engine module directly!\nInstead do yarn dev.'",
+    "build": "tsc",
+    "dev": "tsc --watch"
   },
   "dependencies": {
     "@proceed/capabilities": "^1.0.0",

--- a/src/engine/universal/core/tsconfig.json
+++ b/src/engine/universal/core/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../../../tsconfig.json",
+  "include": ["./**/*"],
+  "compilerOptions": {
+    "declarationDir": "./@types",
+    "emitDeclarationOnly": true
+  }
+}

--- a/src/engine/universal/decider/package.json
+++ b/src/engine/universal/decider/package.json
@@ -2,12 +2,15 @@
   "name": "@proceed/decider",
   "version": "1.0.0",
   "description": "This module handles the evaluations of task, process, user and environment constraints",
-  "main": "module.js",
+  "main": "./module.js",
+  "types": "./@types/module.d.ts",
   "author": "PROCEED Project",
   "license": "MIT",
   "scripts": {
     "test": "jest",
-    "lint": "eslint ."
+    "lint": "eslint .",
+    "build": "tsc",
+    "dev": "tsc --watch"
   },
   "dependencies": {
     "@proceed/capabilities": "^1.0.0",

--- a/src/engine/universal/decider/tsconfig.json
+++ b/src/engine/universal/decider/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../../../tsconfig.json",
+  "include": ["./**/*"],
+  "compilerOptions": {
+    "declarationDir": "./@types",
+    "emitDeclarationOnly": true
+  }
+}

--- a/src/engine/universal/distribution/package.json
+++ b/src/engine/universal/distribution/package.json
@@ -3,10 +3,15 @@
   "version": "1.0.0",
   "description": "PROCEED distribution module",
   "main": "src/module.js",
+  "types": "@types/src/module.d.ts",
   "author": "PROCEED Project",
   "license": "MIT",
   "dependencies": {
     "@proceed/system": "^1.0.0",
     "@proceed/machine": "^1.0.0"
+  },
+  "scripts": {
+    "build": "tsc",
+    "dev": "tsc --watch"
   }
 }

--- a/src/engine/universal/distribution/tsconfig.json
+++ b/src/engine/universal/distribution/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../../../tsconfig.json",
+  "compilerOptions": {
+    "declarationDir": "./@types",
+    "emitDeclarationOnly": true
+  },
+  "include": ["./src"]
+}

--- a/src/engine/universal/machine/package.json
+++ b/src/engine/universal/machine/package.json
@@ -2,11 +2,14 @@
   "name": "@proceed/machine",
   "version": "1.0.0",
   "description": "monitoring and configuration",
-  "main": "module.js",
+  "main": "./module.js",
+  "types": "./@types/module.d.ts",
   "author": "PROCEED Project",
   "license": "MIT",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "build": "tsc",
+    "dev": "tsc --watch"
   },
   "dependencies": {
     "@proceed/system": "^1.0.0"

--- a/src/engine/universal/machine/tsconfig.json
+++ b/src/engine/universal/machine/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../../../tsconfig.json",
+  "include": ["**/*", "./configuration/defaultProfile.json"],
+  "compilerOptions": {
+    "declarationDir": "./@types",
+    "emitDeclarationOnly": true
+  }
+}

--- a/src/engine/universal/monitoring/package.json
+++ b/src/engine/universal/monitoring/package.json
@@ -2,10 +2,15 @@
   "name": "@proceed/monitoring",
   "version": "1.0.0",
   "description": "Monitoring module for the PROCEED engine",
-  "main": "src/module.js",
+  "main": "./src/module.js",
+  "types": "./@types/src/module.d.ts",
   "author": "PROCEED Project",
   "license": "MIT",
   "dependencies": {
     "@proceed/system": "^1.0.0"
+  },
+  "scripts": {
+    "build": "tsc",
+    "dev": "tsc --watch"
   }
 }

--- a/src/engine/universal/monitoring/tsconfig.json
+++ b/src/engine/universal/monitoring/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../../../tsconfig.json",
+  "include": ["./src"],
+  "compilerOptions": {
+    "declarationDir": "./@types",
+    "emitDeclarationOnly": true
+  }
+}

--- a/src/engine/universal/system/package.json
+++ b/src/engine/universal/system/package.json
@@ -2,7 +2,8 @@
   "name": "@proceed/system",
   "version": "1.0.0",
   "description": "Proceed system framework.",
-  "main": "src/module.js",
+  "main": "./src/module.js",
+  "types": "./@types/src/module.d.ts",
   "author": "PROCEED Project",
   "license": "MIT",
   "dependencies": {
@@ -11,5 +12,9 @@
   },
   "devDependencies": {
     "@types/uuid": "^9.0.1"
+  },
+  "scripts": {
+    "build": "tsc",
+    "dev": "tsc --watch"
   }
 }

--- a/src/engine/universal/system/tsconfig.json
+++ b/src/engine/universal/system/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../../../tsconfig.json",
+  "include": ["./src"],
+  "compilerOptions": {
+    "declarationDir": "./@types",
+    "emitDeclarationOnly": true
+  }
+}

--- a/src/engine/universal/ui/package.json
+++ b/src/engine/universal/ui/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "description": "User Interface module for the PROCEED engine",
   "main": "./module.js",
+  "types": "./@types/module.d.ts",
   "author": "PROCEED Project",
   "license": "MIT",
   "scripts": {
@@ -11,7 +12,9 @@
     "dev-logging": "cross-env TARGET=logging webpack-dev-server --mode=development --open --config ./src/display-items/webpack.config.js",
     "build-tasklist": "cross-env TARGET=tasklist webpack --config ./src/display-items/webpack.config.js",
     "build-configuration": "cross-env TARGET=configuration webpack --config ./src/display-items/webpack.config.js",
-    "build-logging": "cross-env TARGET=logging webpack --config ./src/display-items/webpack.config.js"
+    "build-logging": "cross-env TARGET=logging webpack --config ./src/display-items/webpack.config.js",
+    "build": "tsc",
+    "dev": "tsc --watch"
   },
   "dependencies": {
     "@proceed/distribution": "^1.0.0",

--- a/src/engine/universal/ui/tsconfig.json
+++ b/src/engine/universal/ui/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../../../tsconfig.json",
+  "include": ["./src"],
+  "compilerOptions": {
+    "declarationDir": "./@types",
+    "emitDeclarationOnly": true
+  }
+}

--- a/src/engine/universal/webpack.universal.config.js
+++ b/src/engine/universal/webpack.universal.config.js
@@ -16,7 +16,16 @@ module.exports = {
     rules: [
       {
         test: /\.tsx?$/,
-        use: 'ts-loader',
+        use: [
+          {
+            loader: 'ts-loader',
+            options: {
+              compilerOptions: {
+                emitDeclarationOnly: false,
+              },
+            },
+          },
+        ],
         exclude: /node_modules/,
       },
     ],

--- a/src/helper-modules/constraint-parser-xml-json/package.json
+++ b/src/helper-modules/constraint-parser-xml-json/package.json
@@ -6,9 +6,12 @@
   "homepage": "https://proceed.snet.tu-berlin.de/",
   "description": "This library transforms the PROCEED process constraints from XML to JSON or vice versa",
   "main": "parser.js",
+  "types": "@types/parser.d.ts",
   "scripts": {
     "test": "jest",
-    "lint": "eslint ."
+    "lint": "eslint .",
+    "build": "tsc",
+    "dev": "tsc --watch"
   },
   "dependencies": {
     "fast-xml-parser": "3.15.0"

--- a/src/helper-modules/constraint-parser-xml-json/tsconfig.json
+++ b/src/helper-modules/constraint-parser-xml-json/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../../tsconfig.json",
+  "include": ["./**/*"],
+  "compilerOptions": {
+    "declarationDir": "./@types",
+    "emitDeclarationOnly": true
+  }
+}

--- a/src/helper-modules/process-performance-calculator/package.json
+++ b/src/helper-modules/process-performance-calculator/package.json
@@ -5,8 +5,11 @@
   "author": "Luisa Wittig",
   "license": "ISC",
   "main": "index.js",
+  "types": "@types/index.d.ts",
   "scripts": {
-    "test": "jest"
+    "test": "jest",
+    "build": "tsc",
+    "dev": "tsc --watch"
   },
   "dependencies": {
     "bpmn-moddle": "^6.0.0"

--- a/src/helper-modules/process-performance-calculator/tsconfig.json
+++ b/src/helper-modules/process-performance-calculator/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../../tsconfig.json",
+  "include": ["./**/*"],
+  "compilerOptions": {
+    "declarationDir": "./@types",
+    "emitDeclarationOnly": true
+  }
+}

--- a/src/management-system/src/backend/server/webpack.server.backend.config.cjs
+++ b/src/management-system/src/backend/server/webpack.server.backend.config.cjs
@@ -17,7 +17,16 @@ module.exports = {
     rules: [
       {
         test: /\.tsx?$/,
-        use: 'ts-loader',
+        use: [
+          {
+            loader: 'ts-loader',
+            options: {
+              compilerOptions: {
+                emitDeclarationOnly: false,
+              },
+            },
+          },
+        ],
         exclude: /node_modules/,
       },
     ],

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,11 +4,18 @@
     "module": "CommonJS",
     "outDir": "dist",
     "allowJs": true,
+    "checkJs": false,
     "moduleResolution": "node",
     "esModuleInterop": true,
     "resolveJsonModule": true,
-    "target": "es6"
+    "target": "es6",
+    "moduleDetection": "force",
+    "declaration": true,
+    "declarationMap": true,
+    "skipLibCheck": true,
+    "strict": false,
+    "noImplicitAny": false
   },
-  "exclude": ["src/management-system-v2/**/*"],
+  "exclude": ["src/management-system-v2/**/*", "**/@types", "node_modules/**/*"],
   "include": ["src/**/*", "tests/**/*"]
 }

--- a/turbo.json
+++ b/turbo.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://turbo.build/schema.json",
+  "tasks": {
+    "build": {
+      "dependsOn": ["^build"],
+      "outputs": ["**/@types"]
+    },
+    "dev": {
+      "persistent": true,
+      "cache": false
+    }
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -21993,6 +21993,48 @@ tunnel@^0.0.6:
   resolved "https://registry.npmjs.org/tunnel/-/tunnel-0.0.6.tgz"
   integrity sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg==
 
+turbo-darwin-64@2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/turbo-darwin-64/-/turbo-darwin-64-2.1.1.tgz#da7fcfa7fb8a94ad5c33e8518e2b898a6525826d"
+  integrity sha512-aYNuJpZlCoi0Htd79fl/2DywpewGKijdXeOfg9KzNuPVKzSMYlAXuAlNGh0MKjiOcyqxQGL7Mq9LFhwA0VpDpQ==
+
+turbo-darwin-arm64@2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/turbo-darwin-arm64/-/turbo-darwin-arm64-2.1.1.tgz#a80fe457ab7baf838f054382d2f3ef03e51a13de"
+  integrity sha512-tifJKD8yHY48rHXPMcM8o1jI/Jk2KCaXiNjTKvvy9Zsim61BZksNVLelIbrRoCGwAN6PUBZO2lGU5iL/TQJ5Pw==
+
+turbo-linux-64@2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/turbo-linux-64/-/turbo-linux-64-2.1.1.tgz#2f97a1078e73e39ebf080985f3bebe53814bafbc"
+  integrity sha512-Js6d/bSQe9DuV9c7ITXYpsU/ADzFHABdz1UIHa7Oqjj9VOEbFeA9WpAn0c+mdJrVD+IXJFbbDZUjN7VYssmtcg==
+
+turbo-linux-arm64@2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/turbo-linux-arm64/-/turbo-linux-arm64-2.1.1.tgz#8527a9bfe189957398ccaf05669ccd924e732d31"
+  integrity sha512-LidzTCq0yvQ+N8w8Qub9FmhQ/mmEIeoqFi7DSupekEV2EjvE9jw/zYc9Pk67X+g7dHVfgOnvVzmrjChdxpFePw==
+
+turbo-windows-64@2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/turbo-windows-64/-/turbo-windows-64-2.1.1.tgz#fe92cfddcf9d37e9649d67573e06072cd0c2c732"
+  integrity sha512-GKc9ZywKwy4xLDhwXd6H07yzl0TB52HjXMrFLyHGhCVnf/w0oq4sLJv2sjbvuarPjsyx4xnCBJ3m3oyL2XmFtA==
+
+turbo-windows-arm64@2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/turbo-windows-arm64/-/turbo-windows-arm64-2.1.1.tgz#5a20090208a337a1dbeaae8e22341ac684620c6d"
+  integrity sha512-oFKkMj11KKUv3xSK9/fhAEQTxLUp1Ol1EOktwc32+SFtEU0uls7kosAz0b+qe8k3pJGEMFdDPdqoEjyJidbxtQ==
+
+turbo@2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/turbo/-/turbo-2.1.1.tgz#b1e71f8fefa9d1c60b77b2fbdebd35702555593d"
+  integrity sha512-u9gUDkmR9dFS8b5kAYqIETK4OnzsS4l2ragJ0+soSMHh6VEeNHjTfSjk1tKxCqLyziCrPogadxP680J+v6yGHw==
+  optionalDependencies:
+    turbo-darwin-64 "2.1.1"
+    turbo-darwin-arm64 "2.1.1"
+    turbo-linux-64 "2.1.1"
+    turbo-linux-arm64 "2.1.1"
+    turbo-windows-64 "2.1.1"
+    turbo-windows-arm64 "2.1.1"
+
 tweetnacl@^0.14.3, tweetnacl@~0.14.0:
   version "0.14.5"
   resolved "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz"


### PR DESCRIPTION
## Summary

Added a build step that adds types for the modules in the engine with `yarn build-engine-types`.
The modules in the monorepo are treated as npm packages, and the typescript language server doesn't perform inference on them, so this build step allows typescript to infer types for the modules the best it can.
In the future, we could also entirely build the packages that use typescript if it's needed with not much effort.

## Details

Every module has a `tsconfig.json` that specifies where the types should go, all the `tsconfig.json` inside the `src/engine` folder extend the `tsconfig.json` in the root folder of the repo.
In order to cache builds I used [turbo](https://turbo.build/repo/docs), which also can generate a dependency graph with `yarn turbo run build --graph=graph.pdf`
