### PR TITLE
User cannot paste no or deleted processes

### DIFF
--- a/src/management-system-v2/components/processes/index.tsx
+++ b/src/management-system-v2/components/processes/index.tsx
@@ -147,7 +147,11 @@ const Processes = ({
   });
 
   useAddControlCallback('process-list', 'esc', () => setSelectedRowElements([]));
-  useAddControlCallback('process-list', 'del', () => setOpenDeleteModal(true));
+  useAddControlCallback('process-list', 'del', () => {
+    setOpenDeleteModal(true);
+    /* Clear copy selection */
+    setCopySelection([]);
+  });
   useAddControlCallback(
     'process-list',
     'copy',
@@ -158,7 +162,7 @@ const Processes = ({
   );
 
   useAddControlCallback('process-list', 'paste', () => {
-    setOpenCopyModal(true);
+    if (copySelection.length) setOpenCopyModal(true);
   });
   useAddControlCallback(
     'process-list',

--- a/src/management-system-v2/components/processes/index.tsx
+++ b/src/management-system-v2/components/processes/index.tsx
@@ -161,9 +161,14 @@ const Processes = ({
     { dependencies: [selectedRowElements] },
   );
 
-  useAddControlCallback('process-list', 'paste', () => {
-    if (copySelection.length) setOpenCopyModal(true);
-  });
+  useAddControlCallback(
+    'process-list',
+    'paste',
+    () => {
+      if (copySelection.length) setOpenCopyModal(true);
+    },
+    { dependencies: [copySelection.length] },
+  );
   useAddControlCallback(
     'process-list',
     'export',


### PR DESCRIPTION
<!--
  Thank you for your contribution to this project!

  Please provide the following information about your changes,
  in order for us to approve and merge your proposal as quickly as possible.
-->

## Summary
- user can no longer copy a process, delete it, and then paste (caused error) -> deleting a process or just pressing del between copy and paste will now clear "copy-memory"
- user can no longer paste without a copy beforehand (caused empty process-creation modal)

<!--
  Please give a concise description of your proposal.
-->

## Details
closes #353 

<!--
  A list of changes and any additional information that could be relevant for this pull request.

Example:
- Function foobar() now takes an optional third parameter
- The version of dependency dep-js was changed to 1.3.7
-->
