### PR TITLE
ms2/organization fixes

### DIFF
--- a/src/management-system-v2/app/(dashboard)/[environmentId]/iam/roles/[roleId]/roleGeneralData.tsx
+++ b/src/management-system-v2/app/(dashboard)/[environmentId]/iam/roles/[roleId]/roleGeneralData.tsx
@@ -28,11 +28,14 @@ const FolderInput = ({
   defaultFolder?: Folder;
 }) => {
   const [modalOpen, setModalOpen] = useState(false);
-  const [selectedFolder, setSelectedFolder] = useState<{ type: string; name: string } | undefined>(
+  const [selectedFolder, setSelectedFolder] = useState<
+    { type: string; name: string; id: string } | undefined
+  >(
     () =>
       defaultFolder && {
         type: 'folder',
         name: defaultFolder.parentId ? defaultFolder.name : '< root >',
+        id: defaultFolder.id,
       },
   );
 
@@ -58,15 +61,15 @@ const FolderInput = ({
           </Button>
           <FolderTree
             newChildrenHook={(nodes) => nodes.filter((node) => node.element.type === 'folder')}
-            treeProps={{
-              onSelect(_, info) {
-                const element = info.node.element;
-                if (element.type !== 'folder') return;
+            onSelect={(element) => {
+              if (element?.type !== 'folder') return;
 
-                onChange?.(element.id);
-                setSelectedFolder(element);
-                setModalOpen(false);
-              },
+              onChange?.(element.id);
+              setSelectedFolder(element);
+              setModalOpen(false);
+            }}
+            treeProps={{
+              selectedKeys: selectedFolder ? [selectedFolder.id] : [],
             }}
             showRootAsFolder
           />

--- a/src/management-system-v2/lib/data/db/folders.ts
+++ b/src/management-system-v2/lib/data/db/folders.ts
@@ -1,11 +1,5 @@
-import Ability from '@/lib/ability/abilityHelper.js';
-import {
-  Folder,
-  FolderInput,
-  FolderSchema,
-  FolderUserInput,
-  FolderUserInputSchema,
-} from '../folder-schema';
+import Ability, { UnauthorizedError } from '@/lib/ability/abilityHelper';
+import { Folder, FolderInput, FolderSchema, FolderUserInput } from '../folder-schema';
 import { toCaslResource } from '@/lib/ability/caslAbility';
 import { v4 } from 'uuid';
 import { Process, ProcessMetadata } from '../process-schema';
@@ -26,7 +20,7 @@ export async function getRootFolder(environmentId: string, ability?: Ability) {
   }
 
   if (ability && !ability.can('view', toCaslResource('Folder', rootFolder))) {
-    throw new Error('Permission denied');
+    throw new UnauthorizedError();
   }
 
   return rootFolder;
@@ -47,7 +41,7 @@ export async function getFolderById(folderId: string, ability?: Ability) {
   }
 
   if (ability && !ability.can('view', toCaslResource('Folder', folder))) {
-    throw new Error('Permission denied');
+    throw new UnauthorizedError();
   }
 
   return folder;
@@ -76,7 +70,7 @@ export async function getFolderChildren(folderId: string, ability?: Ability) {
   }
 
   if (ability && !ability.can('view', toCaslResource('Folder', folder))) {
-    throw new Error('Permission denied');
+    throw new UnauthorizedError();
   }
 
   const combinedResults = [
@@ -124,7 +118,7 @@ export async function createFolder(
 
   // Checks
   if (ability && !ability.can('create', toCaslResource('Folder', folder)))
-    throw new Error('Permission denied');
+    throw new UnauthorizedError();
 
   const existingFolder = await db.folder.findUnique({
     where: {
@@ -197,7 +191,7 @@ export async function deleteFolder(folderId: string, ability?: Ability) {
   }
 
   if (ability && !ability.can('delete', toCaslResource('Folder', folderToDelete))) {
-    throw new Error('Permission denied');
+    throw new UnauthorizedError();
   }
 
   await db.folder.delete({
@@ -221,7 +215,7 @@ export async function updateFolderMetaData(
   }
 
   if (ability && !ability.can('update', toCaslResource('Folder', folder))) {
-    throw new Error('Permission denied');
+    throw new UnauthorizedError();
   }
 
   if (newMetaDataInput.environmentId && newMetaDataInput.environmentId !== folder.environmentId) {
@@ -302,7 +296,7 @@ export async function moveFolder(folderId: string, newParentId: string, ability?
       ability.can('update', toCaslResource('Folder', folder.parentFolder!))
     )
   ) {
-    throw new Error('Permission denied');
+    throw new UnauthorizedError();
   }
 
   // Check if moving to its own subtree
@@ -355,7 +349,7 @@ export async function moveProcess(processId: string, newParentId: string, abilit
       ability.can('update', toCaslResource('Folder', oldParentFolder!))
     )
   ) {
-    throw new Error('Permission denied');
+    throw new UnauthorizedError();
   }
 
   // Update process

--- a/src/management-system-v2/lib/data/processes.tsx
+++ b/src/management-system-v2/lib/data/processes.tsx
@@ -216,6 +216,7 @@ export const addProcesses = async (
       bpmn,
       creatorId: userId,
       environmentId: activeEnvironment.spaceId,
+      folderId: value.folderId,
     };
 
     if (!ability.can('create', toCaslResource('Process', newProcess))) {

--- a/src/management-system-v2/prisma/migrations/20250609094719_fix_add_parent_id_ro_roles/migration.sql
+++ b/src/management-system-v2/prisma/migrations/20250609094719_fix_add_parent_id_ro_roles/migration.sql
@@ -1,0 +1,5 @@
+-- AlterTable
+ALTER TABLE "role" ADD COLUMN     "parentId" TEXT;
+
+-- AddForeignKey
+ALTER TABLE "role" ADD CONSTRAINT "role_parentId_fkey" FOREIGN KEY ("parentId") REFERENCES "folder"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/src/management-system-v2/prisma/schema.prisma
+++ b/src/management-system-v2/prisma/schema.prisma
@@ -175,6 +175,7 @@ model Folder {
   childrenFolder Folder[]  @relation("folderChildren")
   lastEditedOn   DateTime  @updatedAt
   createdOn      DateTime
+  roles          Role[]
 
   @@map("folder")
 }
@@ -205,6 +206,8 @@ model Role {
   default       Boolean?
   createdOn     DateTime
   lastEditedOn  DateTime  @updatedAt
+  parentId      String?
+  parentFolder  Folder? @relation(fields: [parentId], references: [id], onDelete: Cascade)
 
   members RoleMember[]
 


### PR DESCRIPTION
## Summary

Some fixes for organizations and some refactoring.

## Details

- role page: fix select role folder.
- role schema: add missing `parentId` field.
- processes: fix permission check for folder scoped roles, the object that is passed to the ability needed to have the `folderId` property.
- refactor folder/db: use `UnauthroizedError`. This allows the ms to show an appropriate error ui to the user when he doesn't have access to a folder.
