### PR TITLE
MS: Quicker Instance View Refetching

### DIFF
--- a/src/management-system-v2/lib/engines/deployment.ts
+++ b/src/management-system-v2/lib/engines/deployment.ts
@@ -1,4 +1,4 @@
-import 'server-only';
+'use server';
 
 import {
   getElementMachineMapping,

--- a/src/management-system-v2/lib/engines/instances.ts
+++ b/src/management-system-v2/lib/engines/instances.ts
@@ -1,4 +1,4 @@
-import 'server-only';
+'use server';
 
 import { Engine } from './machines';
 import { engineRequest } from './endpoints/index';

--- a/src/management-system-v2/lib/engines/server-actions.ts
+++ b/src/management-system-v2/lib/engines/server-actions.ts
@@ -13,12 +13,6 @@ import { savedEnginesToEngines } from './saved-engines-helpers';
 import { getCurrentEnvironment } from '@/components/auth';
 import { enableUseDB } from 'FeatureFlags';
 import { getDbEngines, getDbEngineByAddress } from '@/lib/data/db/engines';
-import {
-  startInstanceOnMachine,
-  pauseInstanceOnMachine,
-  resumeInstanceOnMachine,
-  stopInstanceOnMachine,
-} from './instances';
 import { asyncFilter, asyncMap, asyncForEach } from '../helpers/javascriptHelpers';
 
 import {
@@ -28,7 +22,6 @@ import {
   getUserTaskFileFromMachine,
   setTasklistEntryVariableValuesOnMachine,
   setTasklistEntryMilestoneValuesOnMachine,
-  getStartFormFromMachine,
 } from './tasklist';
 import { truthyFilter } from '../typescript-utils';
 import {
@@ -46,7 +39,7 @@ import {
   deleteUserTask,
 } from '../data/user-tasks';
 
-async function getCorrectTargetEngines(
+export async function getCorrectTargetEngines(
   spaceId: string,
   onlyProceedEngines = false,
   validatorFunc?: (engine: Engine) => Promise<boolean>,
@@ -120,38 +113,6 @@ export async function removeDeployment(definitionId: string, spaceId: string) {
     });
 
     await removeDeploymentFromMachines(engines, definitionId);
-  } catch (e) {
-    const message = getErrorMessage(e);
-    return userError(message);
-  }
-}
-
-export async function startInstance(
-  definitionId: string,
-  versionId: string,
-  spaceId: string,
-  variables: { [key: string]: any } = {},
-) {
-  try {
-    // TODO: manage permissions for starting an instance
-
-    if (!enableUseDB) throw new Error('startInstance is only available with enableUseDB');
-
-    const engines = await getCorrectTargetEngines(spaceId, false, async (engine: Engine) => {
-      const deployments = await fetchDeployments([engine]);
-
-      // TODO: in case of static deployment we will need to only return the engines that are
-      // assigned an entry point of the process
-      return deployments.some(
-        (deployment) =>
-          deployment.definitionId === definitionId &&
-          deployment.versions.some((version) => version.versionId === versionId),
-      );
-    });
-
-    // TODO: if there are multiple possible engines maybe try to find the one that fits the best
-    // (e.g. the one with the least load)
-    return await startInstanceOnMachine(definitionId, versionId, engines[0], variables);
   } catch (e) {
     const message = getErrorMessage(e);
     return userError(message);
@@ -245,34 +206,6 @@ export async function getAvailableTaskListEntries(spaceId: string) {
             }) as UserTask,
         ),
     ];
-  } catch (e) {
-    const message = getErrorMessage(e);
-    return userError(message);
-  }
-}
-
-export async function getStartForm(spaceId: string, definitionId: string, versionId: string) {
-  // TODO: manage permissions
-  try {
-    if (!enableUseDB) throw new Error('startInstance is only available with enableUseDB');
-
-    const engines = await getCorrectTargetEngines(spaceId, false, async (engine: Engine) => {
-      const deployments = await fetchDeployments([engine]);
-
-      // TODO: in case of static deployment we will need to only return the engines that are
-      // assigned an entry point of the process that is not a typed start event
-      // (otherwise the engine might not have the start form)
-      return deployments.some(
-        (deployment) =>
-          deployment.definitionId === definitionId &&
-          deployment.versions.some((version) => version.versionId === versionId),
-      );
-    });
-
-    const html = await getStartFormFromMachine(definitionId, versionId, engines[0]);
-    if (html) {
-      return inlineUserTaskData(html, '', '', {}, []);
-    } else return '';
   } catch (e) {
     const message = getErrorMessage(e);
     return userError(message);
@@ -514,79 +447,6 @@ export async function completeTasklistEntry(
     const message = getErrorMessage(e);
     return userError(message);
   }
-}
-
-const activeStates = ['PAUSED', 'RUNNING', 'READY', 'DEPLOYMENT-WAITING', 'WAITING'];
-async function changeInstanceState(
-  definitionId: string,
-  instanceId: string,
-  spaceId: string,
-  stateValidator: (state: InstanceInfo['instanceState']) => boolean,
-  stateChangeFunction: typeof resumeInstanceOnMachine,
-) {
-  try {
-    const engines = await getCorrectTargetEngines(spaceId, undefined, async (engine: Engine) => {
-      const deployments = await fetchDeployments([engine]);
-
-      return deployments.some((deployment) => {
-        if (deployment.definitionId !== definitionId) return false;
-
-        const instance = deployment.instances.find(
-          (instance) => instance.processInstanceId === instanceId,
-        );
-        if (!instance) return false;
-
-        return stateValidator(instance.instanceState);
-      });
-    });
-
-    await asyncForEach(engines, async (engine) => {
-      await stateChangeFunction(definitionId, instanceId, engine);
-    });
-  } catch (e) {
-    const message = getErrorMessage(e);
-    return userError(message);
-  }
-}
-
-export async function resumeInstance(definitionId: string, instanceId: string, spaceId: string) {
-  // TODO: manage permissions for starting an instance
-  if (!enableUseDB) throw new Error('resumeInstance is only available with enableUseDB');
-
-  return await changeInstanceState(
-    definitionId,
-    instanceId,
-    spaceId,
-    (tokenStates) => tokenStates.some((tokenState) => tokenState === 'PAUSED'),
-    resumeInstanceOnMachine,
-  );
-}
-
-export async function pauseInstance(definitionId: string, instanceId: string, spaceId: string) {
-  // TODO: manage permissions for starting an instance
-  if (!enableUseDB) throw new Error('pauseInstance is only available with enableUseDB');
-
-  return await changeInstanceState(
-    definitionId,
-    instanceId,
-    spaceId,
-    (tokenStates) =>
-      tokenStates.some((state) => activeStates.includes(state) && state !== 'PAUSED'),
-    pauseInstanceOnMachine,
-  );
-}
-
-export async function stopInstance(definitionId: string, instanceId: string, spaceId: string) {
-  // TODO: manage permissions for starting an instance
-  if (!enableUseDB) throw new Error('stopInstance is only available with enableUseDB');
-
-  return await changeInstanceState(
-    definitionId,
-    instanceId,
-    spaceId,
-    (tokenStates) => tokenStates.some((state) => activeStates.includes(state)),
-    stopInstanceOnMachine,
-  );
 }
 
 /** Returns space engines that are currently online */

--- a/src/management-system-v2/lib/engines/tasklist.ts
+++ b/src/management-system-v2/lib/engines/tasklist.ts
@@ -1,7 +1,8 @@
-import 'server-only';
+'use server';
 
 import { Engine } from './machines';
 import { engineRequest } from './endpoints/index';
+import { inlineUserTaskData } from '@proceed/user-task-helper';
 
 export type TaskListEntry = {
   id: string;
@@ -72,7 +73,7 @@ export async function getStartFormFromMachine(
   versionId: string,
   engine: Engine,
 ) {
-  const html = await engineRequest({
+  let html = await engineRequest({
     method: 'get',
     endpoint: '/process/:definitionId/versions/:version/start-form',
     engine,
@@ -81,6 +82,11 @@ export async function getStartFormFromMachine(
       version: versionId,
     },
   });
+
+  // initialize the placeholders in the form with empty strings
+  // TODO: use the information from the variable data in the bpmn to initialize the actual initial
+  // values set by the process designer
+  if (html) html = inlineUserTaskData(html, '', '', {}, []);
 
   return html as string;
 }

--- a/src/management-system-v2/lib/engines/use-engines.tsx
+++ b/src/management-system-v2/lib/engines/use-engines.tsx
@@ -1,0 +1,30 @@
+import { useEnvironment } from '@/components/auth-can';
+import { Engine } from './machines';
+import { useCallback } from 'react';
+import { getCorrectTargetEngines } from './server-actions';
+import { useQuery } from '@tanstack/react-query';
+import { asyncFilter } from '../helpers/javascriptHelpers';
+
+function useEngines(
+  filter: { key: any[]; fn: (engine: Engine) => Promise<boolean> } = {
+    key: [],
+    fn: async () => true,
+  },
+) {
+  const space = useEnvironment();
+
+  const queryFn = useCallback(async () => {
+    if (space.spaceId) {
+      const res = await getCorrectTargetEngines(space.spaceId);
+      return asyncFilter(res, filter.fn);
+    }
+  }, [space.spaceId, filter]);
+
+  return useQuery({
+    queryFn,
+    queryKey: ['engines', space.spaceId, ...filter.key],
+    refetchInterval: 5000,
+  });
+}
+
+export default useEngines;


### PR DESCRIPTION
## Summary

The functions to handle a deployment in the deployment view (e.g. startInstance, stopInstance...) use separately fetched engines instead of always having to fetch the engines to find the ones to target heavily reducing the request time in case of mqtt engines

## Details

- added a useEngines hook that periodically fetches engines and keeps them in its state exposing them to other hooks, components
- using the useEngines hook in useDeployment to keep the engines related to a deployment in memory
- used the memoized engines to implement better functions for handling instances of a deployment that can directly communicate with the engines instead of having to find the appropriate engines first
