### PR TITLE
style(ms2): made colorBgContainerDisabled a solid color

### DIFF
--- a/src/management-system-v2/components/theme.tsx
+++ b/src/management-system-v2/components/theme.tsx
@@ -34,6 +34,7 @@ const Theme: FC<PropsWithChildren> = ({ children }) => {
           screenXSMax: 600,
           colorInfoBg: '#fafafa', // gray-3 (ant design colors)
           colorInfoBorder: '#d9d9d9', // gray-2 (ant design colors)
+          colorBgContainerDisabled: 'rgb(245,245,245)', // rgba(0,0,0,0.04) assuming white bg -> rgb(245,245,245)
         },
         components: {
           Layout: {

--- a/src/management-system-v2/components/toolbar.tsx
+++ b/src/management-system-v2/components/toolbar.tsx
@@ -2,7 +2,7 @@
 
 import React, { PropsWithChildren } from 'react';
 
-import { Space } from 'antd';
+import { Space, theme } from 'antd';
 
 type ToolbarProps = {
   className?: string;
@@ -13,7 +13,12 @@ export const Toolbar: React.FC<PropsWithChildren<ToolbarProps>> = ({ children, c
     <div
       role="toolbar"
       className={className}
-      style={{ position: 'absolute', zIndex: 10, padding: '12px', width: '100%' }}
+      style={{
+        position: 'absolute',
+        zIndex: 10,
+        padding: '12px',
+        width: '100%',
+      }}
     >
       {children}
     </div>
@@ -21,5 +26,15 @@ export const Toolbar: React.FC<PropsWithChildren<ToolbarProps>> = ({ children, c
 };
 
 export const ToolbarGroup: React.FC<PropsWithChildren> = ({ children }) => {
-  return <Space.Compact size="large">{children}</Space.Compact>;
+  const { token } = theme.useToken();
+  return (
+    <Space.Compact
+      size="large"
+      style={{
+        backgroundColor: token.colorBgContainer,
+      }}
+    >
+      {children}
+    </Space.Compact>
+  );
 };


### PR DESCRIPTION
closes #547 

The disabled background color was transparent, I transformed it to a solid color assuming a white background.

![image](https://github.com/user-attachments/assets/7e37100d-76a4-453f-824e-5f29743bd4a4)

The gap in right toolbar happened because the group didn't have a backgroundcolor, I fixed it by using token.colorBgContainer

![image](https://github.com/user-attachments/assets/3ec4a948-a59c-48d8-abff-05fedb29cbf3)
