### PR TITLE
fix+refactor(ms2/useColumnWidth): infinite rerenders + removed a lot of memoization

### DIFF
--- a/src/management-system-v2/lib/useColumnWidth.tsx
+++ b/src/management-system-v2/lib/useColumnWidth.tsx
@@ -1,14 +1,5 @@
-import { TableColumnsType, TableProps, Tooltip, Typography } from 'antd';
-import React, {
-  FC,
-  PropsWithChildren,
-  ReactNode,
-  useCallback,
-  useEffect,
-  useMemo,
-  useRef,
-  useState,
-} from 'react';
+import { TableColumnsType, TableProps } from 'antd';
+import { FC, PropsWithChildren, useEffect, useLayoutEffect, useRef, useState } from 'react';
 import { useUserPreferences } from './user-preferences';
 import { Resizable } from 'react-resizable';
 import styles from './useColumnWidth.module.scss';
@@ -20,178 +11,107 @@ export const useResizeableColumnWidth = <T extends any>(
   notResizeabel: string[] = [],
   minWidth: number = 150,
 ) => {
-  const columnsInPreferences = useUserPreferences.use[preferenceKey]();
+  // const columnsInPreferences = useUserPreferences.use[preferenceKey]();
   const addPreferences = useUserPreferences.use.addPreferences();
   const hydrated = useUserPreferences.use._hydrated();
 
-  /* Initialise every column, that has no width with min-width */
-  const [resizeableColumns, setResizeableColumns] = useState(
-    columns.map((col) => ({ ...col, width: col.width || minWidth })),
-  );
-  const initialisedWithHydratedValues =
-    useRef(
-      false,
-    ); /* Basically a switch to check whether the state was updated once with the saved values, once hydrated */
-  const convertedWidthsToNumbers = useRef(false); /* Similar switch */
-
-  const computeNewColumns = useCallback(() => {
-    return columns.map((column: any) => {
-      const columnInPreferences = columnsInPreferences.find(
-        (col: any) => col.name === column.title,
-      );
-      if (!columnInPreferences) return column;
-
-      return {
-        ...column,
-        width: columnInPreferences.width,
-      };
-    });
-  }, [columns, columnsInPreferences]);
+  /* Initialise with undefined -> widths haven't been loaded */
+  const [columnWidths, setColumnWidths] = useState<Record<string, number> | undefined>(undefined);
 
   /* Once hydrated, get the correct values from the localstorage and update state */
   useEffect(() => {
     if (!hydrated) return;
+    const preferences = useUserPreferences.getState().preferences[preferenceKey];
 
-    /* This should only run one time, after localstorage-store is hydrated */
-    if (initialisedWithHydratedValues.current) return;
+    const storeWidths: Record<string, number> = {};
+    for (const column of preferences) {
+      const width = +column?.width;
+      if (typeof width !== 'number' || Number.isNaN(width)) {
+        continue;
+      }
 
-    const newColumns = computeNewColumns();
-    initialisedWithHydratedValues.current = true;
-    // console.debug('Updated columns with hydrated values');
-    setResizeableColumns(newColumns);
-  }, [hydrated, computeNewColumns]);
+      storeWidths[column.name] = width;
+    }
+    setColumnWidths(storeWidths);
+  }, [hydrated, preferenceKey]);
 
-  /* If the user selects different columns (i.e. columnsInPreferences change) update the state with new columns */
-  useEffect(() => {
-    if (!hydrated) return;
+  const handleResize =
+    (title: string) =>
+    (e: any, { size }: any) => {
+      let thWidth = size.width;
+      /* Antdesign can handle a size of 'auto' */
+      /* However, react-resizeable can't */
+      if (Number.isNaN(thWidth) || thWidth === null) {
+        /* In this case we need to read the actual width from the DOM */
+        const th = e.target.closest('th');
+        if (!th) return; // This should never be the case
+        thWidth = th.getBoundingClientRect().width;
+      }
+      let newWidth = Math.max(thWidth, minWidth);
 
-    /* This should only run if the length of the arrays is different */
-    if (columnsInPreferences.length === resizeableColumns.length) return;
-
-    const newColumns = computeNewColumns();
-    /* Since the localstorage could hold NaN */
-    convertedWidthsToNumbers.current = false;
-    // console.debug('Updated columns because of preference change');
-    setResizeableColumns(newColumns);
-  }, [columnsInPreferences, computeNewColumns, hydrated, resizeableColumns]);
-
-  /* Since 'react-resizable' can only handle numbers as width for resize */
-  /* They need to be replaced with their actual pixel values */
-  useEffect(() => {
-    if (!hydrated) return;
-
-    /* This should only happen, once the actual hydrated values have been read from localstorage and the browser had time to calculate its values  */
-
-    /* Case: The state has not been updated yet with hydrated localsorage-values */
-    if (!initialisedWithHydratedValues.current) return;
-
-    /* This should also just be done if the current width values are not numbers */
-    if (convertedWidthsToNumbers.current) return;
-
-    /* Small timeout for browser to calculate values */
-    const timer = setTimeout(() => {
-      /* Replace 'auto' width with actual px values */
-      const resizeableElements = document.querySelectorAll('.react-resizable');
-      const widthsOfResizeableElements = Array.from(resizeableElements).map(
-        (element: any) => element.getBoundingClientRect().width,
-      );
-      /* Get the widths */
-      const widths = columns.map((column: any, index: number) => {
-        /* Check if not resizeable */
-        if (notResizeabel.includes(column.key)) return column.width || minWidth;
-
-        /* Ensure all columns have min width */
-        return Math.max(widthsOfResizeableElements.shift() || minWidth, minWidth);
-      });
-
-      /* Replace width */
-      const newColumns = resizeableColumns.map((column: any, index: number) => {
-        return {
-          ...column,
-          width: widths[index],
-        };
-      });
-
-      convertedWidthsToNumbers.current = true;
-      // console.debug('Converted widths to numbers');
-      setResizeableColumns(newColumns);
-    }, 500);
-
-    return () => {
-      clearTimeout(timer);
-    };
-  }, [
-    columns,
-    resizeableColumns,
-    notResizeabel,
-    minWidth,
-    hydrated,
-    initialisedWithHydratedValues.current,
-    convertedWidthsToNumbers.current,
-  ]);
-
-  const handleResize = useCallback(
-    (index: number) =>
-      (e: any, { size }: any) => {
-        let thWidth = size.width;
-        /* Antdesign can handle a size of 'auto' */
-        /* However, react-resizeable can't */
-        if (Number.isNaN(thWidth) || thWidth === null) {
-          /* In this case we need to read the actual width from the DOM */
-          const th = e.target.closest('th');
-          if (!th) return; // This should never be the case
-          thWidth = th.getBoundingClientRect().width;
-        }
-        const newWidth = Math.max(thWidth, minWidth);
-
+      /* Only update state if local storage was read in */
+      if (columnWidths) {
         /* Change state */
-        /* Note: changing the preferences should suffice (if it triggers a state change as well), however, changing the state here seems to be smoother */
-        /* Therefore only column selection changes in the localstorage are changing the state (after hydration) */
-        setResizeableColumns((old) => {
-          const newWidths = [...old];
-          // @ts-ignore
-          newWidths[index] = { ...newWidths[index], width: newWidth };
+        // /* Note: changing the preferences should suffice (if it triggers a state change as well), however, changing the state here seems to be smoother */
+        // /* Therefore only column selection changes in the localstorage are changing the state (after hydration) */
+        setColumnWidths((old) => {
+          const newWidths = { ...old };
+          newWidths[title] = newWidth;
           return newWidths;
         });
+      }
 
+      /** Only update if local storage was read in, or if it's the first time we see a column and
+                                    want to store it's initial width */
+      const columnsInPreferences = useUserPreferences.getState().preferences[preferenceKey];
+      const currentColumn = columnsInPreferences.find((column: any) => column.name === title);
+      if (columnWidths || !currentColumn || currentColumn.width === 'auto') {
         /* Update Preferences */
         const newColumnsInPreferences = columnsInPreferences.map((column: any) => {
-          if (column.name === columns[index].title) {
+          if (column.name === title) {
             return { name: column.name, width: newWidth };
           }
           return column;
         });
         addPreferences({ [preferenceKey]: newColumnsInPreferences });
-      },
-    [minWidth, columnsInPreferences, addPreferences, preferenceKey, columns],
-  );
+      }
+    };
 
-  const columsWithResize = useMemo(() => {
-    return resizeableColumns.map((column: any, index: number) => {
-      if (notResizeabel.includes(column.key)) return column;
+  const newCols = columns.map((column) => {
+    if (notResizeabel.includes(column.title as string)) return column;
 
-      return {
-        ...column,
-        /* Ensure updates are passed through */
-        ...columns[index],
-        onHeaderCell: (column: any) => ({
-          width: column.width,
-          onResize: handleResize(index),
-        }),
-      };
-    }) as TableColumnsType<any>;
-  }, [resizeableColumns, notResizeabel, columns, handleResize]);
+    const currentWidth = columnWidths?.[column.key as string];
 
-  columsWithResize.push({
+    let width: string | number = 'auto';
+    if (column.width) width = column.width;
+    else if (notResizeabel.includes(column.key as string)) width = minWidth;
+    else if (typeof currentWidth === 'number' && !Number.isNaN(currentWidth)) width = currentWidth;
+
+    const newColumn = {
+      ...column,
+      width,
+    };
+
+    if (!notResizeabel.includes(column.key as string))
+      newColumn.onHeaderCell = () =>
+        ({
+          width,
+          onResize: handleResize(column.key as string),
+        }) as any;
+
+    return newColumn;
+  }) as TableColumnsType<any>;
+
+  newCols.push({
     width: 'fit-content',
     dataIndex: 'id',
     key: 'auto-sizer',
     title: <div className="PROCEED-RESIZE-COLUMN" style={{ width: '100%', height: '2px' }} />,
-    render: (id, record) => '',
+    render: () => '',
     responsive: ['xl'],
   });
 
-  return columsWithResize;
+  return newCols;
 };
 
 type ResizeableTitleProps = PropsWithChildren & {
@@ -200,6 +120,18 @@ type ResizeableTitleProps = PropsWithChildren & {
 };
 
 export const ResizeableTitle: FC<ResizeableTitleProps> = ({ onResize, width, ...restProps }) => {
+  const headerRef = useRef<HTMLTableCellElement>(null);
+
+  useLayoutEffect(() => {
+    if (width !== 'auto') return;
+
+    const headerWidth = headerRef.current!.getBoundingClientRect().width;
+    onResize(undefined, { size: { width: headerWidth } });
+    // memoizing onResize is almost impossible as the columns passed to useResizeableColumnWidth
+    // aren't memoized
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [width]);
+
   if (!width) {
     return <th {...restProps} />;
   }
@@ -218,14 +150,11 @@ export const ResizeableTitle: FC<ResizeableTitleProps> = ({ onResize, width, ...
           onClick={(e) => {
             e.stopPropagation();
           }}
-
-          // style={{ backgroundColor: 'red' }} /* Uncomment to see Handles */
         />
       }
       onResize={onResize}
-      // draggableOpts={{ onMouseDown: console.log }}
     >
-      <th {...restProps} />
+      <th {...restProps} ref={headerRef} />
     </Resizable>
   );
 };


### PR DESCRIPTION
## Summary

Changes to `useResizableColumns` hook to fix an infinite rerender issue in process list.

Infinite rerender issue:
The component triggered a rerender when the stored columns didn't match the ones that were passed in. This became an infinite loop when the device was smaller, because the process list renders different columns.

I removed a lot of the memoization, as it was a bit pointless, as the props to the hook were not being memoized.
