### PR TITLE
CI/CD: fix empty db url for main branch

### DIFF
--- a/.github/workflows/deploy_with_db.yml
+++ b/.github/workflows/deploy_with_db.yml
@@ -342,7 +342,7 @@ jobs:
           image: 'docker.io/proceed/ms-server:${{ env.MS_TAG }}'
           env_vars: |
             NEXTAUTH_URL=https://${{ env.SUBDOMAIN }}.proceed-labs.org
-            DATABASE_URL=${{ steps.configure-connection.outputs.DATABASE_URL }}
+            DATABASE_URL=postgresql://${{ secrets.DB_USER }}:${{secrets.DB_PASSWORD}}@${{ secrets.SSH_HOST }}:5433/${{ steps.generate-name.outputs.DB_NAME }}?schema=public
             PROCEED_PUBLIC_DEPLOYMENT_ENV=local
           region: 'europe-west1'
           revision_traffic: LATEST=100


### PR DESCRIPTION
The env var `DATABASE_URL=${{ steps.configure-connection.outputs.DATABASE_URL }}` is empty for main branch. 
The deployment uses google-github-actions/deploy-cloudrun@v2, which for some reason does not accept env var from GITHUB_OUTPUT.  

