### PR TITLE
Fixed: Editing of newly created user tasks

### DIFF
--- a/src/management-system-v2/app/(dashboard)/[environmentId]/processes/[processId]/_user-task-builder/index.tsx
+++ b/src/management-system-v2/app/(dashboard)/[environmentId]/processes/[processId]/_user-task-builder/index.tsx
@@ -26,6 +26,8 @@ import { useEnvironment } from '@/components/auth-can';
 
 import EditorDnDHandler from './DragAndDropHandler';
 
+import { is as bpmnIs } from 'bpmn-js/lib/util/ModelUtil';
+
 type BuilderProps = {
   processId: string;
   open: boolean;
@@ -66,9 +68,11 @@ const EditorModal: React.FC<BuilderModalProps> = ({
 
   const modeler = useModelerStateStore((state) => state.modeler);
   const selectedElementId = useModelerStateStore((state) => state.selectedElementId);
+
+  const selectedElement = modeler && selectedElementId && modeler.getElement(selectedElementId);
+
   const filename = useMemo(() => {
-    if (modeler && selectedElementId) {
-      const selectedElement = modeler.getElement(selectedElementId);
+    if (modeler && selectedElement && bpmnIs(selectedElement, 'bpmn:UserTask')) {
       if (selectedElement && selectedElement.type === 'bpmn:UserTask') {
         return (
           (selectedElement.businessObject.fileName as string | undefined) ||
@@ -78,7 +82,7 @@ const EditorModal: React.FC<BuilderModalProps> = ({
     }
 
     return undefined;
-  }, [modeler, selectedElementId]);
+  }, [modeler, selectedElement]);
 
   useEffect(() => {
     if (filename && open) {


### PR DESCRIPTION
<!--
  Thank you for your contribution to this project!

  Please provide the following information about your changes,
  in order for us to approve and merge your proposal as quickly as possible.
-->

## Summary
Currently if a user changes a task to a user task the button for editing the user task html will appear and is clickable but clicking it will open the user task editor in an invalid state.
This PR fixes that.

## Details

If a selected task is changed into a user task it is assigned a file name automatically that can then be used to store user task data. Before this only happened when an existing user task was selected.
