### PR TITLE
Fix missing referenced artefacts import error

### DIFF
--- a/src/management-system-v2/components/process-import.tsx
+++ b/src/management-system-v2/components/process-import.tsx
@@ -55,7 +55,7 @@ const ProcessImportButton: React.FC<ButtonProps> = ({ ...props }) => {
     await Promise.all(
       fileList.map(async (file) => {
         try {
-          if (file.type === 'application/zip') {
+          if (file.name.toLowerCase().endsWith('.zip')) {
             await handleZipFile(file, processesData, errors);
           } else {
             await handleBpmnFile(file, processesData, errors);
@@ -151,7 +151,8 @@ const ProcessImportButton: React.FC<ButtonProps> = ({ ...props }) => {
       };
       if (zip) {
         // Handle artefacts in the same directory as the BPMN file
-        const artefactPath = bpmnFilePath.split('/').slice(0, -1).join('/');
+        const normalizedBpmnPath = bpmnFilePath.replace(/\\/g, '/');
+        const artefactPath = normalizedBpmnPath.split('/').slice(0, -1).join('/');
         const artefactFiles = Object.keys(zip.files).filter(
           (name) =>
             name.startsWith(artefactPath.concat('/')) &&

--- a/src/management-system-v2/lib/process-export/index.ts
+++ b/src/management-system-v2/lib/process-export/index.ts
@@ -125,7 +125,7 @@ export async function getExportblob(
         exportData.length === 1
           ? `${exportData[0].definitionName}.zip`
           : 'PROCEED_Multiple-Processes_bpmn.zip',
-      blob: await zip.generateAsync({ type: 'blob' }),
+      blob: await zip.generateAsync({ type: 'blob', platform: 'UNIX' }),
       zip: true,
     };
   } else {


### PR DESCRIPTION
Fixed the missing referenced artefacts import error that occured when importing processes with artefacts.

Error occurred due to inconsistent pathing in Windows and Linux and inconsistent recognition of the zip archive.

Changed the check for zip files and the normalizing of pathing to be agnostic to the operating system and browser.

As a fallback, also hardcoded the platform setting in JSZip to UNIX.