### PR TITLE
ms2/clickable profile menu

### DIFF
--- a/src/management-system-v2/app/(dashboard)/[environmentId]/iam/roles/role-side-panel.tsx
+++ b/src/management-system-v2/app/(dashboard)/[environmentId]/iam/roles/role-side-panel.tsx
@@ -46,8 +46,8 @@ const RoleContent: FC<{
             <>
               <Typography.Title>Members</Typography.Title>
               {role.members.map((user) => (
-                <Space>
-                  <UserAvatar user={user} avatarProps={{ size: 30 }} />
+                <Space key={user.id}>
+                  <UserAvatar user={user} size={30} />
                   <Typography.Text>{userRepresentation(user)}</Typography.Text>
                 </Space>
               ))}

--- a/src/management-system-v2/app/(dashboard)/[environmentId]/iam/users/user-side-panel.tsx
+++ b/src/management-system-v2/app/(dashboard)/[environmentId]/iam/users/user-side-panel.tsx
@@ -16,12 +16,8 @@ const UserSiderContent: FC<{ user: (ListUser & { roles?: Role[] }) | null }> = (
     <>
       <UserAvatar
         user={{ ...user, firstName: user.firstName.value, lastName: user.lastName.value }}
-        avatarProps={{
-          size: 60,
-          style: {
-            marginBottom: '1rem',
-          },
-        }}
+        size={60}
+        style={{ marginBottom: '1rem' }}
       />
 
       <Typography.Title>First Name</Typography.Title>
@@ -41,6 +37,7 @@ const UserSiderContent: FC<{ user: (ListUser & { roles?: Role[] }) | null }> = (
           <Typography.Title>Roles</Typography.Title>
           {user.roles.map((role) => (
             <SpaceLink
+              key={role.id}
               href={`/iam/roles/${role.id}`}
               style={{
                 display: 'block',

--- a/src/management-system-v2/app/(dashboard)/[environmentId]/profile/user-profile.tsx
+++ b/src/management-system-v2/app/(dashboard)/[environmentId]/profile/user-profile.tsx
@@ -134,13 +134,7 @@ const UserProfile: FC<{ userData: User }> = ({ userData }) => {
           )}
           <Typography.Title level={3}>Profile data</Typography.Title>
 
-          <UserAvatar
-            user={userData}
-            avatarProps={{
-              size: 90,
-              style: { marginBottom: '1rem' },
-            }}
-          />
+          <UserAvatar user={userData} size={90} style={{ marginBottom: '1rem' }} />
 
           <div
             style={{

--- a/src/management-system-v2/components/header-actions.tsx
+++ b/src/management-system-v2/components/header-actions.tsx
@@ -164,12 +164,12 @@ const HeaderActions: FC = () => {
         {enableChatbot && <Assistant />}
         {actionButton}
         <Dropdown
-          trigger={['click']}
+          trigger={['click', 'hover']}
           menu={{
             items: avatarDropdownItems,
           }}
         >
-          <UserAvatar user={session.data.user} />
+          <UserAvatar user={session.data.user} style={{ cursor: 'pointer' }} />
         </Dropdown>
       </Space>
     </>

--- a/src/management-system-v2/components/header-actions.tsx
+++ b/src/management-system-v2/components/header-actions.tsx
@@ -164,13 +164,12 @@ const HeaderActions: FC = () => {
         {enableChatbot && <Assistant />}
         {actionButton}
         <Dropdown
+          trigger={['click']}
           menu={{
             items: avatarDropdownItems,
           }}
         >
-          <SpaceLink href={`/profile`}>
-            <UserAvatar user={session.data.user} />
-          </SpaceLink>
+          <UserAvatar user={session.data.user} />
         </Dropdown>
       </Space>
     </>

--- a/src/management-system-v2/components/user-avatar.tsx
+++ b/src/management-system-v2/components/user-avatar.tsx
@@ -11,10 +11,9 @@ type UserAvatarProps = {
     firstName?: string | null;
     lastName?: string | null;
   };
-  avatarProps?: ComponentProps<typeof AntDesignAvatar>;
-};
+} & ComponentProps<typeof AntDesignAvatar>;
 
-const UserAvatar = forwardRef<HTMLElement, UserAvatarProps>(({ user, avatarProps }, ref) => {
+const UserAvatar = forwardRef<HTMLElement, UserAvatarProps>(({ user, ...avatarProps }, ref) => {
   if (!user) return <AntDesignAvatar />;
 
   if (user.isGuest) return <AntDesignAvatar icon={<UserOutlined />} />;


### PR DESCRIPTION
## Summary

- Profile image is now longer a link.
- The profile image is clickable (as well as hoverable) to open profile options

## Details

I had to change the props for `UserAvatar`, this was needed because as described in https://ant.design/components/dropdown#note, onMouseEnter, onMouseLeave, onFocus, onClick, need to be passed to the correct component in order for a dropdown to work.
