### PR TITLE
ms2/script execution fixes

### DIFF
--- a/src/engine/native/node/native-script-execution/src/childProcess.js
+++ b/src/engine/native/node/native-script-execution/src/childProcess.js
@@ -37,15 +37,21 @@ async function callToExecutor(endpoint, body) {
       },
     );
 
-    if (!response.ok) throw new Error(`${endpoint}: Response not ok`);
+    if (!response.ok)
+      return {
+        error: `Failed to contact engine universal part: ${response.status} ${response.statusText}`,
+      };
 
     const contentType = response.headers.get('content-type');
 
     if (!contentType) {
       return;
     } else if (contentType.includes('application/json')) {
-      const json = await response.json();
-      return 'result' in json ? json.result : json;
+      const result = await response.json();
+      if (!('result' in result) && !('error' in result)) {
+        return { result: undefined };
+      }
+      return result;
     } else {
       return await response.text();
     }
@@ -53,6 +59,10 @@ async function callToExecutor(endpoint, body) {
     console.error(e);
 
     if (endpoint === 'result') process.exit(1);
+
+    return {
+      error: 'Unknown error',
+    };
   }
 }
 
@@ -86,7 +96,19 @@ for (const objName of Object.keys(structure)) {
   for (const functionName of functionNames) {
     context.evalClosureSync(
       `globalThis["${objName}"]["${functionName}"] = function (...args) {
-        return $0.applySyncPromise(null, [JSON.stringify(args)], {});
+        const result = $0.applySyncPromise(null, [JSON.stringify(args)], {});
+
+        if (result && 'result' in result) {
+          return result.result;
+        } else {
+          if (!result) {
+            throw new Error('Unknown error');
+          } else if (typeof result.error === 'string') {
+            throw new Error(result.error);
+          } else {
+            throw result.error;
+          }
+        }
       }`,
       [
         new ivm.Reference(async function (args) {
@@ -102,12 +124,24 @@ for (const objName of Object.keys(structure)) {
   }
 }
 
-function _callToService(serviceName, method, args) {
+async function _callToService(serviceName, method, args) {
   /**@type {import('isolated-vm').Reference} */
   const call = $0;
-  return call.apply(null, [serviceName, method, JSON.stringify(args)], {
+  const result = await call.apply(null, [serviceName, method, JSON.stringify(args)], {
     result: { promise: true, copy: true },
   });
+
+  if (result && 'result' in result) {
+    return result.result;
+  } else {
+    if (!result) {
+      throw new Error('Unknown error');
+    } else if (typeof result.error === 'string') {
+      throw new Error(result.error);
+    } else {
+      throw result.error;
+    }
+  }
 }
 function _getService(serviceName) {
   return new Proxy(

--- a/src/engine/universal/core/src/engine/neoEngineSetup.js
+++ b/src/engine/universal/core/src/engine/neoEngineSetup.js
@@ -25,6 +25,22 @@ function networkResponseToSerializable(response) {
   return { response: filteredResponse, body: response.body };
 }
 
+/** @param {(...args: any[]) => Promise<any>} fn */
+function errorWrapper(fn) {
+  return async function (...args) {
+    try {
+      const response = await fn.call(...args);
+      return networkResponseToSerializable(response);
+    } catch (error) {
+      if (error && typeof error === 'object' && 'body' in error && 'response' in error) {
+        throw networkResponseToSerializable(error);
+      } else {
+        throw error;
+      }
+    }
+  };
+}
+
 module.exports = {
   setupNeoEngine() {
     // Register the modules which we wish to make use of in the script environment
@@ -33,14 +49,17 @@ module.exports = {
         capabilities.startCapability.call(capabilities, capabilityName, args, callback),
     });
     NeoEngine.provideService('network', {
-      get: async (_processId, _processInstanceId, _tokenId, url, options) => {
-        const response = await system.http.request.call(system.http, url, {
-          ...options,
-          method: 'GET',
-        });
-        return networkResponseToSerializable(response);
+      get: (_processId, _processInstanceId, _tokenId, url, options) => {
+        try {
+          return errorWrapper(system.http.request)(system.http, url, {
+            ...options,
+            method: 'GET',
+          });
+        } catch (e) {
+          console.erroor(e);
+        }
       },
-      post: async (
+      post: (
         _processId,
         _processInstanceId,
         _tokenId,
@@ -49,7 +68,7 @@ module.exports = {
         contentType = 'text/plain',
         options = {},
       ) => {
-        const response = await system.http.request.call(system.http, url, {
+        return errorWrapper(system.http.request)(system.http, url, {
           ...options,
           body,
           method: 'POST',
@@ -58,9 +77,8 @@ module.exports = {
             'Content-Type': contentType,
           },
         });
-        return networkResponseToSerializable(response);
       },
-      put: async (
+      put: (
         _processId,
         _processInstanceId,
         _tokenId,
@@ -69,7 +87,7 @@ module.exports = {
         contentType = 'text/plain',
         options = {},
       ) => {
-        const response = await system.http.request.call(system.http, url, {
+        return errorWrapper(system.http.request)(system.http, url, {
           ...options,
           body,
           method: 'PUT',
@@ -78,21 +96,18 @@ module.exports = {
             'Content-Type': contentType,
           },
         });
-        return networkResponseToSerializable(response);
       },
-      delete: async (_processId, _processInstanceId, _tokenId, url, options) => {
-        const response = await system.http.request.call(system.http, url, {
+      delete: (_processId, _processInstanceId, _tokenId, url, options) => {
+        return errorWrapper(system.http.request)(system.http, url, {
           ...options,
           method: 'DELETE',
         });
-        return networkResponseToSerializable(response);
       },
-      head: async (_processId, _processInstanceId, _tokenId, url, options) => {
-        const response = await system.http.request.call(system.http, url, {
+      head: (_processId, _processInstanceId, _tokenId, url, options) => {
+        return errorWrapper(system.http.request)(system.http, url, {
           ...options,
           method: 'HEAD',
         });
-        return networkResponseToSerializable(response);
       },
     });
   },

--- a/src/engine/universal/system/src/script-execution.js
+++ b/src/engine/universal/system/src/script-execution.js
@@ -1,6 +1,9 @@
 // @ts-check
+//
 const { System } = require('./system');
 const { generateUniqueTaskID } = require('./utils');
+// @ts-ignore
+const Console = require('./console.ts').default;
 
 /**
  * @typedef {{
@@ -28,6 +31,13 @@ class ScriptExecutor extends System {
     this.childProcesses = new Map();
 
     this.options = options;
+  }
+
+  _getLogger() {
+    if (!this.logger) {
+      this.logger = Console._getLoggingModule().getLogger({ moduleName: 'SYSTEM' });
+    }
+    return this.logger;
   }
 
   /** @param {any} req  */
@@ -111,9 +121,25 @@ class ScriptExecutor extends System {
           let result = target;
           if (typeof target === 'function' || typeof target === 'object')
             result = await target(...args);
-          return { response: { result } };
-        } catch (e) {
-          return { response: { error: `Error: ${e.message}` }, statusCode: 500 };
+
+          return { response: { result: result || undefined } };
+        } catch (error) {
+          let errorResponse = 'Unknown Error';
+          if (error instanceof Error) {
+            errorResponse = error.name + ' ' + error.message;
+          } else {
+            try {
+              // If error is serializable we can send it back
+              JSON.stringify(error);
+              errorResponse = error;
+            } catch (_) {}
+          }
+
+          this._getLogger().error(
+            `Error in function call in script execution of processId: ${req.params.processId} processInstanceId: ${req.params.processInstanceId}: ${JSON.stringify(errorResponse)}`,
+          );
+
+          return { response: { error: errorResponse }, statusCode: 200 };
         }
       }.bind(this),
     );

--- a/src/management-system-v2/app/(dashboard)/[environmentId]/processes/[processId]/modeler-toolbar.tsx
+++ b/src/management-system-v2/app/(dashboard)/[environmentId]/processes/[processId]/modeler-toolbar.tsx
@@ -1,4 +1,4 @@
-import React, { ComponentProps, use, useEffect, useState } from 'react';
+import { ComponentProps, use, useEffect, useState } from 'react';
 import { is as bpmnIs } from 'bpmn-js/lib/util/ModelUtil';
 import { App, Tooltip, Button, Space, Select, SelectProps, Divider } from 'antd';
 import { Toolbar, ToolbarGroup } from '@/components/toolbar';
@@ -34,16 +34,17 @@ import { EnvVarsContext } from '@/components/env-vars-context';
 import { Process } from '@/lib/data/process-schema';
 import FlowConditionModal, { isConditionalFlow } from './flow-condition-modal';
 import { TimerEventButton, isTimerEvent } from './planned-duration-input';
+import XmlEditor from './xml-editor';
 
 const LATEST_VERSION = { id: '-1', name: 'Latest Version', description: '' };
 
 type ModelerToolbarProps = {
   process: Process;
-  onOpenXmlEditor: () => void;
   canUndo: boolean;
   canRedo: boolean;
+  versionName?: string;
 };
-const ModelerToolbar = ({ process, onOpenXmlEditor, canUndo, canRedo }: ModelerToolbarProps) => {
+const ModelerToolbar = ({ process, canRedo, canUndo, versionName }: ModelerToolbarProps) => {
   const processId = process.id;
 
   const router = useRouter();
@@ -75,13 +76,47 @@ const ModelerToolbar = ({ process, onOpenXmlEditor, canUndo, canRedo }: ModelerT
   // Force rerender when the BPMN changes.
   useModelerStateStore((state) => state.changeCounter);
 
+  const [xmlEditorBpmn, setXmlEditorBpmn] = useState<string | undefined>(undefined);
+  const handleOpenXmlEditor = async () => {
+    // Undefined can maybe happen when click happens during router transition?
+    if (modeler) {
+      const xml = await modeler.getXML();
+      setXmlEditorBpmn(xml);
+    }
+  };
+  const handleXmlEditorSave = async (bpmn: string) => {
+    if (modeler) {
+      await modeler.loadBPMN(bpmn);
+      // If the bpmn contains unexpected content (text content for an element
+      // where the model does not define text) the modeler will remove it
+      // automatically => make sure the stored bpmn is the same as the one in
+      // the modeler.
+      const cleanedBpmn = await modeler.getXML();
+      await updateProcess(process.id, environment.spaceId, cleanedBpmn);
+    }
+  };
+
   const modalOpen =
-    showUserTaskEditor || showPropertiesPanel || showScriptTaskEditor || shareModalOpen;
+    showUserTaskEditor ||
+    showPropertiesPanel ||
+    showScriptTaskEditor ||
+    shareModalOpen ||
+    !!xmlEditorBpmn;
+
   useEffect(() => {
     if (modalOpen) {
       modeler?.deactivateKeyboard();
     } else modeler?.activateKeyboard();
   }, [modeler, modalOpen]);
+
+  useAddControlCallback(
+    'modeler',
+    'cut',
+    () => {
+      if (!modalOpen) handleOpenXmlEditor();
+    },
+    { blocking: modalOpen },
+  );
 
   const selectedVersionId = query.get('version');
 
@@ -301,7 +336,7 @@ const ModelerToolbar = ({ process, onOpenXmlEditor, canUndo, canRedo }: ModelerT
                 <Tooltip title="Show XML">
                   <Button
                     icon={<Icon aria-label="xml-sign" component={SvgXML} />}
-                    onClick={onOpenXmlEditor}
+                    onClick={handleOpenXmlEditor}
                   />
                 </Tooltip>
               )}
@@ -349,12 +384,23 @@ const ModelerToolbar = ({ process, onOpenXmlEditor, canUndo, canRedo }: ModelerT
           </Space>
         </Space>
       </Toolbar>
+
       <ShareModal
         processes={[process]}
         open={shareModalOpen}
         setOpen={setShareModalOpen}
         defaultOpenTab={shareModalDefaultOpenTab}
       />
+
+      <XmlEditor
+        bpmn={xmlEditorBpmn}
+        canSave={!selectedVersionId}
+        onClose={() => setXmlEditorBpmn(undefined)}
+        onSaveXml={handleXmlEditorSave}
+        process={process}
+        versionName={versionName}
+      />
+
       {env.PROCEED_PUBLIC_ENABLE_EXECUTION && (
         <>
           <UserTaskBuilder

--- a/src/management-system-v2/app/(dashboard)/[environmentId]/processes/[processId]/modeler.tsx
+++ b/src/management-system-v2/app/(dashboard)/[environmentId]/processes/[processId]/modeler.tsx
@@ -11,13 +11,12 @@ import React, {
 } from 'react';
 import { usePathname, useRouter, useSearchParams } from 'next/navigation';
 import ModelerToolbar from './modeler-toolbar';
-import XmlEditor from './xml-editor';
 import useModelerStateStore from './use-modeler-state-store';
 import { debounce, spaceURL } from '@/lib/utils';
 import VersionToolbar from './version-toolbar';
 import useMobileModeler from '@/lib/useMobileModeler';
 import { updateProcess } from '@/lib/data/processes';
-import { App, message } from 'antd';
+import { App } from 'antd';
 import { is as bpmnIs, isAny as bpmnIsAny } from 'bpmn-js/lib/util/ModelUtil';
 import BPMNCanvas, { BPMNCanvasProps, BPMNCanvasRef } from '@/components/bpmn-canvas';
 import { useEnvironment } from '@/components/auth-can';
@@ -296,32 +295,6 @@ const Modeler = ({ versionName, process, ...divProps }: ModelerProps) => {
     }
   }, [subprocessId]);
 
-  const handleOpenXmlEditor = async () => {
-    // Undefined can maybe happen when click happens during router transition?
-    if (modeler.current) {
-      const xml = await modeler.current.getXML();
-      setXmlEditorBpmn(xml);
-    }
-  };
-
-  useAddControlCallback('modeler', 'cut', handleOpenXmlEditor);
-
-  const handleCloseXmlEditor = () => {
-    setXmlEditorBpmn(undefined);
-  };
-
-  const handleXmlEditorSave = async (bpmn: string) => {
-    if (modeler.current) {
-      await modeler.current.loadBPMN(bpmn);
-      // If the bpmn contains unexpected content (text content for an element
-      // where the model does not define text) the modeler will remove it
-      // automatically => make sure the stored bpmn is the same as the one in
-      // the modeler.
-      const cleanedBpmn = await modeler.current.getXML();
-      await updateProcess(process.id, environment.spaceId, cleanedBpmn);
-    }
-  };
-
   // Create a new object to force rerendering when the bpmn doesn't change.
   const bpmn = useMemo(
     () => ({ bpmn: process.bpmn }),
@@ -337,23 +310,13 @@ const Modeler = ({ versionName, process, ...divProps }: ModelerProps) => {
             {loaded && (
               <ModelerToolbar
                 process={process}
-                onOpenXmlEditor={handleOpenXmlEditor}
                 canRedo={canRedo}
                 canUndo={canUndo}
+                versionName={versionName}
               />
             )}
             {selectedVersionId && !showMobileView && <VersionToolbar processId={process.id} />}
             <ModelerZoombar></ModelerZoombar>
-            {!!xmlEditorBpmn && (
-              <XmlEditor
-                bpmn={xmlEditorBpmn}
-                canSave={!selectedVersionId}
-                onClose={handleCloseXmlEditor}
-                onSaveXml={handleXmlEditorSave}
-                process={process}
-                versionName={versionName}
-              />
-            )}
           </>
         )}
         <BPMNCanvas


### PR DESCRIPTION
## Summary

- error handling on failed function calls from child process script execution to universal part
- error handling for service.network on neo engine service
- fix(ms2/modeler): don't open xml on ctl+x when a modal is open
