### PR TITLE
ms2/iam config

### DIFF
--- a/src/management-system-v2/app/(dashboard)/[environmentId]/layout-client.tsx
+++ b/src/management-system-v2/app/(dashboard)/[environmentId]/layout-client.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import styles from './layout.module.scss';
-import { FC, PropsWithChildren, createContext, useEffect, useState } from 'react';
+import { FC, PropsWithChildren, createContext, use, useEffect, useState } from 'react';
 import { Layout as AntLayout, Button, Drawer, Grid, Menu, MenuProps, Tooltip } from 'antd';
 import { AppstoreOutlined } from '@ant-design/icons';
 import Image from 'next/image';
@@ -19,6 +19,7 @@ import { FaUserEdit } from 'react-icons/fa';
 import { useFileManager } from '@/lib/useFileManager';
 import { EntityType } from '@/lib/helpers/fileManagerHelpers';
 import { enableUseFileManager } from 'FeatureFlags';
+import { EnvVarsContext } from '@/components/env-vars-context';
 
 export const useLayoutMobileDrawer = create<{ open: boolean; set: (open: boolean) => void }>(
   (set) => ({
@@ -62,6 +63,7 @@ const Layout: FC<
   });
   const mobileDrawerOpen = useLayoutMobileDrawer((state) => state.open);
   const setMobileDrawerOpen = useLayoutMobileDrawer((state) => state.set);
+  const envVars = use(EnvVarsContext);
 
   const modelerIsFullScreen = useModelerStateStore((state) => state.isFullScreen);
 
@@ -75,24 +77,29 @@ const Layout: FC<
     );
 
     if (userData && !userData.isGuest) {
+      const mobileLayoutItems = [];
+
+      if (envVars.PROCEED_PUBLIC_IAM_ACTIVATE) {
+        mobileLayoutItems.push({
+          key: 'profile',
+          title: 'Profile Settings',
+          label: <SpaceLink href={`/profile`}>Profile Settings</SpaceLink>,
+          icon: <FaUserEdit />,
+        });
+      }
+
+      mobileLayoutItems.push({
+        key: 'spaces',
+        title: 'My Spaces',
+        label: <SpaceLink href={`/spaces`}>My Spaces</SpaceLink>,
+        icon: <AppstoreOutlined />,
+      });
+
       layoutMenuItems = [
         {
           label: 'Profile',
           key: 'profile-settings',
-          children: [
-            {
-              key: 'profile',
-              title: 'Profile Settings',
-              label: <SpaceLink href={`/profile`}>Profile Settings</SpaceLink>,
-              icon: <FaUserEdit />,
-            },
-            {
-              key: 'spaces',
-              title: 'My Spaces',
-              label: <SpaceLink href={`/spaces`}>My Spaces</SpaceLink>,
-              icon: <AppstoreOutlined />,
-            },
-          ],
+          children: mobileLayoutItems,
         },
         ...layoutMenuItems,
       ];

--- a/src/management-system-v2/app/(dashboard)/[environmentId]/profile/page.tsx
+++ b/src/management-system-v2/app/(dashboard)/[environmentId]/profile/page.tsx
@@ -2,7 +2,8 @@ import { getCurrentUser } from '@/components/auth';
 import UserProfile from './user-profile';
 import Content from '@/components/content';
 import { getUserById } from '@/lib/data/DTOs';
-import { User } from '@/lib/data/user-schema';
+import { env } from '@/lib/env-vars';
+import { notFound } from 'next/navigation';
 
 const ProfilePage = async () => {
   const { userId } = await getCurrentUser();
@@ -10,6 +11,8 @@ const ProfilePage = async () => {
   //TODO take guest into consideration
 
   const userData = await getUserById(userId);
+
+  if (!env.PROCEED_PUBLIC_IAM_ACTIVATE) return notFound();
 
   return (
     <Content>

--- a/src/management-system-v2/app/admin/users/user-table.tsx
+++ b/src/management-system-v2/app/admin/users/user-table.tsx
@@ -18,7 +18,7 @@ export default function UserTable({
   users: {
     isGuest: false;
     id: string;
-    email?: string;
+    email?: string | null;
     username?: string;
     firstName?: string;
     lastName?: string;

--- a/src/management-system-v2/app/change-email/change-email-card.tsx
+++ b/src/management-system-v2/app/change-email/change-email-card.tsx
@@ -5,14 +5,13 @@ import { useState } from 'react';
 import { changeEmail as serverChangeEmail } from '@/lib/change-email/server-actions';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { ArrowRightOutlined } from '@ant-design/icons';
-import Content from '@/components/content';
 import { useSession } from 'next-auth/react';
 
 export default function ChangeEmailCard({
   previousEmail,
   newEmail,
 }: {
-  previousEmail?: string;
+  previousEmail?: string | null;
   newEmail: string;
 }) {
   const { message } = App.useApp();

--- a/src/management-system-v2/components/app.tsx
+++ b/src/management-system-v2/components/app.tsx
@@ -1,28 +1,42 @@
 'use client';
 
-import { ReactNode } from 'react';
+import { ReactNode, useEffect } from 'react';
 import Theme from './theme';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 import { App as AntDesignApp } from 'antd';
-import { SessionProvider } from 'next-auth/react';
-import { PublicEnv } from '@/lib/env-vars';
+import { SessionProvider, getSession, signIn, useSession } from 'next-auth/react';
+import { PublicEnv, publicEnv } from '@/lib/env-vars';
 import { EnvVarsProvider } from './env-vars-context';
 
 const queryClient = new QueryClient();
 
+const SignInToDefaultUser = () => {
+  // When iam is deactivated, a user is hardcoded everywhere,
+  // however we still need the useSession hook to return a valid session
+  // which doesn't happen when the user doesn't have a session cookie.
+  // Afterwards, regardless of the session we will return the default user.
+  const session = useSession();
+  useEffect(() => {
+    if (session.status === 'unauthenticated') signIn('no-iam-user');
+  }, [session]);
+
+  return null;
+};
+
 const App = ({ children, env }: { children: ReactNode; env: PublicEnv }) => {
   return (
-    <EnvVarsProvider env={env}>
-      <SessionProvider>
+    <SessionProvider>
+      {!env.PROCEED_PUBLIC_IAM_ACTIVATE && <SignInToDefaultUser />}
+      <EnvVarsProvider env={env}>
         <QueryClientProvider client={queryClient}>
           <ReactQueryDevtools initialIsOpen={false} />
           <AntDesignApp>
             <Theme>{children}</Theme>
           </AntDesignApp>
         </QueryClientProvider>
-      </SessionProvider>
-    </EnvVarsProvider>
+      </EnvVarsProvider>
+    </SessionProvider>
   );
 };
 

--- a/src/management-system-v2/components/auth.tsx
+++ b/src/management-system-v2/components/auth.tsx
@@ -11,8 +11,18 @@ import {
   packedGlobalOrganizationRules,
   packedGlobalUserRules,
 } from '@/lib/authorization/globalRules';
+import { env } from '@/lib/env-vars';
+import * as noIamUser from '@/lib/no-iam-user';
 
 export const getCurrentUser = cache(async () => {
+  if (!env.PROCEED_PUBLIC_IAM_ACTIVATE) {
+    return {
+      session: noIamUser.session,
+      userId: noIamUser.userId,
+      systemAdmin: noIamUser.systemAdmin,
+    };
+  }
+
   const session = await getServerSession(nextAuthOptions);
   const userId = session?.user.id || '';
   const systemAdmin = await getSystemAdminByUserId(userId);

--- a/src/management-system-v2/components/user-avatar.tsx
+++ b/src/management-system-v2/components/user-avatar.tsx
@@ -11,10 +11,9 @@ type UserAvatarProps = {
     firstName?: string | null;
     lastName?: string | null;
   };
-  avatarProps?: ComponentProps<typeof AntDesignAvatar>;
-};
+} & ComponentProps<typeof AntDesignAvatar>;
 
-const UserAvatar = forwardRef<HTMLElement, UserAvatarProps>(({ user, avatarProps }, ref) => {
+const UserAvatar = forwardRef<HTMLElement, UserAvatarProps>(({ user, ...props }, ref) => {
   if (!user) return <AntDesignAvatar />;
 
   if (user.isGuest) return <AntDesignAvatar icon={<UserOutlined />} />;
@@ -50,7 +49,7 @@ const UserAvatar = forwardRef<HTMLElement, UserAvatarProps>(({ user, avatarProps
           </Typography.Text>
         </>
       }
-      {...avatarProps}
+      {...props}
       ref={ref}
     ></AntDesignAvatar>
   );

--- a/src/management-system-v2/instrumentation.ts
+++ b/src/management-system-v2/instrumentation.ts
@@ -1,0 +1,9 @@
+export async function register() {
+  // Register default admin user if IAM is not activated
+  if (process.env.NEXT_RUNTIME === 'nodejs') {
+    const { userId, createUserArgs } = await import('./lib/no-iam-user');
+    const { addUser, getUserById } = await import('./lib/data/db/iam/users');
+
+    if (!process.env.IAM_ACTIVATE && !(await getUserById(userId))) await addUser(createUserArgs);
+  }
+}

--- a/src/management-system-v2/lib/data/db/iam/users.ts
+++ b/src/management-system-v2/lib/data/db/iam/users.ts
@@ -67,7 +67,7 @@ export async function addUser(inputUser: OptionalKeys<User, 'id'>) {
   if (
     !user.isGuest &&
     ((user.username && (await getUserByUsername(user.username))) ||
-      (await getUserByEmail(user.email!)))
+      (user.email && (await getUserByEmail(user.email!))))
   )
     throw new Error('User with this email or username already exists');
 

--- a/src/management-system-v2/lib/data/user-schema.ts
+++ b/src/management-system-v2/lib/data/user-schema.ts
@@ -31,7 +31,7 @@ export const AuthenticatedUserSchema = AuthenticatedUserDataSchema.extend({
   // NOTE: maybe email should be moved to user data as the user could change their email
   // TODO: email is optional because Twitter doesn't return an email for the time being,
   // once it does this type should be non-optional and the commit d34be03d9a89cd11418f4b550a04b3664ce1de71 reverted
-  email: z.string().optional(),
+  email: z.string().optional().nullable(),
   emailVerifiedOn: z.date().nullable(),
 });
 export type AuthenticatedUser = z.infer<typeof AuthenticatedUserSchema> & { id: string };

--- a/src/management-system-v2/lib/env-vars.ts
+++ b/src/management-system-v2/lib/env-vars.ts
@@ -33,6 +33,8 @@ const environmentVariables = {
     MQTT_USERNAME: z.string().optional(),
     MQTT_PASSWORD: z.string().optional(),
     MQTT_BASETOPIC: z.string().optional(),
+
+    PROCEED_PUBLIC_IAM_ACTIVATE: z.string().optional(),
   },
   production: {
     NEXTAUTH_SECRET: z.string(),

--- a/src/management-system-v2/lib/no-iam-user.ts
+++ b/src/management-system-v2/lib/no-iam-user.ts
@@ -1,0 +1,40 @@
+import type { User as UserDB, SystemAdmin } from '@prisma/client';
+import type { addUser } from '@/lib/data/db/iam/users';
+import { Session } from 'next-auth';
+
+export const userId = 'proceed-default-no-iam-user';
+
+export const user = {
+  id: userId,
+  firstName: 'Admin',
+  lastName: 'Admin',
+  username: 'default',
+  email: null,
+  isGuest: false,
+  emailVerifiedOn: null,
+  image: null,
+  favourites: [],
+} satisfies UserDB;
+
+export const createUserArgs = {
+  id: userId,
+  firstName: user.firstName,
+  lastName: user.lastName,
+  username: user.username,
+  emailVerifiedOn: null,
+  isGuest: false,
+} satisfies Parameters<typeof addUser>[0];
+
+export const session = {
+  user,
+  expires: '',
+  csrfToken: 'csrf-token',
+} satisfies Session;
+
+export const systemAdmin = {
+  id: userId,
+  userId: userId,
+  role: 'admin',
+  lastEditedOn: new Date(),
+  createdOn: new Date(),
+} satisfies SystemAdmin;

--- a/src/management-system-v2/next.config.js
+++ b/src/management-system-v2/next.config.js
@@ -5,6 +5,7 @@ const nextConfig = {
   output: 'standalone',
   experimental: {
     outputFileTracingRoot: path.join(__dirname, '../../'),
+    instrumentationHook: true,
   },
   /**
    *


### PR DESCRIPTION
## Summary

introduced new env var `PROCEED_PUBLIC_IAM_ACTIVATE` to deactivate any IAM feature in the MS.

This is done through hardcoding a default user in the following places:

- getCurrentUser
- NextAuth jwt callback

Additionally, I had to add a new NextAuth provider to sign in to the default user, whenever a user isn't signed in, they're signed in with this default user.
This is necessary because some portions of the ms rely on the clientside `useSession` hook from NextAuth, this hook returns no data when the user isn't signed in at all. If they where signed in, it would show the hardcoded session data.
