### PR TITLE
fix overlapping user controls in folder modal

### DIFF
--- a/src/management-system-v2/components/folder-modal.tsx
+++ b/src/management-system-v2/components/folder-modal.tsx
@@ -6,6 +6,7 @@ import type { ModalProps } from 'antd';
 import useParseZodErrors, { antDesignInputProps } from '@/lib/useParseZodErrors';
 import { Folder, FolderUserInput, FolderUserInputSchema } from '@/lib/data/folder-schema';
 import TextArea from 'antd/es/input/TextArea';
+import { useAddControlCallback } from '@/lib/controls-store';
 
 type FolderModalProps = {
   spaceId: string;
@@ -40,6 +41,35 @@ const FolderModal = ({
     if (initialValues) form.setFieldsValue(initialValues);
     else form.resetFields();
   }, [open, initialValues]);
+
+  useAddControlCallback(
+    'process-list',
+    [
+      'selectall',
+      'esc',
+      'del',
+      'copy',
+      'paste',
+      'enter',
+      'cut',
+      'export',
+      'import',
+      'shift+enter',
+      'new',
+    ],
+    (e) => {
+      // e.preventDefault();
+    },
+    { level: 2, blocking: open },
+  );
+  useAddControlCallback(
+    'process-list',
+    'control+enter',
+    () => {
+      // if (open) onOk();
+    },
+    { level: 2, blocking: open, dependencies: [open] },
+  );
 
   return (
     <Modal

--- a/src/management-system-v2/components/process-modal.tsx
+++ b/src/management-system-v2/components/process-modal.tsx
@@ -102,7 +102,6 @@ const ProcessModal = <T extends { name: string; description: string }>({
     'control+enter',
     () => {
       if (open) onOk();
-      console.log(`trying to submit in process export. Modal is ${open ? 'open' : 'closed'}`);
     },
     { level: 2, blocking: open, dependencies: [open] },
   );


### PR DESCRIPTION
<!--
  Thank you for your contribution to this project!

  Please provide the following information about your changes,
  in order for us to approve and merge your proposal as quickly as possible.
-->

## Summary
When creating a folder, the user can now use normal shortcuts (copy + paste, ctrl + enter, etc, without using it on the process-list at the same time

<!--
  Please give a concise description of your proposal.
-->

<!--
  A list of changes and any additional information that could be relevant for this pull request.

Example:
- Function foobar() now takes an optional third parameter
- The version of dependency dep-js was changed to 1.3.7
-->
