### PR TITLE
Fix: clould-sql-issues

### DIFF
--- a/.github/workflows/deploy_with_db.yml
+++ b/.github/workflows/deploy_with_db.yml
@@ -369,7 +369,6 @@ jobs:
           key: ${{ github.sha }}-${{ github.run_number }}
 
       - name: Apply Prisma Migrations
-        if: steps.db-status.outputs.create_db == 'true'
         env:
           DATABASE_URL: ${{ steps.configure-connection.outputs.DATABASE_URL }}
         run: |
@@ -384,7 +383,7 @@ jobs:
           flags: '--add-cloudsql-instances=${{secrets.INSTANCE_CONNECTION_NAME}}'
           env_vars: |
             NEXTAUTH_URL=https://${{ env.SUBDOMAIN }}.proceed-labs.org
-            DATABASE_URL=postgresql://${{ secrets.CLOUD_SQL_DB_USER }}:${{secrets.CLOUD_SQL_DB_PASS}}@localhost/${{ secrets.CLOUD_SQL_DB_NAME }}?host=/cloudsql/${{secrets.INSTANCE_CONNECTION_NAME}}/
+            DATABASE_URL=postgresql://${{ secrets.CLOUD_SQL_DB_USER }}:${{secrets.CLOUD_SQL_DB_PASS}}@localhost/${{ secrets.CLOUD_SQL_DB_NAME }}?host=/cloudsql/${{secrets.INSTANCE_CONNECTION_NAME}}&schema=public
             PROCEED_PUBLIC_DEPLOYMENT_ENV=local
           region: 'europe-west1'
           revision_traffic: LATEST=100

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,32 +2,8 @@ services:
   management_system:
     image: proceed/ms-server:${MS_TAG:-edge}
     container_name: management_system
-    environment:
-      - NEXTAUTH_URL=http://localhost:3000
-      - NEXTAUTH_SECRET=T8VB/r1dw0kJAXjanUvGXpDb+VRr4dV5y59BT9TBqiQ=
-
-      - ENABLE_MACHINE_CONFIG=true
-      - PROCEED_PUBLIC_NEW_LAYOUT=true
-      - PROCEED_PUBLIC_ENABLE_EXECUTION=true
-      - INVITATION_ENCRYPTION_SECRET=T8VB/r1dw0kJAXjanUvGXpDb+VRr4dV5y59BT9TBqiQ=
-      - SMTP_MAIL_HOST=
-      - SMTP_MAIL_PORT=
-      - SMTP_MAIL_USER=
-      - SMTP_MAIL_PASSWORD=T8VB/r1dw0kJAXjanUvGXpDb+VRr4dV5y59BT9TBqiQ=
-      - USE_AUTH0=false
-      - AUTH0_CLIENT_ID=
-      - AUTH0_CLIENT_SECRET=
-      - AUTH0_ISSUER=
-      - AUTH0_SCOPE=
-      - GOOGLE_CLIENT_ID=
-      - GOOGLE_CLIENT_SECRET=
-      - DISCORD_CLIENT_ID=
-      - DISCORD_CLIENT_SECRET=
-      - TWITTER_CLIENT_ID=
-      - TWITTER_CLIENT_SECRET=
-      - SHARING_ENCRYPTION_SECRET=T8VB/r1dw0kJAXjanUvGXpDb+VRr4dV5y59BT9TBqiQ=
-      - GUEST_REFERENCE_SECRET=T8VB/r1dw0kJAXjanUvGXpDb+VRr4dV5y59BT9TBqiQ=
-      - DATABASE_URL=postgresql://proceed:proceed@postgres:5432/proceed_db?schema=public
+    env_file:
+      - .env
     ports:
       - '3000:33081'
     depends_on:


### PR DESCRIPTION
Deployment of proceed-ms on cloud run with Cloud SQL db involves two steps :
1. Applying db migrations from GitHub pipeline
--> here we setup a Cloud SQL proxy on a docker container and use a local tcp connection to connect prisma with Cloud SQL proxy. The proxy takes care of the authentication and forwarding request to the google database server.
The connection string uses a url encoded password as our previous password had special characters. 

2. Connecting to Cloud SQL from cloud run
--> Here we are have to use the unix sockets. `/cloudsql/<Instance_connection_str>`,
 Google's Documentation says for postgres instance we have to use `/cloudsql/INSTANCE_CONNECTION_NAME/.s.PGSQL.5432`. This does not work. **Avoiding .s.PGSQL.5432 is the way to go.** The prisma's pg unix client **does not work** with url encoded password.