### PR TITLE
Fix: Width changes of process list

### DIFF
--- a/src/management-system-v2/app/(dashboard)/[environmentId]/layout-client.tsx
+++ b/src/management-system-v2/app/(dashboard)/[environmentId]/layout-client.tsx
@@ -19,6 +19,9 @@ import { FaUserEdit } from 'react-icons/fa';
 import { useFileManager } from '@/lib/useFileManager';
 import { EntityType } from '@/lib/helpers/fileManagerHelpers';
 import { enableUseFileManager } from 'FeatureFlags';
+import { useUserPreferences } from '@/lib/user-preferences';
+
+export const COLLAPSED_SIDER_WIDTH = 75;
 
 export const useLayoutMobileDrawer = create<{ open: boolean; set: (open: boolean) => void }>(
   (set) => ({
@@ -65,7 +68,11 @@ const Layout: FC<
 
   const modelerIsFullScreen = useModelerStateStore((state) => state.isFullScreen);
 
-  const [collapsed, setCollapsed] = useState(false);
+  // const [collapsed, setCollapsed] = useState(false);
+  const { collapsed } = useUserPreferences.use['layout-menu']();
+  const addPreferences = useUserPreferences.use.addPreferences();
+  const setCollapsed = (collapsed: boolean) => addPreferences({ 'layout-menu': { collapsed } });
+
   const breakpoint = Grid.useBreakpoint();
 
   let layoutMenuItems = _layoutMenuItems;
@@ -162,7 +169,7 @@ const Layout: FC<
                 collapsible
                 collapsed={collapsed}
                 onCollapse={(collapsed) => setCollapsed(collapsed)}
-                collapsedWidth={breakpoint.xs ? '0' : '75'}
+                collapsedWidth={breakpoint.xs ? '0' : `${COLLAPSED_SIDER_WIDTH}`}
                 breakpoint="xl"
                 theme="light"
               >

--- a/src/management-system-v2/components/process-info-card-content.tsx
+++ b/src/management-system-v2/components/process-info-card-content.tsx
@@ -1,11 +1,13 @@
 'use client';
 
-import { Divider, Spin } from 'antd';
+import { Descriptions, Divider, Spin } from 'antd';
 import React, { FC, Suspense } from 'react';
 import Viewer from './bpmn-viewer';
-import { ProcessListProcess } from './processes';
+import { canDoActionOnResource, ProcessListProcess } from './processes';
 import { useUserPreferences } from '@/lib/user-preferences';
 import ProceedLoadingIndicator from './loading-proceed';
+import { generateDateString } from '@/lib/utils';
+import { useAbilityStore } from '@/lib/abilityStore';
 
 type MetaDataContentType = {
   selectedElement?: ProcessListProcess;
@@ -13,6 +15,11 @@ type MetaDataContentType = {
 
 const MetaDataContent: FC<MetaDataContentType> = ({ selectedElement }) => {
   const hydrated = useUserPreferences.use._hydrated();
+
+  const ability = useAbilityStore((state) => state.ability);
+
+  const canDelete = selectedElement && canDoActionOnResource([selectedElement], 'delete', ability);
+  const canEdit = selectedElement && canDoActionOnResource([selectedElement], 'update', ability);
 
   if (!hydrated) return null;
 
@@ -47,27 +54,39 @@ const MetaDataContent: FC<MetaDataContentType> = ({ selectedElement }) => {
           <h5>
             <b>Last Edited</b>
           </h5>
-          <p>{/**generateDateString(selectedElement.lastEdited, true)*/}</p>
+          <p>{generateDateString(selectedElement.lastEditedOn!, true)}</p>
           <h5>
             <b>Created On</b>
           </h5>
-          <p>{/**generateDateString(selectedElement.createdOn, true)*/}</p>
-          <h5>
-            <b>File Size</b>
-          </h5>
-          <p>X KB</p>
+          <p>{generateDateString(selectedElement.createdOn!, true)}</p>
           <h5>
             <b>Owner</b>
           </h5>
-          <p>Obi Wan Kenobi</p>
+          <p>{/* TODO: once userID-userName Mapping is done */}</p>
           <h5>
             <b>Description</b>
           </h5>
           <p>{selectedElement.description.value}</p>
 
           <Divider style={{ width: '100%', marginLeft: '-20%' }} />
-          <h3>Access Rights</h3>
-          <p>Test</p>
+          {/* <h3>Access Rights</h3> */}
+          <Descriptions
+            title={'Access Rights'}
+            bordered
+            size="small"
+            layout="horizontal"
+            // colon={false}
+          >
+            <Descriptions.Item span={3} label="View the Process:">
+              ✅
+            </Descriptions.Item>
+            <Descriptions.Item span={3} label="Edit the Process:">
+              {canEdit ? '✅' : '❌'}
+            </Descriptions.Item>
+            <Descriptions.Item span={3} label="Delete the Process">
+              {canDelete ? '✅' : '❌'}
+            </Descriptions.Item>
+          </Descriptions>
         </>
       ) : (
         <div>Please select a process.</div>

--- a/src/management-system-v2/components/process-info-card.tsx
+++ b/src/management-system-v2/components/process-info-card.tsx
@@ -6,6 +6,7 @@ import { useUserPreferences } from '@/lib/user-preferences';
 import { ProcessListProcess } from './processes';
 import ResizableElement, { ResizableElementRefType } from './ResizableElement';
 import MetaDataContent from './process-info-card-content';
+import { debounce } from '@/lib/utils';
 
 type MetaDataType = {
   selectedElement?: ProcessListProcess;
@@ -41,6 +42,15 @@ const MetaData = forwardRef<() => void, MetaDataType>(({ selectedElement }, ref)
 
   if (!hydrated) return null;
 
+  const finalPrefChange = debounce((width: number) => {
+    addPreferences({
+      'process-meta-data': {
+        open: showInfo,
+        width: width,
+      },
+    });
+  }, 300);
+
   return (
     <ResizableElement
       initialWidth={
@@ -55,14 +65,16 @@ const MetaData = forwardRef<() => void, MetaDataType>(({ selectedElement }, ref)
         marginLeft: '20px',
         maxWidth: '33%',
       }}
-      onWidthChange={(width) =>
+      onWidthChange={(width) => {
         addPreferences({
           'process-meta-data': {
             open: showInfo,
             width: width,
           },
-        })
-      }
+        });
+
+        finalPrefChange(width);
+      }}
       ref={resizableElementRef}
       lock={!showInfo}
     >

--- a/src/management-system-v2/components/processes/index.tsx
+++ b/src/management-system-v2/components/processes/index.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import styles from './processes.module.scss';
-import { ComponentProps, useRef, useState, useTransition } from 'react';
+import { ComponentProps, useEffect, useRef, useState, useTransition } from 'react';
 import { Space, Button, Tooltip, Grid, App, Drawer, Dropdown, Card, Badge } from 'antd';
 import {
   CopyOutlined,
@@ -49,6 +49,7 @@ import { DraggableContext } from './draggable-element';
 import SelectionActions from '../selection-actions';
 import ProceedLoadingIndicator from '../loading-proceed';
 import { wrapServerCall } from '@/lib/wrap-server-call';
+import { COLLAPSED_SIDER_WIDTH } from '@/app/(dashboard)/[environmentId]/layout-client';
 
 export function canDoActionOnResource(
   items: ProcessListProcess[],
@@ -119,6 +120,12 @@ const Processes = ({
   const iconView = useUserPreferences.use['icon-view-in-process-list']();
   const { open: metaPanelisOpened, width: metaPanelWidth } =
     useUserPreferences.use['process-meta-data']();
+  const { collapsed: layoutMenuSiderCollapsed } = useUserPreferences.use['layout-menu']();
+
+  const siderOpen = !layoutMenuSiderCollapsed;
+  const siderWidth = COLLAPSED_SIDER_WIDTH;
+  const siderOffSet = siderOpen ? 0 : 200 - siderWidth;
+  let tableWidthOffSet = metaPanelWidth - siderOffSet;
 
   const [openExportModal, setOpenExportModal] = useState(false);
   const [openCopyModal, setOpenCopyModal] = useState(false);
@@ -511,8 +518,8 @@ const Processes = ({
                     style={{
                       maxWidth: breakpoint.xl
                         ? metaPanelisOpened
-                          ? `calc(87vw - ${metaPanelWidth}px)`
-                          : '85.5vw'
+                          ? `calc(87vw - ${tableWidthOffSet}px)`
+                          : `calc(85.5vw + ${siderOffSet}px)`
                         : '100%',
                     }}
                   >

--- a/src/management-system-v2/lib/user-preferences.ts
+++ b/src/management-system-v2/lib/user-preferences.ts
@@ -43,6 +43,9 @@ const defaultPreferences = {
   'process-meta-data': { open: false, width: 300 },
   'tech-data-open-tree-items': [] as { id: string; open: string[] }[],
   'tech-data-editor': { siderOpen: true, siderWidth: 300 },
+  'layout-menu': {
+    collapsed: false,
+  },
 }; /* as const */ /* Does not work for strings */
 
 const partialUpdate = (


### PR DESCRIPTION
<!--
  Thank you for your contribution to this project!

  Please provide the following information about your changes,
  in order for us to approve and merge your proposal as quickly as possible.
-->

## Summary

- Whether the sider (navigation) is opened is now saved in the localstorage
- Opening ? Closing the navigation / sider changes Table width accordingly
- Resizing the Panel (on right of process list) now triggers an additional debounce resize 300ms after last invoke to ensure proper resizing
- Replaced the placeholder in the panel with actual information of process 

<!--
  Please give a concise description of your proposal.
-->

## Details
closes [#354](https://github.com/PROCEED-Labs/proceed/issues/354)

<!--
  A list of changes and any additional information that could be relevant for this pull request.

Example:
- Function foobar() now takes an optional third parameter
- The version of dependency dep-js was changed to 1.3.7
-->
