### PR TITLE
XOR Gateway Conditions

### DIFF
--- a/src/engine/universal/system/src/script-execution.js
+++ b/src/engine/universal/system/src/script-execution.js
@@ -135,6 +135,13 @@ class ScriptExecutor extends System {
       };
       this.setProcess(processId, processInstanceId, scriptIdentifier, processEntry);
 
+      // inline global variables
+      for (const key in dependencies) {
+        if (typeof dependencies[key] !== 'object' && typeof dependencies[key] !== 'function') {
+          scriptString = `const ${key} = ${dependencies[key]};\n` + scriptString;
+        }
+      }
+
       const subprocessLaunchReqId = generateUniqueTaskID();
 
       this.commandRequest(subprocessLaunchReqId, [

--- a/src/management-system-v2/app/(dashboard)/[environmentId]/processes/[processId]/flow-condition-modal.module.scss
+++ b/src/management-system-v2/app/(dashboard)/[environmentId]/processes/[processId]/flow-condition-modal.module.scss
@@ -1,0 +1,6 @@
+.DisabledConditionInput {
+  :global(.view-lines) {
+    cursor: not-allowed;
+    background-color: #d9d9d9;
+  }
+}

--- a/src/management-system-v2/app/(dashboard)/[environmentId]/processes/[processId]/flow-condition-modal.tsx
+++ b/src/management-system-v2/app/(dashboard)/[environmentId]/processes/[processId]/flow-condition-modal.tsx
@@ -1,0 +1,173 @@
+import React, { useEffect, useRef, useState } from 'react';
+
+import { is as bpmnIs, Element } from 'bpmn-js/lib/util/ModelUtil';
+import { Checkbox, Form, Input, Modal } from 'antd';
+import useModelerStateStore from './use-modeler-state-store';
+import { Editor, Monaco } from '@monaco-editor/react';
+import * as monaco from 'monaco-editor';
+import languageExtension from './languageExtension.js';
+import styles from './flow-condition-modal.module.scss';
+import cn from 'classnames';
+
+export function isConditionalFlow(element?: Element) {
+  return (
+    element &&
+    bpmnIs(element, 'bpmn:SequenceFlow') &&
+    element.source &&
+    bpmnIs(element.source, 'bpmn:ExclusiveGateway')
+  );
+}
+
+function isDefaultFlow(element?: Element) {
+  if (!element || !isConditionalFlow(element)) return false;
+
+  return element.source.businessObject.default === element.businessObject;
+}
+
+function getConditionString(element?: Element) {
+  if (!element || !isConditionalFlow(element)) return '';
+
+  return element.businessObject.conditionExpression
+    ? element.businessObject.conditionExpression.body
+    : '';
+}
+
+type FlowConditionModalProps = {
+  element?: Element;
+  open: boolean;
+  onClose: () => void;
+};
+
+const FlowConditionModal: React.FC<FlowConditionModalProps> = ({ element, open, onClose }) => {
+  const [description, setDescription] = useState('');
+  const [isDefault, setIsDefault] = useState(false);
+
+  const monacoEditorRef = useRef<null | monaco.editor.IStandaloneCodeEditor>(null);
+  const monacoRef = useRef<null | Monaco>(null);
+
+  const modeler = useModelerStateStore((state) => state.modeler);
+
+  useEffect(() => {
+    if (element && isConditionalFlow(element)) {
+      setDescription(element.businessObject.name);
+      setIsDefault(isDefaultFlow(element));
+      monacoEditorRef.current?.setValue(getConditionString(element));
+    }
+  }, [element, open]);
+
+  const handleEditorMount = (editor: monaco.editor.IStandaloneCodeEditor, monaco: Monaco) => {
+    monacoEditorRef.current = editor;
+    monacoRef.current = monaco;
+
+    const defaultOptions =
+      monacoRef.current.languages.typescript.javascriptDefaults.getCompilerOptions();
+
+    monacoRef.current.languages.typescript.javascriptDefaults.setCompilerOptions({
+      ...defaultOptions,
+      target: monacoRef.current.languages.typescript.ScriptTarget.ES2017,
+      lib: ['es2017'],
+    });
+
+    monacoEditorRef.current.setValue(getConditionString(element));
+
+    monacoRef.current.languages.typescript.javascriptDefaults.addExtraLib(languageExtension);
+    monacoRef.current.editor.createModel(languageExtension, 'typescript');
+
+    editor.onKeyDown((e) => {
+      if (e.keyCode == monaco.KeyCode.Enter) e.preventDefault();
+    });
+  };
+
+  const handleSubmit = () => {
+    if (!modeler || !element) return;
+
+    const modeling = modeler.getModeling();
+    const factory = modeler.getFactory();
+
+    if (isDefault) {
+      modeling.updateProperties(element.source, {
+        default: element.businessObject,
+      });
+    }
+    if (!isDefault && isDefaultFlow(element)) {
+      modeling.updateProperties(element.source, {
+        default: null,
+      });
+    }
+
+    const condition = monacoEditorRef.current?.getValue();
+    const conditionExpression =
+      condition && !isDefault ? factory.create('bpmn:FormalExpression', { body: condition }) : null;
+    modeling.updateProperties(element, {
+      name: description,
+      conditionExpression,
+    });
+
+    onClose();
+  };
+
+  return (
+    <>
+      <Modal
+        open={open}
+        centered
+        title={<span style={{ fontSize: '1.5rem' }}>Gateway Condition</span>}
+        onCancel={() => onClose()}
+        onOk={() => handleSubmit()}
+      >
+        <Form layout="vertical">
+          <Form.Item label="Description">
+            <Input value={description} onChange={(e) => setDescription(e.target.value)} />
+          </Form.Item>
+          <Form.Item label="Condition">
+            <div
+              style={{
+                border: '1px solid #d9d9d9',
+                height: '32px',
+                padding: '0.25rem 0.6875rem',
+                borderRadius: '0.375rem',
+                cursor: isDefault ? 'not-allowed' : undefined,
+                backgroundColor: isDefault ? '#d9d9d9' : undefined,
+              }}
+            >
+              <Editor
+                defaultValue=""
+                defaultLanguage="typescript"
+                theme="vs-light"
+                options={{
+                  readOnly: isDefault,
+                  automaticLayout: true,
+                  fontSize: 14,
+                  wordWrap: 'off',
+                  lineNumbers: 'off',
+                  lineNumbersMinChars: 0,
+                  overviewRulerLanes: 0,
+                  lineDecorationsWidth: 0,
+                  hideCursorInOverviewRuler: true,
+                  glyphMargin: false,
+                  folding: false,
+                  scrollBeyondLastColumn: 0,
+                  scrollbar: { horizontal: 'hidden', vertical: 'hidden' },
+                  renderLineHighlight: 'none',
+                  find: {
+                    addExtraSpaceOnTop: false,
+                    autoFindInSelection: 'never',
+                    seedSearchStringFromSelection: 'never',
+                  },
+                  minimap: { enabled: false },
+                }}
+                onMount={handleEditorMount}
+                className={cn({ [styles.DisabledConditionInput]: isDefault })}
+              />
+            </div>
+          </Form.Item>
+          <Form.Item label="Default">
+            <Checkbox checked={isDefault} onChange={(e) => setIsDefault(e.target.checked)} />
+          </Form.Item>
+        </Form>
+      </Modal>
+    </>
+  );
+};
+
+export default FlowConditionModal;

--- a/src/management-system-v2/app/(dashboard)/[environmentId]/processes/[processId]/modeler-toolbar.tsx
+++ b/src/management-system-v2/app/(dashboard)/[environmentId]/processes/[processId]/modeler-toolbar.tsx
@@ -32,6 +32,7 @@ import ScriptEditor from '@/app/(dashboard)/[environmentId]/processes/[processId
 import { handleOpenDocumentation } from '../processes-helper';
 import { EnvVarsContext } from '@/components/env-vars-context';
 import { Process } from '@/lib/data/process-schema';
+import FlowConditionModal, { isConditionalFlow } from './flow-condition-modal';
 
 const LATEST_VERSION = { id: '-1', name: 'Latest Version', description: '' };
 
@@ -54,6 +55,7 @@ const ModelerToolbar = ({ process, onOpenXmlEditor, canUndo, canRedo }: ModelerT
 
   const [showPropertiesPanel, setShowPropertiesPanel] = useState(false);
   const [showScriptTaskEditor, setShowScriptTaskEditor] = useState(false);
+  const [showFlowNodeConditionModal, setShowFlowNodeConditionModal] = useState(false);
 
   const [shareModalOpen, setShareModalOpen] = useState(false);
   const [shareModalDefaultOpenTab, setShareModalDefaultOpenTab] =
@@ -263,7 +265,15 @@ const ModelerToolbar = ({ process, onOpenXmlEditor, canUndo, canRedo }: ModelerT
                         onClick={() => setShowScriptTaskEditor(true)}
                       />
                     </Tooltip>
-                  )))}
+                  )) ||
+                (env.PROCEED_PUBLIC_ENABLE_EXECUTION && isConditionalFlow(selectedElement) && (
+                  <Tooltip title="Edit Condition">
+                    <Button
+                      icon={<FormOutlined />}
+                      onClick={() => setShowFlowNodeConditionModal(true)}
+                    />
+                  </Tooltip>
+                )))}
           </ToolbarGroup>
 
           <Space style={{ height: '3rem' }}>
@@ -344,6 +354,12 @@ const ModelerToolbar = ({ process, onOpenXmlEditor, canUndo, canRedo }: ModelerT
             open={showScriptTaskEditor}
             onClose={() => setShowScriptTaskEditor(false)}
             selectedElement={selectedElement}
+          />
+
+          <FlowConditionModal
+            open={showFlowNodeConditionModal}
+            onClose={() => setShowFlowNodeConditionModal(false)}
+            element={selectedElement}
           />
         </>
       )}


### PR DESCRIPTION
## Summary

Added UI elements to add conditions to sequence flows that come from an xor gateway.

## Details

- added a button to the modeler toolbar that is shown when a sequence flow is selected which has an exclusive gateway as its source
- added a modal that is opened by clicking the button
  - the modal has a 'description' input that maps to the name attribute of the selected sequence flow
  - the modal has a one line monaco editor as an input for the condition
  - the modal has a checkbox to set if the sequence flow should be the default (taken if no other evaluates to true)
- added functionality that inlines process variables as global variables on the engine when a script is called from the neo-engine that depends on process variables
