### PR TITLE
Update package systeminformation to avoid windows errors

### DIFF
--- a/src/engine/native/node/native-machine/package.json
+++ b/src/engine/native/node/native-machine/package.json
@@ -8,7 +8,7 @@
   "dependencies": {
     "@proceed/native-module": "^1.0.0",
     "machine-uuid": "^1.2.0",
-    "systeminformation": "^4.30.1",
+    "systeminformation": "^5.27.6",
     "ping": "^0.3.0"
   }
 }

--- a/src/engine/native/node/native-machine/src/index.js
+++ b/src/engine/native/node/native-machine/src/index.js
@@ -50,7 +50,7 @@ class Machine extends NativeModule {
     }
     if (properties.includes('cpu')) {
       const cpu = await si.cpu();
-      const currentLoad = (await si.currentLoad()).currentload;
+      const currentLoad = (await si.currentLoad()).currentLoad;
       deviceInfo.cpu = {
         cores: cpu.cores,
         physicalCores: cpu.physicalCores,
@@ -88,9 +88,9 @@ class Machine extends NativeModule {
     if (properties.includes('battery')) {
       const battery = await si.battery();
       deviceInfo.battery = {
-        hasBattery: battery.hasbattery,
+        hasBattery: battery.hasBattery,
         percent: battery.percent,
-        maxCapacity: battery.maxcapacity,
+        maxCapacity: battery.maxCapacity,
       };
     }
     if (properties.includes('display')) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -14576,10 +14576,10 @@ symbol-tree@^3.2.4:
   resolved "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz"
   integrity sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==
 
-systeminformation@^4.30.1:
-  version "4.34.23"
-  resolved "https://registry.npmjs.org/systeminformation/-/systeminformation-4.34.23.tgz"
-  integrity sha512-33+lQwlLxXoxy0o9WLOgw8OjbXeS3Jv+pSl+nxKc2AOClBI28HsdRPpH0u9Xa9OVjHLT9vonnOMw1ug7YXI0dA==
+systeminformation@^5.27.6:
+  version "5.27.6"
+  resolved "https://registry.yarnpkg.com/systeminformation/-/systeminformation-5.27.6.tgz#9b2948d169d219ad01167ae4822d2158d7b21471"
+  integrity sha512-9gmEXEtFp8vkewF8MLo69OmYBf0UpvGnqfAQs0kO+dgJRyFuCDxBwX53NQj4p/aV4fFmJQry+K1LLxPadAgmFQ==
 
 taffydb@2.6.2:
   version "2.6.2"


### PR DESCRIPTION
- just [systeminformation package] (https://systeminformation.io/changes.html) updated to have no errors on windows anymore