### PR TITLE
fix(ms2/e2e): flaky process list test

### DIFF
--- a/tests/ms2/processes/process-list.spec.ts
+++ b/tests/ms2/processes/process-list.spec.ts
@@ -986,11 +986,17 @@ test.describe('Click-Controls in Process-List', () => {
     await page.getByRole('button', { name: 'appstore' }).click();
 
     /* Variables */
-    const counter = await page.getByRole('note');
-    const processA = await page.getByRole('button', { name: /Process A/ });
-    const processB = await page.getByRole('button', { name: /Process B/ });
-    const processC = await page.getByRole('button', { name: /Process C/ });
-    const processD = await page.getByRole('button', { name: /Process D/ });
+    const counter = page.getByRole('note');
+
+    // Since the order that the objects will appear on the list isn't predictable, we just index
+    // them by their order instead of their name
+    const processes = page.getByRole('button', { name: /Process [A-Z]/, exact: true });
+    expect(processes).toHaveCount(4);
+
+    const processA = processes.nth(0);
+    const processB = processes.nth(1);
+    const processC = processes.nth(2);
+    const processD = processes.nth(3);
 
     /* Select B (while pressing shift) */
     await processB.click({ modifiers: ['Shift'] });


### PR DESCRIPTION
## Summary

The drag and select test relied on the order that the processes appeared in the icon view, which isn't always the same.
To fix this we just index the processes by their order instead of their name.
