### PR TITLE
ms2/configuration updates

### DIFF
--- a/src/management-system-v2/app/(dashboard)/[environmentId]/layout.tsx
+++ b/src/management-system-v2/app/(dashboard)/[environmentId]/layout.tsx
@@ -271,7 +271,14 @@ const DashboardLayout = async ({
     });
   }
 
-  if (systemAdmin && msConfig.PROCEED_PUBLIC_IAM_ACTIVE) {
+  if (
+    systemAdmin &&
+    msConfig.PROCEED_PUBLIC_IAM_ACTIVE &&
+    !(
+      msConfig.PROCEED_PUBLIC_IAM_ONLY_ONE_ORGANIZATIONAL_SPACE &&
+      !msConfig.PROCEED_PUBLIC_IAM_PERSONAL_SPACES_ACTIVE
+    )
+  ) {
     layoutMenuItems.push({
       key: 'ms-admin',
       label: <Link href="/admin">MS Administration</Link>,

--- a/src/management-system-v2/app/admin/layout.tsx
+++ b/src/management-system-v2/app/admin/layout.tsx
@@ -8,6 +8,7 @@ import { RiAdminFill } from 'react-icons/ri';
 import { type ReactNode } from 'react';
 import { FaGear } from 'react-icons/fa6';
 import { env } from '@/lib/ms-config/env-vars';
+import { notFound } from 'next/navigation';
 
 let adminViews = [
   {
@@ -46,6 +47,13 @@ if (!env.PROCEED_PUBLIC_IAM_ACTIVE)
   adminViews = adminViews.filter(({ key }) => !['users', 'systemadmins'].includes(key));
 
 export default function AdminLayout({ children }: { children: ReactNode }) {
+  if (
+    env.PROCEED_PUBLIC_IAM_ONLY_ONE_ORGANIZATIONAL_SPACE &&
+    !env.PROCEED_PUBLIC_IAM_PERSONAL_SPACES_ACTIVE
+  ) {
+    return notFound();
+  }
+
   return (
     <Layout
       activeSpace={{ spaceId: '', isOrganization: false }}

--- a/src/management-system-v2/app/error.tsx
+++ b/src/management-system-v2/app/error.tsx
@@ -4,6 +4,7 @@ import Content from '@/components/content';
 import UnauthorizedFallback from '@/components/unauthorized-fallback';
 import { UnauthorizedError } from '@/lib/ability/abilityHelper';
 import { SpaceNotFoundError } from '@/lib/errors';
+import { UIError } from '@/lib/ui-error';
 import { Button, Result } from 'antd';
 
 export default function Error({
@@ -13,9 +14,13 @@ export default function Error({
   error: Error & { digest?: string };
   reset: () => void;
 }) {
+  let title = 'Something went wrong!';
   if (error.message.startsWith(UnauthorizedError.prefix)) {
     return <UnauthorizedFallback />;
+  } else if (error.message.startsWith(UIError.prefix)) {
+    title = error.message.substring(UIError.prefix.length + 2);
   }
+
   const retryButton = (
     <Button type="primary" onClick={() => reset()}>
       Try again
@@ -25,7 +30,7 @@ export default function Error({
   let feedback = (
     <Result
       status="warning"
-      title="Something went wrong!"
+      title={title}
       subTitle={`Digest: ${error.digest}`}
       extra={retryButton}
     />

--- a/src/management-system-v2/components/auth.tsx
+++ b/src/management-system-v2/components/auth.tsx
@@ -73,8 +73,8 @@ export const getCurrentEnvironment = cache(
       spaceIdParam = userId;
     }
 
-    const activeSpace = decodeURIComponent(spaceIdParam);
-    const isOrganization = activeSpace !== userId;
+    let activeSpace = decodeURIComponent(spaceIdParam);
+    let isOrganization = activeSpace !== userId;
 
     // When trying to access a personal space
     if (userId && !isOrganization && !env.PROCEED_PUBLIC_IAM_PERSONAL_SPACES_ACTIVE) {
@@ -89,7 +89,8 @@ export const getCurrentEnvironment = cache(
         }
       }
 
-      spaceIdParam = userOrgs[0];
+      activeSpace = userOrgs[0];
+      isOrganization = true;
     }
 
     // TODO: account for bought resources

--- a/src/management-system-v2/components/header-actions.tsx
+++ b/src/management-system-v2/components/header-actions.tsx
@@ -93,8 +93,13 @@ const HeaderActions: FC = () => {
       icon: <TbUserEdit />,
     });
 
-    // userSpaces is null when the component is outside of the UserSpaces provider
-    if (userSpaces) {
+    if (
+      userSpaces &&
+      !(
+        envVars.PROCEED_PUBLIC_IAM_ONLY_ONE_ORGANIZATIONAL_SPACE &&
+        !envVars.PROCEED_PUBLIC_IAM_PERSONAL_SPACES_ACTIVE
+      )
+    ) {
       actionButton = (
         <div style={{ padding: '1rem' }}>
           <Select

--- a/src/management-system-v2/instrumentation.ts
+++ b/src/management-system-v2/instrumentation.ts
@@ -46,7 +46,7 @@ export async function register() {
         );
         process.exit(1);
       }
-      if (organizations[0].id !== seed.organizations[0].id) {
+      if (organizations[0].id !== seed!.organizations[0].id) {
         console.error(
           "Consistency error: PROCEED_PUBLIC_IAM_ONLY_ONE_ORGANIZATIONAL_SPACE is active and the only organization in the database doesn't match the one in the seed file.",
         );

--- a/src/management-system-v2/instrumentation.ts
+++ b/src/management-system-v2/instrumentation.ts
@@ -31,6 +31,27 @@ export async function register() {
 
     // Import db seed
     const { importSeed } = await import('./lib/db-seed');
-    await importSeed();
+    const seed = await importSeed();
+
+    // Verify that there is only one org in the db if that's needed
+    if (env.PROCEED_PUBLIC_IAM_ONLY_ONE_ORGANIZATIONAL_SPACE) {
+      const organizations = await db.default.space.findMany({
+        where: {
+          isOrganization: true,
+        },
+      });
+      if (organizations.length !== 1) {
+        console.error(
+          `When PROCEED_PUBLIC_IAM_ONLY_ONE_ORGANIZATIONAL_SPACE there can only be one organization in the database. Found ${organizations.length}.`,
+        );
+        process.exit(1);
+      }
+      if (organizations[0].id !== seed.organizations[0].id) {
+        console.error(
+          "Consistency error: PROCEED_PUBLIC_IAM_ONLY_ONE_ORGANIZATIONAL_SPACE is active and the only organization in the database doesn't match the one in the seed file.",
+        );
+        process.exit(1);
+      }
+    }
   }
 }

--- a/src/management-system-v2/lib/data/db/iam/roles.ts
+++ b/src/management-system-v2/lib/data/db/iam/roles.ts
@@ -177,7 +177,7 @@ export async function addRole(
 
   const createdOn = new Date().toISOString();
   const lastEditedOn = createdOn;
-  const id = v4();
+  const id = roleRepresentationInput.id ?? v4();
 
   const createdRole = await dbMutator.role.create({
     data: {

--- a/src/management-system-v2/lib/data/role-schema.ts
+++ b/src/management-system-v2/lib/data/role-schema.ts
@@ -8,6 +8,7 @@ for (const resource of resources) {
   perms[resource] = z.number();
 }
 export const RoleInputSchema = z.object({
+  id: z.string().optional(),
   environmentId: z.string(),
   name: z.string(),
   description: z.string().nullish().optional(),

--- a/src/management-system-v2/lib/db-seed.ts
+++ b/src/management-system-v2/lib/db-seed.ts
@@ -266,6 +266,9 @@ async function writeSeedToDb(seed: DBSeed) {
  * Import Seed + Verification + Write to DB
  * -----------------------------------------------------------------------------------------------*/
 
+/**
+ * @note This function will terminate the process if the import fails.
+ */
 export async function importSeed() {
   let seedDbConfig: unknown | undefined;
   try {
@@ -290,5 +293,6 @@ export async function importSeed() {
   } catch (e) {
     console.error('Failed to import seed');
     console.error(e);
+    process.exit(1);
   }
 }

--- a/src/management-system-v2/lib/db-seed.ts
+++ b/src/management-system-v2/lib/db-seed.ts
@@ -190,7 +190,7 @@ async function writeSeedToDb(seed: DBSeed) {
 
       const newUser = await addUser({ ...user, isGuest: false, emailVerifiedOn: null }, tx);
       const hashedPassword = await hashPassword(user.initialPassword);
-      await setUserPassword(user.id, hashedPassword, tx);
+      await setUserPassword(user.id, hashedPassword, tx, true);
       usernameToId.set(user.username, newUser.id);
     }
 

--- a/src/management-system-v2/lib/ui-error.ts
+++ b/src/management-system-v2/lib/ui-error.ts
@@ -1,0 +1,15 @@
+import { UserFacingError } from './user-error';
+
+/**
+ * If thrown in a server component, the message will be displayed to the user in the ui through the
+ * error boundary.
+ * If thrown in a server action, the error message will be sent back as a userError
+ * (if the server action implements the right functions)
+ */
+export class UIError extends UserFacingError {
+  static prefix = '500';
+  constructor(message?: string) {
+    super(`${UIError.prefix}: ${message || 'Something went wrong'}`);
+    this.name = 'UserFacingError';
+  }
+}

--- a/src/management-system-v2/prisma/migrations/20250731185719_seedfile_version/migration.sql
+++ b/src/management-system-v2/prisma/migrations/20250731185719_seedfile_version/migration.sql
@@ -1,0 +1,7 @@
+-- CreateTable
+CREATE TABLE "SeedVersion" (
+    "id" INTEGER NOT NULL DEFAULT 0,
+    "version" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "SeedVersion_pkey" PRIMARY KEY ("id")
+);

--- a/src/management-system-v2/prisma/schema.prisma
+++ b/src/management-system-v2/prisma/schema.prisma
@@ -307,3 +307,9 @@ model MSConfig {
   id      Int   @id @default(0) 
   config  Json
 }
+
+// Last seed version written to db, this table should only have one entry
+model SeedVersion { 
+  id      Int   @id @default(0) 
+  version DateTime
+}

--- a/src/management-system-v2/seed-db-with-spaces.config.ts
+++ b/src/management-system-v2/seed-db-with-spaces.config.ts
@@ -1,6 +1,7 @@
 import { DBSeed } from './lib/db-seed';
 
 export const seedDbConfig: DBSeed = {
+  version: '2025-07-31T00:00:00.000Z',
   users: [],
   organizations: [],
 };


### PR DESCRIPTION
## Summary

Implemented multiple things for the configuration of the ms via env-vars (msconfig) and seed file.

There is a special case when PROCEED_PUBLIC_IAM_PERSONAL_SPACES_ACTIVE=true and PROCEED_PUBLIC_IAM_ONLY_ONE_ORGANIZATIONAL_SPACE=true, there should only be one environment in the MS, the one defined in the seed file. Im going to call this case exclusive org in this issue.

- stop ms if file seed couldn't be imported
- moved error boundary to root and added new type of error that passes the message to the error boundary (to show it to the user)
- fix edge case when exclusive org that redirected to /create-organization even though it won't render
- fix seed-file don't recreate roles, by adding an id to them
- date version in seed file to avoid writing it twice
- hide space selection when exclusive org
- fix `getCurrentEnvironment`: correctly overwrite personal space
- disable admin panel when exclusive org
- enforce PROCEED_PUBLIC_IAM_ONLY_ONE_ORGANIZATIONAL_SPACE in the DB
- write initialPassword as temporary password
