### PR TITLE
ms2/script editor fixes

### DIFF
--- a/src/management-system-v2/app/(dashboard)/[environmentId]/processes/[processId]/_user-task-builder/BuilderContext.tsx
+++ b/src/management-system-v2/app/(dashboard)/[environmentId]/processes/[processId]/_user-task-builder/BuilderContext.tsx
@@ -1,9 +1,0 @@
-import { createContext } from 'react';
-
-type BuilderContextType = {
-  editingEnabled: boolean;
-};
-
-const BuilderContext = createContext<BuilderContextType>({ editingEnabled: false });
-
-export default BuilderContext;

--- a/src/management-system-v2/app/(dashboard)/[environmentId]/processes/[processId]/_user-task-builder/Toolbar.tsx
+++ b/src/management-system-v2/app/(dashboard)/[environmentId]/processes/[processId]/_user-task-builder/Toolbar.tsx
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react';
+import React from 'react';
 
 import { Row, Button, Divider, Col, Space } from 'antd';
 
@@ -13,7 +13,7 @@ import {
 import styles from './index.module.scss';
 
 import { useEditor, Node } from '@craftjs/core';
-import BuilderContext from './BuilderContext';
+import { useCanEdit } from '../modeler';
 
 export type EditorLayout = 'computer' | 'mobile';
 
@@ -61,7 +61,7 @@ export const Toolbar: React.FC<ToolbarProps> = ({
     };
   });
 
-  const { editingEnabled } = useContext(BuilderContext);
+  const editingEnabled = useCanEdit();
 
   return (
     <Row className={styles.EditorHeader}>

--- a/src/management-system-v2/app/(dashboard)/[environmentId]/processes/[processId]/_user-task-builder/_sidebar/Toolbox.tsx
+++ b/src/management-system-v2/app/(dashboard)/[environmentId]/processes/[processId]/_user-task-builder/_sidebar/Toolbox.tsx
@@ -1,6 +1,6 @@
 import { Element } from '@craftjs/core';
 import { Button as AntButton } from 'antd';
-import React, { ReactNode, useContext } from 'react';
+import React, { ReactNode } from 'react';
 
 import { LuFormInput, LuImage, LuTable, LuText } from 'react-icons/lu';
 import { MdCheckBox, MdRadioButtonChecked, MdTitle, MdOutlineCheck } from 'react-icons/md';
@@ -22,7 +22,7 @@ import {
 } from '../elements';
 
 import { createPortal } from 'react-dom';
-import BuilderContext from '../BuilderContext';
+import { useCanEdit } from '../../modeler';
 
 type CreationButtonProps = React.PropsWithChildren<{
   title: string;
@@ -30,7 +30,7 @@ type CreationButtonProps = React.PropsWithChildren<{
 }>;
 
 const CreationButton: React.FC<CreationButtonProps> = ({ children, title, icon }) => {
-  const { editingEnabled } = useContext(BuilderContext);
+  const editingEnabled = useCanEdit();
 
   const id = `create-${title}-button`;
 

--- a/src/management-system-v2/app/(dashboard)/[environmentId]/processes/[processId]/_user-task-builder/elements/CheckboxOrRadioGroup.tsx
+++ b/src/management-system-v2/app/(dashboard)/[environmentId]/processes/[processId]/_user-task-builder/elements/CheckboxOrRadioGroup.tsx
@@ -1,6 +1,6 @@
-import { useContext, useEffect, useId, useMemo, useState } from 'react';
+import { useEffect, useId, useMemo, useState } from 'react';
 
-import { Divider, Input, MenuProps, Select, Space, Tooltip } from 'antd';
+import { Divider, Input, MenuProps, Space, Tooltip } from 'antd';
 import { InfoCircleOutlined } from '@ant-design/icons';
 import { TbRowInsertTop, TbRowInsertBottom, TbRowRemove } from 'react-icons/tb';
 
@@ -20,7 +20,7 @@ import { WithRequired } from '@/lib/typescript-utils';
 
 import { SettingOutlined, EditOutlined } from '@ant-design/icons';
 import { createPortal } from 'react-dom';
-import BuilderContext from '../BuilderContext';
+import { useCanEdit } from '../../modeler';
 
 const checkboxValueHint =
   'This will be the value that is added to the variable associated with this group when the checkbox is checked at the time the form is submitted.';
@@ -64,7 +64,7 @@ const CheckboxOrRadioButton: React.FC<CheckBoxOrRadioButtonProps> = ({
   const [hovered, setHovered] = useState(false);
   const [textEditing, setTextEditing] = useState(false);
 
-  const { editingEnabled } = useContext(BuilderContext);
+  const editingEnabled = useCanEdit();
 
   return (
     <>
@@ -153,7 +153,7 @@ const CheckBoxOrRadioGroup: UserComponent<CheckBoxOrRadioGroupProps> = ({
     }
   }, [isSelected]);
 
-  const { editingEnabled } = useContext(BuilderContext);
+  const editingEnabled = useCanEdit();
 
   const handleLabelEdit = (index: number, text: string) => {
     if (!editingEnabled) return;

--- a/src/management-system-v2/app/(dashboard)/[environmentId]/processes/[processId]/_user-task-builder/elements/Column.tsx
+++ b/src/management-system-v2/app/(dashboard)/[environmentId]/processes/[processId]/_user-task-builder/elements/Column.tsx
@@ -1,10 +1,10 @@
 import { UserComponent, useNode } from '@craftjs/core';
 import { useDraggable } from '@dnd-kit/core';
-import { useContext, useRef } from 'react';
+import { useRef } from 'react';
 import { createPortal } from 'react-dom';
 import { useFrame } from 'react-frame-component';
 import useBuilderStateStore from '../use-builder-state-store';
-import BuilderContext from '../BuilderContext';
+import { useCanEdit } from '../../modeler';
 /**
  * This component wraps every editor element provides drag handling and some styling
  */
@@ -25,7 +25,7 @@ const Column: UserComponent<React.PropsWithChildren<{ fixed?: boolean }>> = ({
   }));
 
   const dragBlockers = useBuilderStateStore((state) => state.dragBlockers);
-  const { editingEnabled } = useContext(BuilderContext);
+  const editingEnabled = useCanEdit();
 
   const ref = useRef<HTMLDivElement>();
   const frame = useFrame();

--- a/src/management-system-v2/app/(dashboard)/[environmentId]/processes/[processId]/_user-task-builder/elements/Image.tsx
+++ b/src/management-system-v2/app/(dashboard)/[environmentId]/processes/[processId]/_user-task-builder/elements/Image.tsx
@@ -2,17 +2,17 @@ import { useEditor, useNode, UserComponent, Node } from '@craftjs/core';
 
 import { InputNumber } from 'antd';
 
-import { useContext, useEffect, useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
 import { fallbackImage } from '../../image-selection-section';
 import { useParams } from 'next/navigation';
 import { useEnvironment } from '@/components/auth-can';
 import { ContextMenu, Setting } from './utils';
 import ImageUpload from '@/components/image-upload';
-import BuilderContext from '../BuilderContext';
 import { EntityType } from '@/lib/helpers/fileManagerHelpers';
 import { useFileManager } from '@/lib/useFileManager';
 import { enableUseFileManager } from 'FeatureFlags';
+import { useCanEdit } from '../../modeler';
 
 type ImageProps = {
   src?: string;
@@ -60,7 +60,7 @@ export const EditImage: UserComponent<ImageProps> = ({ src, reloadParam, width }
     return { isHovered: !!parent && parent.events.hovered };
   });
 
-  const { editingEnabled } = useContext(BuilderContext);
+  const editingEnabled = useCanEdit();
 
   const {
     fileUrl: imageUrl,

--- a/src/management-system-v2/app/(dashboard)/[environmentId]/processes/[processId]/_user-task-builder/elements/Input.tsx
+++ b/src/management-system-v2/app/(dashboard)/[environmentId]/processes/[processId]/_user-task-builder/elements/Input.tsx
@@ -1,4 +1,4 @@
-import { useContext, useEffect, useId, useState } from 'react';
+import { useEffect, useId, useState } from 'react';
 
 import { Select, Input as AntInput } from 'antd';
 import { EditOutlined } from '@ant-design/icons';
@@ -8,7 +8,7 @@ import { UserComponent, useNode } from '@craftjs/core';
 import { ContextMenu, Overlay, Setting } from './utils';
 import EditableText from '../_utils/EditableText';
 import useBuilderStateStore from '../use-builder-state-store';
-import BuilderContext from '../BuilderContext';
+import { useCanEdit } from '../../modeler';
 
 type InputProps = {
   label?: string;
@@ -29,7 +29,7 @@ const Input: UserComponent<InputProps> = ({
     connectors: { connect },
     actions: { setProp },
   } = useNode();
-  const { editingEnabled } = useContext(BuilderContext);
+  const editingEnabled = useCanEdit();
 
   const inputId = useId();
 

--- a/src/management-system-v2/app/(dashboard)/[environmentId]/processes/[processId]/_user-task-builder/elements/SubmitButton.tsx
+++ b/src/management-system-v2/app/(dashboard)/[environmentId]/processes/[processId]/_user-task-builder/elements/SubmitButton.tsx
@@ -3,13 +3,13 @@ import { useNode, UserComponent, useEditor } from '@craftjs/core';
 import { EditOutlined } from '@ant-design/icons';
 
 import EditableText from '../_utils/EditableText';
-import React, { useContext, useState } from 'react';
+import React, { useState } from 'react';
 import { Overlay, Setting } from './utils';
 
 import cn from 'classnames';
 import { Checkbox, Select } from 'antd';
 
-import BuilderContext from '../BuilderContext';
+import { useCanEdit } from '../../modeler';
 
 type SubmitButtonProps = React.PropsWithChildren & {
   title?: string;
@@ -30,7 +30,7 @@ const SubmitButton: UserComponent<SubmitButtonProps> = ({
   const [textEditing, setTextEditing] = useState(false);
   const [hovered, setHovered] = useState(false);
 
-  const { editingEnabled } = useContext(BuilderContext);
+  const editingEnabled = useCanEdit();
 
   return (
     <div>

--- a/src/management-system-v2/app/(dashboard)/[environmentId]/processes/[processId]/_user-task-builder/elements/Table.tsx
+++ b/src/management-system-v2/app/(dashboard)/[environmentId]/processes/[processId]/_user-task-builder/elements/Table.tsx
@@ -15,9 +15,9 @@ import cn from 'classnames';
 
 import EditableText from '../_utils/EditableText';
 import { ContextMenu, MenuItemFactoryFactory, Overlay, SidebarButtonFactory } from './utils';
-import React, { useContext, useEffect, useMemo, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import { createPortal } from 'react-dom';
-import BuilderContext from '../BuilderContext';
+import { useCanEdit } from '../../modeler';
 
 const defaultHeaderContent =
   '<b><strong class="text-style-bold" style="white-space: pre-wrap;">Header Cell</strong></b>';
@@ -52,7 +52,7 @@ const TableCell: React.FC<
   const [hovered, setHovered] = useState(false);
   const [textEditing, setTextEditing] = useState(false);
 
-  const { editingEnabled } = useContext(BuilderContext);
+  const editingEnabled = useCanEdit();
 
   return React.createElement(
     type,
@@ -163,7 +163,7 @@ const Table: UserComponent<TableProps> = ({
     }
   }, [isSelected]);
 
-  const { editingEnabled } = useContext(BuilderContext);
+  const editingEnabled = useCanEdit();
 
   const addRow = (index: number) => {
     if (!editingEnabled) return;

--- a/src/management-system-v2/app/(dashboard)/[environmentId]/processes/[processId]/_user-task-builder/elements/Text.tsx
+++ b/src/management-system-v2/app/(dashboard)/[environmentId]/processes/[processId]/_user-task-builder/elements/Text.tsx
@@ -4,8 +4,8 @@ import { EditOutlined } from '@ant-design/icons';
 
 import EditableText from '../_utils/EditableText';
 import { ContextMenu, Overlay } from './utils';
-import { useContext, useState } from 'react';
-import BuilderContext from '../BuilderContext';
+import { useState } from 'react';
+import { useCanEdit } from '../../modeler';
 
 type TextProps = {
   text?: string;
@@ -19,7 +19,7 @@ const Text: UserComponent<TextProps> = ({ text = '' }) => {
   const [hovered, setHovered] = useState(false);
   const [textEditing, setTextEditing] = useState(false);
 
-  const { editingEnabled } = useContext(BuilderContext);
+  const editingEnabled = useCanEdit();
 
   return (
     <ContextMenu menu={[]}>

--- a/src/management-system-v2/app/(dashboard)/[environmentId]/processes/[processId]/_user-task-builder/elements/utils.tsx
+++ b/src/management-system-v2/app/(dashboard)/[environmentId]/processes/[processId]/_user-task-builder/elements/utils.tsx
@@ -1,12 +1,4 @@
-import React, {
-  ReactElement,
-  ReactNode,
-  useContext,
-  useEffect,
-  useId,
-  useMemo,
-  useState,
-} from 'react';
+import React, { ReactElement, ReactNode, useEffect, useId, useMemo, useState } from 'react';
 import { createPortal } from 'react-dom';
 
 import { Button, Menu, MenuProps } from 'antd';
@@ -14,7 +6,7 @@ import { useDndContext } from '@dnd-kit/core';
 
 import useBuilderStateStore from '../use-builder-state-store';
 import { truthyFilter } from '@/lib/typescript-utils';
-import BuilderContext from '../BuilderContext';
+import { useCanEdit } from '../../modeler';
 
 export const Setting: React.FC<{
   label: string;
@@ -23,7 +15,7 @@ export const Setting: React.FC<{
 }> = ({ label, control, style = {} }) => {
   const id = useId();
 
-  const { editingEnabled } = useContext(BuilderContext);
+  const editingEnabled = useCanEdit();
 
   const clonedControl = React.cloneElement(control, { id, disabled: !editingEnabled });
 
@@ -48,7 +40,7 @@ type ContextMenuProps = React.PropsWithChildren<{
 export const ContextMenu: React.FC<ContextMenuProps> = ({ children, menu, onClose }) => {
   const [menuPosition, setMenuPosition] = useState<{ top: number; left: number }>();
 
-  const { editingEnabled } = useContext(BuilderContext);
+  const editingEnabled = useCanEdit();
 
   const id = useId();
   const blockDragging = useBuilderStateStore((state) => state.blockDragging);
@@ -192,7 +184,7 @@ function SidebarButton<T extends string>({
   onClick,
   onHovered,
 }: SidebarButtonProps<T>) {
-  const { editingEnabled } = useContext(BuilderContext);
+  const editingEnabled = useCanEdit();
 
   return (
     <Button

--- a/src/management-system-v2/app/(dashboard)/[environmentId]/processes/[processId]/_user-task-builder/utils.tsx
+++ b/src/management-system-v2/app/(dashboard)/[environmentId]/processes/[processId]/_user-task-builder/utils.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import ReactDOMServer from 'react-dom/server';
 
 import * as Elements from './elements';
-import BuilderContext from './BuilderContext';
+import { CanEditContext } from '../modeler';
 
 const styles = `
 body {
@@ -164,7 +164,7 @@ p, h1, h2, h3, h4, h5, th, td {
 
 export function toHtml(json: string) {
   const markup = ReactDOMServer.renderToStaticMarkup(
-    <BuilderContext.Provider value={{ editingEnabled: true }}>
+    <CanEditContext.Provider value={true}>
       <Editor
         enabled={false}
         resolver={{
@@ -175,7 +175,7 @@ export function toHtml(json: string) {
         <Frame data={json} />
       </Editor>
       ,
-    </BuilderContext.Provider>,
+    </CanEditContext.Provider>,
   );
 
   return `

--- a/src/management-system-v2/app/(dashboard)/[environmentId]/processes/[processId]/blockly-editor.tsx
+++ b/src/management-system-v2/app/(dashboard)/[environmentId]/processes/[processId]/blockly-editor.tsx
@@ -114,8 +114,41 @@ const BlocklyEditor = ({ onChange, initialXml, editorRef, blocklyOptions }: Bloc
     onChangeFunc.current?.(isBlockScriptValid, { xml: xmlText, js: javascriptCode });
   }, []);
 
-  return (
+  useEffect(() => {
+    if (!blocklyEditorRef.current || initialXml === '') return;
+    const xml = Blockly.utils.xml.textToDom(initialXml);
+    Blockly.Xml.clearWorkspaceAndLoadFromXml(xml, blocklyEditorRef.current);
+    blocklyEditorRef.current.scrollCenter();
+  }, [initialXml]);
+
+  // react blockly doesn't when readOnly changes and it can even lead to issues if the workspace was
+  // readonly and changed to editable
+  // For this reason, when reaOnly changes, we unmount the BlocklyWorkspace and mount a new one
+  return blocklyOptions?.readOnly ? (
     <BlocklyWorkspace
+      key="readonly-blockly"
+      initialXml={initialXml}
+      className="width-100 fill-height" // you can use whatever classes are appropriate for your app's CSS
+      toolboxConfiguration={INITIAL_TOOLBOX_JSON} // this must be a JSON toolbox definition
+      workspaceConfiguration={{
+        grid: {
+          spacing: 20,
+          length: 3,
+          colour: '#ccc',
+          snap: true,
+        },
+        scrollbars: true,
+        ...blocklyOptions,
+      }}
+      onWorkspaceChange={onWorkspaceChange}
+      onInject={(newWorkspace) => {
+        blocklyEditorRef.current = newWorkspace;
+      }}
+    />
+  ) : (
+    <BlocklyWorkspace
+      key="editable-blockly"
+      initialXml={initialXml}
       className="width-100 fill-height" // you can use whatever classes are appropriate for your app's CSS
       toolboxConfiguration={INITIAL_TOOLBOX_JSON} // this must be a JSON toolbox definition
       workspaceConfiguration={{

--- a/src/management-system-v2/app/(dashboard)/[environmentId]/processes/[processId]/blockly-editor.tsx
+++ b/src/management-system-v2/app/(dashboard)/[environmentId]/processes/[processId]/blockly-editor.tsx
@@ -14,6 +14,7 @@ import './blockly-editor.css';
 
 export type BlocklyEditorRefType = {
   getCode: () => { js: string; xml: string };
+  fillContainer: () => void;
   reset: () => void;
 };
 
@@ -72,6 +73,10 @@ const BlocklyEditor = ({ onChange, initialXml, editorRef, blocklyOptions }: Bloc
             return { xml: xmlText, js: javascriptCode };
           }
           return { xml: '', js: '' };
+        },
+        fillContainer: () => {
+          // firing this event is easier and more robust than copying blockly's resize logic
+          window.dispatchEvent(new Event('resize'));
         },
         reset: () => {
           if (!blocklyEditorRef.current) return;

--- a/src/management-system-v2/app/(dashboard)/[environmentId]/processes/[processId]/blockly-editor.tsx
+++ b/src/management-system-v2/app/(dashboard)/[environmentId]/processes/[processId]/blockly-editor.tsx
@@ -1,5 +1,5 @@
 'use client';
-import {
+import React, {
   forwardRef,
   PropsWithChildren,
   useEffect,
@@ -18,9 +18,10 @@ type BlocklyEditorProps = PropsWithChildren<{
   onChange: (isScriptValid: boolean, code: { xml: string; js: string }) => void;
   initialXml: string;
   editorRef: React.Ref<BlocklyEditorRefType>;
+  blocklyOptions?: Blockly.BlocklyOptions;
 }>;
 
-const BlocklyEditor = ({ onChange, initialXml, editorRef }: BlocklyEditorProps) => {
+const BlocklyEditor = ({ onChange, initialXml, editorRef, blocklyOptions }: BlocklyEditorProps) => {
   const blocklyEditorRef = useRef<Blockly.WorkspaceSvg | null>(null);
 
   const validateBlockScript = () => {
@@ -77,6 +78,7 @@ const BlocklyEditor = ({ onChange, initialXml, editorRef }: BlocklyEditorProps) 
           colour: '#ccc',
           snap: true,
         },
+        ...blocklyOptions,
       }}
       onWorkspaceChange={(workspace) => {
         const isBlockScriptValid = validateBlockScript();

--- a/src/management-system-v2/app/(dashboard)/[environmentId]/processes/[processId]/blockly-editor.tsx
+++ b/src/management-system-v2/app/(dashboard)/[environmentId]/processes/[processId]/blockly-editor.tsx
@@ -56,6 +56,7 @@ const BlocklyEditor = ({ onChange, initialXml, editorRef, blocklyOptions }: Bloc
     if (blocklyEditorRef.current && blocklyEditorRef.current.rendered && initialXml) {
       const xml = Blockly.utils.xml.textToDom(initialXml);
       Blockly.Xml.clearWorkspaceAndLoadFromXml(xml, blocklyEditorRef.current);
+      blocklyEditorRef.current.scrollCenter();
     }
   }, [initialXml]);
 
@@ -74,15 +75,15 @@ const BlocklyEditor = ({ onChange, initialXml, editorRef, blocklyOptions }: Bloc
           return { xml: '', js: '' };
         },
         fillContainer: () => {
+          if (!blocklyEditorRef.current) return;
           // firing this event is easier and more robust than copying blockly's resize logic
           window.dispatchEvent(new Event('resize'));
+          blocklyEditorRef.current.scrollCenter();
         },
         reset: () => {
-          if (!blocklyEditorRef.current) return;
-
-          blocklyEditorRef.current.clear();
-          const xmlDom = Blockly.utils.xml.textToDom(initialXml);
-          Blockly.Xml.domToWorkspace(xmlDom, blocklyEditorRef.current);
+          if (!blocklyEditorRef.current || initialXml === '') return;
+          const xml = Blockly.utils.xml.textToDom(initialXml);
+          Blockly.Xml.clearWorkspaceAndLoadFromXml(xml, blocklyEditorRef.current);
           blocklyEditorRef.current.scrollCenter();
         },
       }) satisfies BlocklyEditorRefType,

--- a/src/management-system-v2/app/(dashboard)/[environmentId]/processes/[processId]/blockly-editor.tsx
+++ b/src/management-system-v2/app/(dashboard)/[environmentId]/processes/[processId]/blockly-editor.tsx
@@ -1,13 +1,12 @@
 'use client';
 import React, {
-  forwardRef,
   PropsWithChildren,
+  useCallback,
   useEffect,
   useImperativeHandle,
   useRef,
-  useState,
 } from 'react';
-import { BlocklyWorkspace, useBlocklyWorkspace } from 'react-blockly';
+import { BlocklyWorkspace } from 'react-blockly';
 import { INITIAL_TOOLBOX_JSON, javascriptGenerator, Blockly } from './blockly-editor-config';
 
 import './blockly-editor.css';
@@ -89,6 +88,17 @@ const BlocklyEditor = ({ onChange, initialXml, editorRef, blocklyOptions }: Bloc
       }) satisfies BlocklyEditorRefType,
   );
 
+  const onWorkspaceChange = useCallback(
+    (workspace: Blockly.WorkspaceSvg) => {
+      const isBlockScriptValid = validateBlockScript();
+      const xmlText = Blockly.Xml.domToText(Blockly.Xml.workspaceToDom(workspace));
+      const javascriptCode = javascriptGenerator.workspaceToCode(workspace);
+
+      onChange(isBlockScriptValid, { xml: xmlText, js: javascriptCode });
+    },
+    [onChange],
+  );
+
   return (
     <BlocklyWorkspace
       className="width-100 fill-height" // you can use whatever classes are appropriate for your app's CSS
@@ -102,13 +112,7 @@ const BlocklyEditor = ({ onChange, initialXml, editorRef, blocklyOptions }: Bloc
         },
         ...blocklyOptions,
       }}
-      onWorkspaceChange={(workspace) => {
-        const isBlockScriptValid = validateBlockScript();
-        const xmlText = Blockly.Xml.domToText(Blockly.Xml.workspaceToDom(workspace));
-        const javascriptCode = javascriptGenerator.workspaceToCode(workspace);
-
-        onChange(isBlockScriptValid, { xml: xmlText, js: javascriptCode });
-      }}
+      onWorkspaceChange={onWorkspaceChange}
       onInject={(newWorkspace) => {
         blocklyEditorRef.current = newWorkspace;
       }}

--- a/src/management-system-v2/app/(dashboard)/[environmentId]/processes/[processId]/modeler-toolbar.tsx
+++ b/src/management-system-v2/app/(dashboard)/[environmentId]/processes/[processId]/modeler-toolbar.tsx
@@ -73,14 +73,13 @@ const ModelerToolbar = ({ process, onOpenXmlEditor, canUndo, canRedo }: ModelerT
   // Force rerender when the BPMN changes.
   useModelerStateStore((state) => state.changeCounter);
 
+  const modalOpen =
+    showUserTaskEditor || showPropertiesPanel || showScriptTaskEditor || shareModalOpen;
   useEffect(() => {
-    if (modeler && showUserTaskEditor) {
-      // TODO: maybe  do this without an effect
-      modeler.deactivateKeyboard();
-    } else if (modeler) {
-      modeler.activateKeyboard();
-    }
-  }, [modeler, showUserTaskEditor]);
+    if (modalOpen) {
+      modeler?.deactivateKeyboard();
+    } else modeler?.activateKeyboard();
+  }, [modeler, modalOpen]);
 
   const selectedVersionId = query.get('version');
 

--- a/src/management-system-v2/app/(dashboard)/[environmentId]/processes/[processId]/modeler.tsx
+++ b/src/management-system-v2/app/(dashboard)/[environmentId]/processes/[processId]/modeler.tsx
@@ -1,6 +1,14 @@
 'use client';
 
-import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  createContext,
+  useContext,
+} from 'react';
 import { usePathname, useRouter, useSearchParams } from 'next/navigation';
 import ModelerToolbar from './modeler-toolbar';
 import XmlEditor from './xml-editor';
@@ -30,6 +38,12 @@ type ModelerProps = React.HTMLAttributes<HTMLDivElement> & {
   versionName?: string;
   process: Process;
 };
+
+export const CanEditContext = createContext<boolean>(true);
+
+export function useCanEdit() {
+  return useContext(CanEditContext);
+}
 
 const Modeler = ({ versionName, process, ...divProps }: ModelerProps) => {
   const pathname = usePathname();
@@ -315,46 +329,48 @@ const Modeler = ({ versionName, process, ...divProps }: ModelerProps) => {
   );
 
   return (
-    <div className={styles.Modeler} style={{ height: '100%' }}>
-      {!minimized && (
-        <>
-          {loaded && (
-            <ModelerToolbar
-              process={process}
-              onOpenXmlEditor={handleOpenXmlEditor}
-              canRedo={canRedo}
-              canUndo={canUndo}
-            />
-          )}
-          {selectedVersionId && !showMobileView && <VersionToolbar processId={process.id} />}
-          <ModelerZoombar></ModelerZoombar>
-          {!!xmlEditorBpmn && (
-            <XmlEditor
-              bpmn={xmlEditorBpmn}
-              canSave={!selectedVersionId}
-              onClose={handleCloseXmlEditor}
-              onSaveXml={handleXmlEditorSave}
-              process={process}
-              versionName={versionName}
-            />
-          )}
-        </>
-      )}
-      <BPMNCanvas
-        ref={modeler}
-        type={canEdit ? 'modeler' : 'navigatedviewer'}
-        bpmn={bpmn}
-        className={divProps.className}
-        onLoaded={onLoaded}
-        onUnload={canEdit ? onUnload : undefined}
-        onRootChange={onRootChange}
-        onChange={canEdit ? onChange : undefined}
-        onSelectionChange={onSelectionChange}
-        onZoom={onZoom}
-        onShapeRemove={onShapeRemove}
-        onShapeRemoveUndo={onShapeRemoveUndo}
-      />
-    </div>
+    <CanEditContext.Provider value={canEdit}>
+      <div className={styles.Modeler} style={{ height: '100%' }}>
+        {!minimized && (
+          <>
+            {loaded && (
+              <ModelerToolbar
+                process={process}
+                onOpenXmlEditor={handleOpenXmlEditor}
+                canRedo={canRedo}
+                canUndo={canUndo}
+              />
+            )}
+            {selectedVersionId && !showMobileView && <VersionToolbar processId={process.id} />}
+            <ModelerZoombar></ModelerZoombar>
+            {!!xmlEditorBpmn && (
+              <XmlEditor
+                bpmn={xmlEditorBpmn}
+                canSave={!selectedVersionId}
+                onClose={handleCloseXmlEditor}
+                onSaveXml={handleXmlEditorSave}
+                process={process}
+                versionName={versionName}
+              />
+            )}
+          </>
+        )}
+        <BPMNCanvas
+          ref={modeler}
+          type={canEdit ? 'modeler' : 'navigatedviewer'}
+          bpmn={bpmn}
+          className={divProps.className}
+          onLoaded={onLoaded}
+          onUnload={canEdit ? onUnload : undefined}
+          onRootChange={onRootChange}
+          onChange={canEdit ? onChange : undefined}
+          onSelectionChange={onSelectionChange}
+          onZoom={onZoom}
+          onShapeRemove={onShapeRemove}
+          onShapeRemoveUndo={onShapeRemoveUndo}
+        />
+      </div>
+    </CanEditContext.Provider>
   );
 };
 

--- a/src/management-system-v2/app/(dashboard)/[environmentId]/processes/[processId]/script-editor.tsx
+++ b/src/management-system-v2/app/(dashboard)/[environmentId]/processes/[processId]/script-editor.tsx
@@ -193,7 +193,13 @@ const ScriptEditor: FC<ScriptEditorProps> = ({ processId, open, onClose, selecte
         onOk: () => handleSave().then(onClose),
         okText: 'Save',
         cancelText: 'Discard',
-        onCancel: onClose,
+        onCancel: () => {
+          onClose();
+
+          // discard changes
+          if (selectedEditor === 'JS') monacoEditorRef.current?.setValue(initialScript);
+          if (selectedEditor === 'blockly') blocklyRef.current?.reset();
+        },
       });
     }
   };

--- a/src/management-system-v2/app/(dashboard)/[environmentId]/processes/[processId]/script-editor.tsx
+++ b/src/management-system-v2/app/(dashboard)/[environmentId]/processes/[processId]/script-editor.tsx
@@ -101,6 +101,11 @@ const ScriptEditor: FC<ScriptEditorProps> = ({ processId, open, onClose, selecte
   });
 
   useEffect(() => {
+    // Fetch the data for the script task when the element is selected in the editor
+    if (!open) refetch();
+  }, [open, refetch]);
+
+  useEffect(() => {
     setHasUnsavedChanges(false);
     setInitialScript('');
     setSelectedEditor(null);
@@ -195,10 +200,13 @@ const ScriptEditor: FC<ScriptEditorProps> = ({ processId, open, onClose, selecte
         cancelText: 'Discard',
         onCancel: () => {
           onClose();
-
           // discard changes
+          // no change was saved to the script -> script is opened again -> no props change -> Editors keep changes
+          // (if changes where made, the props of the editors would change and the editors would reset)
           if (selectedEditor === 'JS') monacoEditorRef.current?.setValue(initialScript);
           if (selectedEditor === 'blockly') blocklyRef.current?.reset();
+
+          setHasUnsavedChanges(false);
         },
       });
     }

--- a/src/management-system-v2/app/(dashboard)/[environmentId]/processes/[processId]/script-editor.tsx
+++ b/src/management-system-v2/app/(dashboard)/[environmentId]/processes/[processId]/script-editor.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { FC, useEffect, useMemo, useRef, useState } from 'react';
+import { FC, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import dynamic from 'next/dynamic';
 import {
   Modal,
@@ -227,6 +227,14 @@ const ScriptEditor: FC<ScriptEditorProps> = ({ processId, open, onClose, selecte
     }
   };
 
+  const blocklyOnChange = useCallback(
+    (isScriptValid: boolean | ((prevState: boolean) => boolean), code: any) => {
+      if (code.xml && initialScript !== code.xml) setHasUnsavedChanges(true);
+      setIsScriptValid(isScriptValid);
+    },
+    [initialScript],
+  );
+
   return (
     <Modal
       open={open}
@@ -373,7 +381,7 @@ const ScriptEditor: FC<ScriptEditorProps> = ({ processId, open, onClose, selecte
                         target="_blank"
                         rel="noopener"
                       >
-                        Open Script Task API
+                        Open Script Task AP
                       </Button>
                     </Tooltip>
                   </Space>
@@ -456,18 +464,7 @@ const ScriptEditor: FC<ScriptEditorProps> = ({ processId, open, onClose, selecte
                   <BlocklyEditor
                     editorRef={blocklyRef}
                     initialXml={initialScript}
-                    onChange={(
-                      isScriptValid: boolean | ((prevState: boolean) => boolean),
-                      code: any,
-                    ) => {
-                      if (
-                        (code.xml && initialScript !== code.xml) ||
-                        (code.ts && initialScript !== code.ts)
-                      ) {
-                        setHasUnsavedChanges(true);
-                      }
-                      setIsScriptValid(isScriptValid);
-                    }}
+                    onChange={blocklyOnChange}
                     blocklyOptions={{
                       readOnly: !canEdit,
                     }}

--- a/src/management-system-v2/app/(dashboard)/[environmentId]/processes/[processId]/script-editor.tsx
+++ b/src/management-system-v2/app/(dashboard)/[environmentId]/processes/[processId]/script-editor.tsx
@@ -302,7 +302,13 @@ const ScriptEditor: FC<ScriptEditorProps> = ({ processId, open, onClose, selecte
                     style={{ display: 'flex', justifyContent: 'center', marginBottom: '1rem' }}
                   >
                     <Tooltip title="Open Script Task API for further reference">
-                      <Button> Open Script Task API </Button>
+                      <Button
+                        href="https://docs.proceed-labs.org/developer/bpmn/bpmn-script-task#api"
+                        target="_blank"
+                        rel="noopener"
+                      >
+                        Open Script Task API
+                      </Button>
                     </Tooltip>
                   </Space>
                   <div

--- a/src/management-system-v2/app/(dashboard)/[environmentId]/processes/[processId]/script-editor.tsx
+++ b/src/management-system-v2/app/(dashboard)/[environmentId]/processes/[processId]/script-editor.tsx
@@ -247,6 +247,9 @@ const ScriptEditor: FC<ScriptEditorProps> = ({ processId, open, onClose, selecte
           )}
         </Space>
       }
+      afterOpenChange={(open) => {
+        if (open && selectedEditor === 'blockly') blocklyRef.current?.fillContainer();
+      }}
     >
       {/* Error display */}
       {isError && (

--- a/src/management-system-v2/app/(dashboard)/[environmentId]/processes/[processId]/script-editor.tsx
+++ b/src/management-system-v2/app/(dashboard)/[environmentId]/processes/[processId]/script-editor.tsx
@@ -74,6 +74,7 @@ const ScriptEditor: FC<ScriptEditorProps> = ({ processId, open, onClose, selecte
     setHasUnsavedChanges(false);
     setInitialScript('');
     setSelectedEditor(null);
+    setIsScriptValid(true);
     if (filename && open) {
       // Check if script is stored in JS or blockly and set script and selected editor accordingly
       getProcessScriptTaskData(processId, filename, 'ts', environment.spaceId).then((res) => {

--- a/src/management-system-v2/app/(dashboard)/[environmentId]/processes/[processId]/script-editor.tsx
+++ b/src/management-system-v2/app/(dashboard)/[environmentId]/processes/[processId]/script-editor.tsx
@@ -97,13 +97,10 @@ const ScriptEditor: FC<ScriptEditorProps> = ({ processId, open, onClose, selecte
 
       return [script, scriptType] as const;
     },
+    // Refetch on close to update the script if it was changed
+    enabled: !open,
     queryKey: ['processScriptTaskData', environment.spaceId, processId, filename],
   });
-
-  useEffect(() => {
-    // Fetch the data for the script task when the element is selected in the editor
-    if (!open) refetch();
-  }, [open, refetch]);
 
   useEffect(() => {
     setHasUnsavedChanges(false);

--- a/src/management-system-v2/app/(dashboard)/[environmentId]/processes/[processId]/script-editor.tsx
+++ b/src/management-system-v2/app/(dashboard)/[environmentId]/processes/[processId]/script-editor.tsx
@@ -440,6 +440,7 @@ const ScriptEditor: FC<ScriptEditorProps> = ({ processId, open, onClose, selecte
                       readOnly: !canEdit,
                     }}
                     onMount={handleEditorMount}
+                    onChange={() => setHasUnsavedChanges(true)}
                     className="Hide-Scroll-Bar"
                   />
                 ) : (

--- a/src/management-system-v2/app/(dashboard)/[environmentId]/processes/[processId]/script-editor.tsx
+++ b/src/management-system-v2/app/(dashboard)/[environmentId]/processes/[processId]/script-editor.tsx
@@ -235,14 +235,6 @@ const ScriptEditor: FC<ScriptEditorProps> = ({ processId, open, onClose, selecte
     }
   };
 
-  const blocklyOnChange = useCallback(
-    (isScriptValid: boolean | ((prevState: boolean) => boolean), code: any) => {
-      if (code.xml && initialScript !== code.xml) setHasUnsavedChanges(true);
-      setIsScriptValid(isScriptValid);
-    },
-    [initialScript],
-  );
-
   return (
     <Modal
       open={open}
@@ -472,7 +464,11 @@ const ScriptEditor: FC<ScriptEditorProps> = ({ processId, open, onClose, selecte
                   <BlocklyEditor
                     editorRef={blocklyRef}
                     initialXml={initialScript}
-                    onChange={blocklyOnChange}
+                    onChange={(isScriptValid, code) => {
+                      if (code.xml && initialScript !== code.xml) setHasUnsavedChanges(true);
+
+                      setIsScriptValid(isScriptValid);
+                    }}
                     blocklyOptions={{
                       readOnly: !canEdit,
                     }}


### PR DESCRIPTION
## Summary

### Changes to the modeler

- disable keyboard in modeler when any modal is open
- global canEdit context consumed by task editor and script editor

### Changes to the script editor

- disable editing when version is selected
- correctly handle isScriptValid and if script has changed (this was achieved by other changes that are also listed in this pr)
- add link to docs for normal script editor and for blockly
- use react-query for fetching script, which enables a loading animation and easier error display
- animation + feedback when saving
- track unsaved changes for JS scripts
- correctly discard unsaved changes
- correct blockly size after modal is reopened

### Changes to the blockly editor (inside the script editor)

- functions to fill container size
- blockly onChange is only called when there are changes in the xml and not when the onChange function changes
- always automatically scroll to center

There where some complications in the way the script is fetched:

In order to discard unsaved changes there are two approaches:

1. Always fetch the script when the modal is opened
2. Restore to the script which was fetched when the modal was opened (this has to be updated when the script is saved, however updating it isn't trivial as it causes a rerender in the editors and changes the scroll)

My approach works this way (through react-query):

- whenever a script block is selected in the modeler the script is fetched.
- whenever the modal is closed the script is refetched (and isn't fetched again if the modal is immediately reopened)

This could have been achieved with fewer fetches by updating the query, but the code would be way more verbose and harder to maintain.

## Known issues

The react-blockly library doesn't handle the case when readOnly changes, so this will lead to issues when it changes and the blockly editor isn't remounted.
