### PR TITLE
ms2/role page

### DIFF
--- a/src/management-system-v2/app/(dashboard)/[environmentId]/iam/roles/[roleId]/page.tsx
+++ b/src/management-system-v2/app/(dashboard)/[environmentId]/iam/roles/[roleId]/page.tsx
@@ -4,7 +4,7 @@ import { getRoleWithMembersById } from '@/lib/data/db/iam/roles';
 import UnauthorizedFallback from '@/components/unauthorized-fallback';
 import { getMembers } from '@/lib/data/db/iam/memberships';
 import { getUserById } from '@/lib/data/db/iam/users';
-import { Button, Card, Space, Tabs } from 'antd';
+import { Button, Card, Result, Space, Tabs } from 'antd';
 import { LeftOutlined } from '@ant-design/icons';
 import RoleGeneralData from './roleGeneralData';
 import RolePermissions from './rolePermissions';
@@ -26,7 +26,17 @@ const Page = async ({
   if (!role)
     return (
       <Content>
-        <h1>Role not found</h1>
+        <Result
+          status="404"
+          title="Role not found"
+          subTitle="Sorry, the page you visited does not exist."
+          extra={
+            <SpaceLink href={`/iam/roles`}>
+              <Button type="primary">Back to Roles</Button>
+            </SpaceLink>
+          }
+        />
+        );
       </Content>
     );
 

--- a/src/management-system-v2/app/(dashboard)/[environmentId]/iam/roles/[roleId]/page.tsx
+++ b/src/management-system-v2/app/(dashboard)/[environmentId]/iam/roles/[roleId]/page.tsx
@@ -2,7 +2,6 @@ import { getCurrentEnvironment } from '@/components/auth';
 import Content from '@/components/content';
 import { getRoleWithMembersById } from '@/lib/data/db/iam/roles';
 import UnauthorizedFallback from '@/components/unauthorized-fallback';
-import { toCaslResource } from '@/lib/ability/caslAbility';
 import { getMembers } from '@/lib/data/db/iam/memberships';
 import { getUserById } from '@/lib/data/db/iam/users';
 import { Button, Card, Space, Tabs } from 'antd';
@@ -21,7 +20,8 @@ const Page = async ({
 }) => {
   const { ability, activeEnvironment } = await getCurrentEnvironment(environmentId);
   const role = await getRoleWithMembersById(roleId, ability);
-  if (role && !ability.can('manage', toCaslResource('Role', role))) return <UnauthorizedFallback />;
+  // if (role && !ability.can('manage', toCaslResource('Role', role))) return <UnauthorizedFallback />;
+  if (!ability.can('admin', 'All')) return <UnauthorizedFallback />;
 
   if (!role)
     return (

--- a/src/management-system-v2/app/(dashboard)/[environmentId]/iam/roles/[roleId]/page.tsx
+++ b/src/management-system-v2/app/(dashboard)/[environmentId]/iam/roles/[roleId]/page.tsx
@@ -53,7 +53,6 @@ const Page = async ({
       label: 'Permissions',
       children: <RolePermissions role={role} />,
     },
-    ,
   ];
 
   if (role.name !== '@everyone' && role.name !== '@guest') {

--- a/src/management-system-v2/app/(dashboard)/[environmentId]/iam/roles/[roleId]/page.tsx
+++ b/src/management-system-v2/app/(dashboard)/[environmentId]/iam/roles/[roleId]/page.tsx
@@ -42,6 +42,30 @@ const Page = async ({
 
   const roleParentFolder = role.parentId ? await getFolderById(role.parentId, ability) : undefined;
 
+  const tabs = [
+    {
+      key: 'generalData',
+      label: 'General Data',
+      children: <RoleGeneralData role={role} roleParentFolder={roleParentFolder} />,
+    },
+    {
+      key: 'permissions',
+      label: 'Permissions',
+      children: <RolePermissions role={role} />,
+    },
+    ,
+  ];
+
+  if (role.name !== '@everyone' && role.name !== '@guest') {
+    tabs.push({
+      key: 'members',
+      label: 'Manage Members',
+      children: (
+        <RoleMembers role={role} usersNotInRole={usersNotInRole} usersInRole={usersInRole} />
+      ),
+    });
+  }
+
   return (
     <Content
       title={
@@ -57,31 +81,7 @@ const Page = async ({
     >
       <div style={{ maxWidth: '800px', margin: 'auto' }}>
         <Card>
-          <Tabs
-            items={[
-              {
-                key: 'generalData',
-                label: 'General Data',
-                children: <RoleGeneralData role={role} roleParentFolder={roleParentFolder} />,
-              },
-              {
-                key: 'permissions',
-                label: 'Permissions',
-                children: <RolePermissions role={role} />,
-              },
-              {
-                key: 'members',
-                label: 'Manage Members',
-                children: (
-                  <RoleMembers
-                    role={role}
-                    usersNotInRole={usersNotInRole}
-                    usersInRole={usersInRole}
-                  />
-                ),
-              },
-            ]}
-          />
+          <Tabs items={tabs} />
         </Card>
       </div>
     </Content>

--- a/src/management-system-v2/app/(dashboard)/[environmentId]/iam/roles/[roleId]/role-members.tsx
+++ b/src/management-system-v2/app/(dashboard)/[environmentId]/iam/roles/[roleId]/role-members.tsx
@@ -5,7 +5,10 @@ import { DeleteOutlined, PlusOutlined } from '@ant-design/icons';
 import UserList, { UserListProps } from '@/components/user-list';
 import { App, Button, Modal, Tooltip } from 'antd';
 import ConfirmationButton from '@/components/confirmation-button';
-import { addRoleMappings, deleteRoleMappings } from '@/lib/data/role-mappings';
+import {
+  addRoleMappings,
+  deleteRoleMappings as serverDeleteRoleMappings,
+} from '@/lib/data/role-mappings';
 import { useRouter } from 'next/navigation';
 import { Role, RoleWithMembers } from '@/lib/data/role-schema';
 import { AuthenticatedUser } from '@/lib/data/user-schema';
@@ -40,6 +43,7 @@ const AddUserModal: FC<{
           if (clearIds) clearIds();
           router.refresh();
         },
+        errorDisplay: 'notification',
         app,
       });
     });
@@ -98,12 +102,12 @@ const RoleMembers: FC<{
   const environment = useEnvironment();
   const app = App.useApp();
 
-  async function deleteMembers(userIds: string[], clearIds: () => void) {
+  async function deleteRoleMappings(userIds: string[], clearIds: () => void) {
     setLoading(true);
 
     await wrapServerCall({
       fn: () =>
-        deleteRoleMappings(
+        serverDeleteRoleMappings(
           environment.spaceId,
           userIds.map((userId) => ({
             roleId: role.id,
@@ -114,6 +118,7 @@ const RoleMembers: FC<{
         router.refresh();
         clearIds();
       },
+      errorDisplay: 'notification',
       app,
     });
 
@@ -148,7 +153,7 @@ const RoleMembers: FC<{
                 <ConfirmationButton
                   title="Remove Member"
                   description="Are you sure you want to remove this member?"
-                  onConfirm={() => deleteMembers([id], clearSelected)}
+                  onConfirm={() => deleteRoleMappings([id], clearSelected)}
                   buttonProps={{
                     style: { opacity: hoveredId == id && selectedRowKeys.length === 0 ? 1 : 0 },
                     icon: <DeleteOutlined />,
@@ -164,7 +169,7 @@ const RoleMembers: FC<{
             <ConfirmationButton
               title="Remove Members"
               description="Are you sure you want to remove the selected members?"
-              onConfirm={() => deleteMembers(ids, clearIds)}
+              onConfirm={() => deleteRoleMappings(ids, clearIds)}
               buttonProps={{
                 icon: <DeleteOutlined />,
                 type: 'text',

--- a/src/management-system-v2/app/(dashboard)/[environmentId]/iam/roles/[roleId]/role-permissions-helper.ts
+++ b/src/management-system-v2/app/(dashboard)/[environmentId]/iam/roles/[roleId]/role-permissions-helper.ts
@@ -42,8 +42,8 @@ export function switchChecked(
     const permissionNumber = permissions[resource]!;
 
     if (action === 'admin' && permissionNumber !== ResourceActionsMapping.admin) return false;
-    // disable all other actions if admin is checked
-    else if (permissionNumber === ResourceActionsMapping.admin) return false;
+    // If admin is checked all other permissions are checked
+    else if (action !== 'admin' && permissionNumber === ResourceActionsMapping.admin) continue;
 
     // bit check
     if (!(ResourceActionsMapping[action] & permissionNumber)) return false;

--- a/src/management-system-v2/app/(dashboard)/[environmentId]/iam/roles/[roleId]/roleGeneralData.tsx
+++ b/src/management-system-v2/app/(dashboard)/[environmentId]/iam/roles/[roleId]/roleGeneralData.tsx
@@ -118,20 +118,26 @@ const RoleGeneralData: FC<{ role: Role; roleParentFolder?: Folder }> = ({
     });
   }
 
+  let note;
+  if (role.note) {
+    note = role.note;
+  } else if (role.name === '@guest') {
+    note = 'This role applies to users that are not part of the organization.';
+  } else if (role.name === '@everyone') {
+    note = 'This role applies to every user that is part of the organization.';
+  }
+
   return (
     <Form form={form} layout="vertical" onFinish={submitChanges} initialValues={role}>
-      {role.note && (
+      {note && (
         <>
-          <Alert type="warning" message={role.note} />
+          <Alert type="info" message={note} />
           <br />
         </>
       )}
 
       <Form.Item label="Name" name="name" {...antDesignInputProps(errors, 'name')} required>
-        <Input
-          placeholder="input placeholder"
-          disabled={!ability.can('update', role, { field: 'name' })}
-        />
+        <Input disabled={!ability.can('update', role, { field: 'name' })} />
       </Form.Item>
 
       <Form.Item
@@ -139,10 +145,7 @@ const RoleGeneralData: FC<{ role: Role; roleParentFolder?: Folder }> = ({
         name="description"
         {...antDesignInputProps(errors, 'description')}
       >
-        <Input.TextArea
-          placeholder="input placeholder"
-          disabled={!ability.can('update', role, { field: 'description' })}
-        />
+        <Input.TextArea disabled={!ability.can('update', role, { field: 'description' })} />
       </Form.Item>
 
       {/** <Form.Item label="Expiration" name="expirationDayJs">

--- a/src/management-system-v2/app/(dashboard)/[environmentId]/iam/roles/[roleId]/roleGeneralData.tsx
+++ b/src/management-system-v2/app/(dashboard)/[environmentId]/iam/roles/[roleId]/roleGeneralData.tsx
@@ -3,8 +3,8 @@
 import { toCaslResource } from '@/lib/ability/caslAbility';
 import { Alert, App, Button, DatePicker, Form, Input, Modal, Space } from 'antd';
 import { FC, useState } from 'react';
-import dayjs from 'dayjs';
-import germanLocale from 'antd/es/date-picker/locale/de_DE';
+// import dayjs from 'dayjs';
+// import germanLocale from 'antd/es/date-picker/locale/de_DE';
 import { useAbilityStore } from '@/lib/abilityStore';
 import { updateRole } from '@/lib/data/roles';
 import { useRouter } from 'next/navigation';
@@ -103,10 +103,10 @@ const RoleGeneralData: FC<{ role: Role; roleParentFolder?: Folder }> = ({
   const role = toCaslResource('Role', _role);
 
   async function submitChanges(values: Record<string, any>) {
-    if (typeof values?.expirationDayJs === 'object') {
-      values.expiration = (values.expirationDayJs as dayjs.Dayjs).toISOString();
-      delete values.expirationDayJs;
-    }
+    // if (typeof values?.expirationDayJs === 'object') {
+    //   values.expiration = (values.expirationDayJs as dayjs.Dayjs).toISOString();
+    //   delete values.expirationDayJs;
+    // }
 
     await wrapServerCall({
       fn: () => updateRole(environment.spaceId, role.id, values),
@@ -145,7 +145,7 @@ const RoleGeneralData: FC<{ role: Role; roleParentFolder?: Folder }> = ({
         />
       </Form.Item>
 
-      <Form.Item label="Expiration" name="expirationDayJs">
+      {/** <Form.Item label="Expiration" name="expirationDayJs">
         <DatePicker
           // Note german locale hard coded
           locale={germanLocale}
@@ -153,7 +153,7 @@ const RoleGeneralData: FC<{ role: Role; roleParentFolder?: Folder }> = ({
           disabled={!ability.can('update', role, { field: 'expiration' })}
           defaultValue={role.expiration ? dayjs(new Date(role.expiration)) : undefined}
         />
-      </Form.Item>
+      </Form.Item>*/}
 
       <Form.Item label="Folder" name="parentId">
         <FolderInput defaultFolder={roleParentFolder} />

--- a/src/management-system-v2/app/(dashboard)/[environmentId]/iam/roles/[roleId]/rolePermissions.tsx
+++ b/src/management-system-v2/app/(dashboard)/[environmentId]/iam/roles/[roleId]/rolePermissions.tsx
@@ -2,7 +2,7 @@
 
 import { Divider, Form, Row, Space, Switch, Typography, App, Button } from 'antd';
 import { SaveOutlined } from '@ant-design/icons';
-import { ResourceActionType } from '@/lib/ability/caslAbility';
+import { ResourceActionType, ResourceType } from '@/lib/ability/caslAbility';
 import { FC, Fragment, useState } from 'react';
 import { switchChecked, switchDisabled, togglePermission } from './role-permissions-helper';
 import { useAbilityStore } from '@/lib/abilityStore';
@@ -14,7 +14,7 @@ import { UserErrorType } from '@/lib/user-error';
 type PermissionCategory = {
   key: string;
   title: string;
-  resource: keyof Role['permissions'] | (keyof Role['permissions'])[];
+  resource: ResourceType | ResourceType[];
   permissions: {
     key: string;
     title: string;
@@ -40,7 +40,7 @@ const basePermissionOptions: PermissionCategory[] = [
         title: 'Administrate Organization',
         description:
           'Allows a user to update the Organization information and to delete the Organization.',
-        permission: 'manage',
+        permission: 'admin',
       },
     ],
   },
@@ -278,12 +278,12 @@ const RolePermissions: FC<{ role: Role }> = ({ role }) => {
   return (
     <Form form={form} onFinish={updateRole}>
       {basePermissionOptions.map((permissionCategory) => (
-        <>
+        <Fragment key={permissionCategory.key}>
           <Typography.Title type="secondary" level={5}>
             {permissionCategory.title}
           </Typography.Title>
           {permissionCategory.permissions.map((permission, idx) => (
-            <Fragment key={permissionCategory.key}>
+            <Fragment key={permission.key}>
               <Row align="top" justify="space-between" wrap={false}>
                 <Space direction="vertical" size={0}>
                   <Typography.Text strong>{permission.title}</Typography.Text>
@@ -320,7 +320,7 @@ const RolePermissions: FC<{ role: Role }> = ({ role }) => {
             </Fragment>
           ))}
           <br />
-        </>
+        </Fragment>
       ))}
 
       <Button

--- a/src/management-system-v2/app/(dashboard)/[environmentId]/iam/roles/[roleId]/rolePermissions.tsx
+++ b/src/management-system-v2/app/(dashboard)/[environmentId]/iam/roles/[roleId]/rolePermissions.tsx
@@ -187,19 +187,19 @@ const basePermissionOptions: PermissionCategory[] = [
       },
     ],
   },
-  {
-    key: 'roles',
-    title: 'ROLES',
-    resource: ['Role', 'RoleMapping'],
-    permissions: [
-      {
-        key: 'Manage Roles',
-        title: 'Manage Roles',
-        description: 'Allows a user to create, modify and delete roles.',
-        permission: 'manage',
-      },
-    ],
-  },
+  // {
+  //   key: 'roles',
+  //   title: 'ROLES',
+  //   resource: ['Role', 'RoleMapping'],
+  //   permissions: [
+  //     {
+  //       key: 'Manage Roles',
+  //       title: 'Manage Roles',
+  //       description: 'Allows a user to create, modify and delete roles.',
+  //       permission: 'manage',
+  //     },
+  //   ],
+  // },
   {
     key: 'users',
     title: 'USERS',

--- a/src/management-system-v2/app/(dashboard)/[environmentId]/iam/roles/[roleId]/rolePermissions.tsx
+++ b/src/management-system-v2/app/(dashboard)/[environmentId]/iam/roles/[roleId]/rolePermissions.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import { Divider, Form, Row, Space, Switch, Typography, App, Button } from 'antd';
-import { SaveOutlined } from '@ant-design/icons';
 import { ResourceActionType, ResourceType } from '@/lib/ability/caslAbility';
 import { FC, Fragment, use, useState } from 'react';
 import { switchChecked, switchDisabled, togglePermission } from './role-permissions-helper';
@@ -328,13 +327,12 @@ const RolePermissions: FC<{ role: Role }> = ({ role }) => {
         type="primary"
         htmlType="submit"
         loading={loading}
-        icon={<SaveOutlined />}
         style={{
           position: 'sticky',
           bottom: 0,
         }}
       >
-        Save
+        Update Role
       </Button>
     </Form>
   );

--- a/src/management-system-v2/app/(dashboard)/[environmentId]/iam/roles/header-actions.tsx
+++ b/src/management-system-v2/app/(dashboard)/[environmentId]/iam/roles/header-actions.tsx
@@ -1,15 +1,15 @@
 'use client';
 
 import { PlusOutlined } from '@ant-design/icons';
-import { Button, Form, Input, Modal, DatePicker, App } from 'antd';
+import { Button, Form, Input, Modal, App } from 'antd';
 import { FC, ReactNode, useEffect, useState } from 'react';
-import dayjs from 'dayjs';
-import germanLocale from 'antd/es/date-picker/locale/de_DE';
+// import dayjs from 'dayjs';
+// import germanLocale from 'antd/es/date-picker/locale/de_DE';
 import { AuthCan, useEnvironment } from '@/components/auth-can';
 import { addRole as serverAddRoles } from '@/lib/data/roles';
 import { wrapServerCall } from '@/lib/wrap-server-call';
 
-type PostRoleKeys = 'name' | 'description' | 'expiration';
+type PostRoleKeys = 'name' | 'description'; //| 'expiration';
 
 const CreateRoleModal: FC<{
   modalOpen: boolean;
@@ -42,9 +42,9 @@ const CreateRoleModal: FC<{
   }, [form, modalOpen]);
 
   const submitData = async (values: Record<'name' | 'description' | 'expirationDayJs', 'post'>) => {
-    let expiration;
-    if (typeof values.expirationDayJs === 'object')
-      expiration = (values.expirationDayJs as dayjs.Dayjs).toISOString();
+    // let expiration;
+    // if (typeof values.expirationDayJs === 'object')
+    //   expiration = (values.expirationDayJs as dayjs.Dayjs).toISOString();
 
     await wrapServerCall({
       fn: () =>
@@ -81,7 +81,7 @@ const CreateRoleModal: FC<{
           <Input.TextArea />
         </Form.Item>
 
-        <Form.Item
+        {/**<Form.Item
           label="Expiration"
           name="expirationDayJs"
           help={formatError.expiration}
@@ -93,6 +93,7 @@ const CreateRoleModal: FC<{
             allowClear={true}
           />
         </Form.Item>
+        */}
 
         <Form.Item>
           <Button type="primary" htmlType="submit" disabled={!submittable}>

--- a/src/management-system-v2/app/(dashboard)/[environmentId]/iam/roles/page.tsx
+++ b/src/management-system-v2/app/(dashboard)/[environmentId]/iam/roles/page.tsx
@@ -7,7 +7,8 @@ import UnauthorizedFallback from '@/components/unauthorized-fallback';
 const Page = async ({ params }: { params: { environmentId: string } }) => {
   const { ability, activeEnvironment } = await getCurrentEnvironment(params.environmentId);
 
-  if (!ability.can('manage', 'Role')) return <UnauthorizedFallback />;
+  // if (!ability.can('manage', 'Role')) return <UnauthorizedFallback />;
+  if (!ability.can('admin', 'All')) return <UnauthorizedFallback />;
 
   const roles = await getRolesWithMembers(activeEnvironment.spaceId, ability);
 

--- a/src/management-system-v2/app/(dashboard)/[environmentId]/iam/roles/role-page.tsx
+++ b/src/management-system-v2/app/(dashboard)/[environmentId]/iam/roles/role-page.tsx
@@ -4,8 +4,8 @@ import { useState } from 'react';
 import {
   DeleteOutlined,
   InfoCircleOutlined,
-  UnorderedListOutlined,
-  AppstoreOutlined,
+  // UnorderedListOutlined,
+  // AppstoreOutlined,
   PlusOutlined,
 } from '@ant-design/icons';
 import { Space, Button, Table, Breakpoint, Grid, FloatButton, Tooltip, App } from 'antd';
@@ -24,7 +24,6 @@ import { RoleWithMembers } from '@/lib/data/role-schema';
 import { useEnvironment } from '@/components/auth-can';
 import styles from './role-page.module.scss';
 import { useUserPreferences } from '@/lib/user-preferences';
-import cn from 'classnames';
 
 import { wrapServerCall } from '@/lib/wrap-server-call';
 import SelectionActions from '@/components/selection-actions';
@@ -59,7 +58,7 @@ const RolesPage = ({ roles }: { roles: RoleWithMembers[] }) => {
   const [hoveredRow, setHoveredRow] = useState<string | null>(null);
   const [showMobileRoleSider, setShowMobileRoleSider] = useState(false);
 
-  const addPreferences = useUserPreferences.use.addPreferences();
+  // const addPreferences = useUserPreferences.use.addPreferences();
   const iconView = useUserPreferences.use['icon-view-in-role-list']();
 
   const breakpoint = Grid.useBreakpoint();
@@ -180,28 +179,26 @@ const RolesPage = ({ roles }: { roles: RoleWithMembers[] }) => {
                   {selectedRowKeys.length > 0 ? <Space size={20}></Space> : undefined}
                 </span>
 
-                {
-                  <span>
-                    <Space.Compact className={cn(breakpoint.xs ? styles.MobileToggleView : '')}>
-                      <Button
-                        style={!iconView ? { color: '#3e93de', borderColor: '#3e93de' } : {}}
-                        onClick={() => {
-                          addPreferences({ 'icon-view-in-process-list': false });
-                        }}
-                      >
-                        <UnorderedListOutlined />
-                      </Button>
-                      <Button
-                        style={!iconView ? {} : { color: '#3e93de', borderColor: '#3e93de' }}
-                        onClick={() => {
-                          addPreferences({ 'icon-view-in-process-list': true });
-                        }}
-                      >
-                        <AppstoreOutlined />
-                      </Button>
-                    </Space.Compact>
-                  </span>
-                }
+                {/**
+                  <Space.Compact className={cn(breakpoint.xs ? styles.MobileToggleView : '')}>
+                    <Button
+                      style={!iconView ? { color: '#3e93de', borderColor: '#3e93de' } : {}}
+                      onClick={() => {
+                        addPreferences({ 'icon-view-in-process-list': false });
+                      }}
+                    >
+                      <UnorderedListOutlined />
+                    </Button>
+                    <Button
+                      style={!iconView ? {} : { color: '#3e93de', borderColor: '#3e93de' }}
+                      onClick={() => {
+                        addPreferences({ 'icon-view-in-process-list': true });
+                      }}
+                    >
+                      <AppstoreOutlined />
+                    </Button>
+                  </Space.Compact>
+                */}
 
                 {/* <!-- FloatButtonGroup needs a z-index of 101
               since BPMN Logo of the viewer has an z-index of 100 --> */}

--- a/src/management-system-v2/app/(dashboard)/[environmentId]/iam/roles/role-page.tsx
+++ b/src/management-system-v2/app/(dashboard)/[environmentId]/iam/roles/role-page.tsx
@@ -8,7 +8,7 @@ import {
   // AppstoreOutlined,
   PlusOutlined,
 } from '@ant-design/icons';
-import { Space, Button, Breakpoint, Grid, FloatButton, Tooltip, App } from 'antd';
+import { Space, Button, Breakpoint, Grid, FloatButton, Tooltip, App, TableProps } from 'antd';
 import { CloseOutlined } from '@ant-design/icons';
 import HeaderActions from './header-actions';
 import useFuzySearch, { ReplaceKeysWithHighlighted } from '@/lib/useFuzySearch';
@@ -85,7 +85,7 @@ const RolesPage = ({ roles }: { roles: RoleWithMembers[] }) => {
     });
   }
 
-  const columns = [
+  const columns: TableProps<FilteredRole>['columns'] = [
     {
       title: 'Name',
       dataIndex: 'name',
@@ -95,6 +95,7 @@ const RolesPage = ({ roles }: { roles: RoleWithMembers[] }) => {
           {name.highlighted}
         </Link>
       ),
+      sorter: (a, b) => a.name.value.localeCompare(b.name.value),
     },
     {
       title: 'Members',
@@ -102,6 +103,7 @@ const RolesPage = ({ roles }: { roles: RoleWithMembers[] }) => {
       render: (members: FilteredRole['members']) => (
         <Tooltip title={getMembersRepresentation(members)}>{members.length}</Tooltip>
       ),
+      sorter: (a, b) => a.members.length - b.members.length,
       key: 'username',
     },
     {

--- a/src/management-system-v2/app/(dashboard)/[environmentId]/iam/roles/role-side-panel.tsx
+++ b/src/management-system-v2/app/(dashboard)/[environmentId]/iam/roles/role-side-panel.tsx
@@ -35,8 +35,12 @@ const RoleContent: FC<{
             </>
           )}
 
-          <Typography.Title>Members</Typography.Title>
-          <Typography.Text>{role.members.length}</Typography.Text>
+          {role.name.value !== '@everyone' && role.name.value !== '@gues' && (
+            <>
+              <Typography.Title>Members</Typography.Title>
+              <Typography.Text>{role.members.length}</Typography.Text>
+            </>
+          )}
 
           <Typography.Title>Last Edited</Typography.Title>
           <Typography.Text>{role.lastEditedOn.toUTCString()}</Typography.Text>

--- a/src/management-system-v2/app/(dashboard)/[environmentId]/iam/roles/role-side-panel.tsx
+++ b/src/management-system-v2/app/(dashboard)/[environmentId]/iam/roles/role-side-panel.tsx
@@ -47,12 +47,17 @@ const RoleContent: FC<{
           {role.members.length > 0 && (
             <>
               <Typography.Title>Members</Typography.Title>
-              {role.members.map((user) => (
-                <Space key={user.id}>
-                  <UserAvatar user={user} size={30} />
-                  <Typography.Text>{userRepresentation(user)}</Typography.Text>
-                </Space>
-              ))}
+              <div style={{ display: 'flex', flexWrap: 'wrap', gap: '.5rem' }}>
+                {role.members.map((user) => (
+                  <div
+                    key={user.id}
+                    style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}
+                  >
+                    <UserAvatar user={user} size={30} />
+                    <Typography.Text>{userRepresentation(user)}</Typography.Text>
+                  </div>
+                ))}
+              </div>
             </>
           )}
         </>

--- a/src/management-system-v2/app/(dashboard)/[environmentId]/layout.tsx
+++ b/src/management-system-v2/app/(dashboard)/[environmentId]/layout.tsx
@@ -177,16 +177,14 @@ const DashboardLayout = async ({
   if (
     activeEnvironment.isOrganization &&
     (can('manage', 'User') ||
-      // can('manage', 'RoleMapping') ||
-      // can('manage', 'Role') ||
+      can('manage', 'RoleMapping') ||
+      can('manage', 'Role') ||
       can('update', 'Environment') ||
-      can('delete', 'Environment') ||
-      can('view', 'Setting') ||
-      can('update', 'Setting'))
+      can('delete', 'Environment'))
   ) {
     const children: MenuProps['items'] = [];
 
-    if (can('view', 'Setting') || can('update', 'Setting')) {
+    if (can('update', 'Environment') || can('delete', 'Environment')) {
       children.push({
         key: 'organization-settings',
         label: <Link href={spaceURL(activeEnvironment, `/settings`)}>Settings</Link>,

--- a/src/management-system-v2/app/(dashboard)/[environmentId]/layout.tsx
+++ b/src/management-system-v2/app/(dashboard)/[environmentId]/layout.tsx
@@ -185,36 +185,40 @@ const DashboardLayout = async ({
   ) {
     const children: MenuProps['items'] = [];
 
-    if (can('update', 'Environment') || can('delete', 'Environment'))
+    if (can('update', 'Environment') || can('delete', 'Environment')) {
       children.push({
         key: 'organization-settings',
         label: <Link href={spaceURL(activeEnvironment, `/settings`)}>Settings</Link>,
         icon: <SettingOutlined />,
       });
+    }
 
     if (
       activeEnvironment.isOrganization &&
       (can('update', 'Environment') || can('delete', 'Environment'))
-    )
+    ) {
       children.push({
         key: 'organization-management',
         label: <Link href={spaceURL(activeEnvironment, `/management`)}>Management</Link>,
         icon: <GoOrganization />,
       });
+    }
 
-    if (can('manage', 'User'))
+    if (can('manage', 'User')) {
       children.push({
         key: 'users',
         label: <Link href={spaceURL(activeEnvironment, `/iam/users`)}>Users</Link>,
         icon: <UserOutlined />,
       });
+    }
 
-    if (can('manage', 'RoleMapping') || can('manage', 'Role'))
+    if (can('admin', 'All')) {
       children.push({
         key: 'roles',
         label: <Link href={spaceURL(activeEnvironment, `/iam/roles`)}>Roles</Link>,
         icon: <TeamOutlined />,
       });
+    }
 
     layoutMenuItems.push({
       key: 'iam-group',

--- a/src/management-system-v2/app/(dashboard)/[environmentId]/layout.tsx
+++ b/src/management-system-v2/app/(dashboard)/[environmentId]/layout.tsx
@@ -178,14 +178,16 @@ const DashboardLayout = async ({
   if (
     activeEnvironment.isOrganization &&
     (can('manage', 'User') ||
-      can('manage', 'RoleMapping') ||
-      can('manage', 'Role') ||
+      // can('manage', 'RoleMapping') ||
+      // can('manage', 'Role') ||
       can('update', 'Environment') ||
-      can('delete', 'Environment'))
+      can('delete', 'Environment') ||
+      can('view', 'Setting') ||
+      can('update', 'Setting'))
   ) {
     const children: MenuProps['items'] = [];
 
-    if (can('update', 'Environment') || can('delete', 'Environment')) {
+    if (can('view', 'Setting') || can('update', 'Setting')) {
       children.push({
         key: 'organization-settings',
         label: <Link href={spaceURL(activeEnvironment, `/settings`)}>Settings</Link>,

--- a/src/management-system-v2/app/(dashboard)/[environmentId]/layout.tsx
+++ b/src/management-system-v2/app/(dashboard)/[environmentId]/layout.tsx
@@ -1,5 +1,5 @@
 import { PropsWithChildren } from 'react';
-import { getCurrentEnvironment, getCurrentUser } from '@/components/auth';
+import { getCurrentEnvironment, getCurrentUser, getSystemAdminRules } from '@/components/auth';
 import { SetAbility } from '@/lib/abilityStore';
 import Layout from './layout-client';
 import { getUserOrganizationEnvironments } from '@/lib/data/db/iam/memberships';
@@ -28,9 +28,8 @@ import { getEnvironmentById, getSpaceLogo } from '@/lib/data/db/iam/environments
 import { getSpaceFolderTree, getUserRules } from '@/lib/authorization/authorization';
 import { Environment } from '@/lib/data/environment-schema';
 import { spaceURL } from '@/lib/utils';
-import { RemoveReadOnly, truthyFilter } from '@/lib/typescript-utils';
+import { truthyFilter } from '@/lib/typescript-utils';
 import { asyncMap } from '@/lib/helpers/javascriptHelpers';
-import { adminRules } from '@/lib/authorization/globalRules';
 import { getSpaceSettingsValues } from '@/lib/data/db/space-settings';
 import { getMSConfig } from '@/lib/ms-config/ms-config';
 import GuestWarningButton from '@/components/guest-warning-button';
@@ -67,7 +66,7 @@ const DashboardLayout = async ({
   userEnvironments.push(...orgEnvironments);
 
   const userRules = systemAdmin
-    ? (adminRules as RemoveReadOnly<typeof adminRules>)
+    ? getSystemAdminRules(activeEnvironment.isOrganization)
     : await getUserRules(userId, activeEnvironment.spaceId);
 
   const generalSettings = await getSpaceSettingsValues(

--- a/src/management-system-v2/app/(dashboard)/[environmentId]/management/@organizationSettings/page.tsx
+++ b/src/management-system-v2/app/(dashboard)/[environmentId]/management/@organizationSettings/page.tsx
@@ -4,17 +4,23 @@ import { OrganizationEnvironment } from '@/lib/data/environment-schema';
 import Wrapper from './wrapper';
 import { Setting, SettingGroup } from '../../settings/type-util';
 import SettingsInjector from '../../settings/settings-injector';
+import { UnauthorizedError } from '@/lib/ability/abilityHelper';
 
 const GeneralSettingsPage = async ({ params }: { params: { environmentId: string } }) => {
   const { ability, activeEnvironment } = await getCurrentEnvironment(params.environmentId);
-  if (!activeEnvironment.isOrganization || !ability.can('manage', 'Environment')) return null;
+  if (
+    !activeEnvironment.isOrganization ||
+    (!ability.can('update', 'Environment') && !ability.can('delete', 'Environment'))
+  ) {
+    throw new UnauthorizedError();
+  }
 
   const organization = (await getEnvironmentById(
     activeEnvironment.spaceId,
   )) as OrganizationEnvironment;
 
   const children: (Setting | SettingGroup)[] = [];
-  if (ability.can('manage', 'Environment')) {
+  if (ability.can('update', 'Environment')) {
     children.push({
       key: 'organizationDetails',
       name: 'Information',

--- a/src/management-system-v2/components/auth.tsx
+++ b/src/management-system-v2/components/auth.tsx
@@ -6,7 +6,7 @@ import { getUserOrganizationEnvironments, isMember } from '@/lib/data/db/iam/mem
 import { getSystemAdminByUserId } from '@/lib/data/db/iam/system-admins';
 import Ability from '@/lib/ability/abilityHelper';
 import {
-  adminRules,
+  packedAdminRules,
   packedGlobalOrganizationRules,
   packedGlobalUserRules,
 } from '@/lib/authorization/globalRules';
@@ -16,6 +16,7 @@ import { getUserById } from '@/lib/data/db/iam/users';
 import { cookies } from 'next/headers';
 import { getMSConfig } from '@/lib/ms-config/ms-config';
 import { UIError as UserUIError } from '@/lib/ui-error';
+import { packedStaticRules } from '@/lib/authorization/caslRules';
 
 export const getCurrentUser = cache(async () => {
   if (!env.PROCEED_PUBLIC_IAM_ACTIVE) {
@@ -46,6 +47,22 @@ export const getCurrentUser = cache(async () => {
   }
 
   return { session, userId, systemAdmin, user };
+});
+
+const systemAdminRulesForOrganizations = packedAdminRules
+  .concat(packedGlobalOrganizationRules)
+  .concat(packedStaticRules);
+
+const systemAdminRulesForPersonalSpaces = packedAdminRules
+  .concat(packedGlobalUserRules)
+  .concat(packedStaticRules);
+
+export const getSystemAdminRules = cache((isOrganization: boolean) => {
+  if (isOrganization) {
+    return systemAdminRulesForOrganizations;
+  } else {
+    return systemAdminRulesForPersonalSpaces;
+  }
 });
 
 // TODO: To enable PPR move the session redirect into this function, so it will
@@ -96,9 +113,7 @@ export const getCurrentEnvironment = cache(
     // TODO: account for bought resources
 
     if (systemAdmin || !msConfig.PROCEED_PUBLIC_IAM_ACTIVE) {
-      let rules;
-      if (isOrganization) rules = adminRules.concat(packedGlobalOrganizationRules);
-      else rules = adminRules.concat(packedGlobalUserRules);
+      const rules = getSystemAdminRules(isOrganization);
 
       return {
         ability: new Ability(rules, activeSpace),

--- a/src/management-system-v2/components/user-list.tsx
+++ b/src/management-system-v2/components/user-list.tsx
@@ -164,15 +164,10 @@ const UserList: FC<UserListProps> = ({
             onRow: (element) => ({
               onMouseEnter: () => setHoveredRowId(element.id),
               onMouseLeave: () => setHoveredRowId(null),
-              onClick: () => {
-                setSelectedRows([element]);
-                if (onSelectedRows) onSelectedRows([element]);
-              },
-
-              pagination: { position: ['bottomCenter'] },
-              rowKey: 'id',
-              loading,
             }),
+            pagination: { position: ['bottomCenter'] },
+            rowKey: 'id',
+            loading,
           }}
         />
       )}

--- a/src/management-system-v2/components/user-list.tsx
+++ b/src/management-system-v2/components/user-list.tsx
@@ -121,26 +121,25 @@ const UserList: FC<UserListProps> = ({
               ) : null}
             </span>
 
-            <span>
+            {/** TODO: implement icon view and uncomment this toggle
               <Space.Compact className={cn(breakpoint.xs ? styles.MobileToggleView : '')}>
-                <Button
-                  style={!iconView ? { color: '#3e93de', borderColor: '#3e93de' } : {}}
-                  onClick={() => {
-                    addPreferences({ 'icon-view-in-process-list': false });
-                  }}
-                >
-                  <UnorderedListOutlined />
-                </Button>
-                <Button
-                  style={!iconView ? {} : { color: '#3e93de', borderColor: '#3e93de' }}
-                  onClick={() => {
-                    addPreferences({ 'icon-view-in-process-list': true });
-                  }}
-                >
-                  <AppstoreOutlined />
-                </Button>
-              </Space.Compact>
-            </span>
+              <Button
+                style={!iconView ? { color: '#3e93de', borderColor: '#3e93de' } : {}}
+                onClick={() => {
+                  addPreferences({ 'icon-view-in-process-list': false });
+                }}
+              >
+                <UnorderedListOutlined />
+              </Button>
+              <Button
+                style={!iconView ? {} : { color: '#3e93de', borderColor: '#3e93de' }}
+                onClick={() => {
+                  addPreferences({ 'icon-view-in-process-list': true });
+                }}
+              >
+                <AppstoreOutlined />
+              </Button>
+            </Space.Compact>*/}
           </span>
         }
         searchProps={{

--- a/src/management-system-v2/lib/ability/caslAbility.ts
+++ b/src/management-system-v2/lib/ability/caslAbility.ts
@@ -17,9 +17,7 @@ export const resources = [
   'Role',
   'User',
   'Setting',
-  'EnvConfig',
   'RoleMapping',
-  'Share',
   'Environment',
   'Folder',
   // NOTE: All is just supposed to be used for storing permissions in roles

--- a/src/management-system-v2/lib/authorization/caslRules.ts
+++ b/src/management-system-v2/lib/authorization/caslRules.ts
@@ -17,19 +17,20 @@ import {
 import { Environment } from '../data/environment-schema';
 import { Role } from '../data/role-schema';
 
-const sharedResources = new Set<ResourceType>(['Process', 'Project', 'Template']);
+export type PackedRulesForUser = ReturnType<typeof computeRulesForUser>;
 
-const globalRoles = {
-  everybodyRole: '',
-  guestRole: '',
-};
+/* -------------------------------------------------------------------------------------------------
+ * Rules for Users (= members of an organization)
+ * -----------------------------------------------------------------------------------------------*/
+const staticUserRules: AbilityRule[] = [
+  {
+    subject: 'User',
+    action: 'view',
+  },
+];
 
 function rulesForAuthenticatedUsers(userId: string): AbilityRule[] {
   return [
-    {
-      subject: 'User',
-      action: 'view',
-    },
     {
       subject: 'User',
       action: ['delete'],
@@ -43,15 +44,15 @@ function rulesForAuthenticatedUsers(userId: string): AbilityRule[] {
   ];
 }
 
-function rulesForRoles(ability: CaslAbility, userId: string) {
-  const rules: AbilityRule[] = [];
-
-  rules.push({
+/* -------------------------------------------------------------------------------------------------
+ * Rules for Roles
+ * -----------------------------------------------------------------------------------------------*/
+const staticRoleRules: AbilityRule[] = [
+  {
     subject: 'Role',
     action: 'view',
-  });
-
-  rules.push({
+  },
+  {
     inverted: true,
     subject: 'Role',
     action: 'delete',
@@ -60,7 +61,22 @@ function rulesForRoles(ability: CaslAbility, userId: string) {
         default: { $eq: true },
       },
     },
-  });
+  },
+  {
+    inverted: true,
+    subject: 'Role',
+    action: 'update',
+    conditions: {
+      conditions: {
+        default: { $eq: true },
+      },
+    },
+    fields: ['default', 'name', 'expiration'],
+  },
+];
+
+function rulesForRoles(ability: CaslAbility, userId: string) {
+  const rules: AbilityRule[] = [];
 
   rules.push({
     subject: 'RoleMapping',
@@ -73,29 +89,19 @@ function rulesForRoles(ability: CaslAbility, userId: string) {
     reason: 'Users can view their own role mappings',
   });
 
-  rules.push({
-    inverted: true,
-    subject: 'Role',
-    action: 'update',
-    conditions: {
-      conditions: {
-        default: { $eq: true },
-      },
-    },
-    fields: ['default', 'name', 'expiration'],
-  });
-  rules.push({
-    inverted: true,
-    subject: 'RoleMapping',
-    action: 'create',
-    conditions: {
-      conditions: {
-        roleId: {
-          $in: [globalRoles.everybodyRole, globalRoles.guestRole],
-        },
-      },
-    },
-  });
+  // For now we don't know the everyone and guest role ids
+  // rules.push({
+  //   inverted: true,
+  //   subject: 'RoleMapping',
+  //   action: 'create',
+  //   conditions: {
+  //     conditions: {
+  //       roleId: {
+  //         $in: [globalRoles.everybodyRole, globalRoles.guestRole],
+  //       },
+  //     },
+  //   },
+  // });
 
   if (AllowedResourcesForAdmins.some((resource) => !ability.can('admin', resource))) {
     rules.push({
@@ -132,6 +138,9 @@ function rulesForRoles(ability: CaslAbility, userId: string) {
   return rules;
 }
 
+/* -------------------------------------------------------------------------------------------------
+ * Disallow access to resources outside of the environment
+ * -----------------------------------------------------------------------------------------------*/
 const disallowOutsideOfEnvRule = (environmentId: string) =>
   ({
     inverted: true,
@@ -144,7 +153,18 @@ const disallowOutsideOfEnvRule = (environmentId: string) =>
     },
   }) as AbilityRule;
 
-export type PackedRulesForUser = ReturnType<typeof computeRulesForUser>;
+/* -------------------------------------------------------------------------------------------------
+ * Static Rules (there are always the same for all users)
+ * -----------------------------------------------------------------------------------------------*/
+export const staticRules: AbilityRule[] = Object.freeze([
+  ...staticUserRules,
+  ...staticRoleRules,
+]) as any;
+export const packedStaticRules = Object.freeze(packRules(staticRules));
+
+/* -------------------------------------------------------------------------------------------------
+ * Computes the rules for a user, this puts all the previous parts together
+ * -----------------------------------------------------------------------------------------------*/
 
 /** If possible don't use this function directly, use rulesForUser which caches the rules */
 export function computeRulesForUser({
@@ -237,6 +257,8 @@ export function computeRulesForUser({
   translatedRules.push(...rulesForAuthenticatedUsers(userId));
 
   translatedRules.push(...rulesForRoles(ability, userId));
+
+  translatedRules.push(...staticRules);
 
   // Disallow every action on other environments
   translatedRules.push(disallowOutsideOfEnvRule(space.id));

--- a/src/management-system-v2/lib/authorization/globalRules.ts
+++ b/src/management-system-v2/lib/authorization/globalRules.ts
@@ -66,7 +66,7 @@ export const packedGlobalUserRules = Object.freeze(
   packRules<AbilityRule>([...globalPersonalSpaceRules]),
 );
 
-export const adminRules = Object.freeze(
+export const packedAdminRules = Object.freeze(
   packRules([
     {
       subject: AllowedResourcesForAdmins,

--- a/src/management-system-v2/lib/data/db/iam/role-mappings.ts
+++ b/src/management-system-v2/lib/data/db/iam/role-mappings.ts
@@ -106,6 +106,10 @@ export async function addRoleMappings(
   ability?: Ability,
   _tx?: Prisma.TransactionClient,
 ): Promise<void> {
+  if (ability && !ability.can('admin', 'All')) {
+    throw new UnauthorizedError();
+  }
+
   if (!_tx) {
     return db.$transaction(async (tx) => {
       return await addRoleMappings(roleMappingsInput, ability, tx);
@@ -178,6 +182,10 @@ export async function deleteRoleMapping(
   environmentId: string,
   ability?: Ability,
 ) {
+  if (ability && !ability.can('admin', 'All')) {
+    throw new UnauthorizedError();
+  }
+
   const [environment, user, roleMapping, role] = await Promise.all([
     getEnvironmentById(environmentId),
     getUserById(userId),

--- a/src/management-system-v2/lib/data/db/iam/roles.ts
+++ b/src/management-system-v2/lib/data/db/iam/roles.ts
@@ -157,7 +157,12 @@ export async function addRole(
 
   const roleRepresentation = RoleInputSchema.parse(roleRepresentationInput);
 
-  if (ability && !ability.can('create', toCaslResource('Role', roleRepresentation))) {
+  // if (ability && !ability.can('create', toCaslResource('Role', roleRepresentation))) {
+  if (
+    ability &&
+    (!ability.can('create', toCaslResource('Role', roleRepresentation)) ||
+      !ability.can('admin', 'All'))
+  ) {
     throw new UnauthorizedError();
   }
 
@@ -220,7 +225,8 @@ export async function updateRole(
       ability.can('create', toCaslResource('Role', roleRepresentation), {
         environmentId: targetRole.environmentId,
       })
-    )
+    ) ||
+    !ability.can('admin', 'All')
   )
     throw new UnauthorizedError();
   const updatedRole = await db.role.update({
@@ -256,7 +262,10 @@ export async function deleteRole(roleId: string, ability?: Ability) {
   }
 
   // Check if user has permission to delete the role
-  if (ability && !ability.can('delete', toCaslResource('Role', role))) {
+  if (
+    ability &&
+    (!ability.can('delete', toCaslResource('Role', role)) || !ability.can('admin', 'All'))
+  ) {
     throw new UnauthorizedError();
   }
 

--- a/src/management-system-v2/lib/data/environment-memberships.ts
+++ b/src/management-system-v2/lib/data/environment-memberships.ts
@@ -47,6 +47,7 @@ export async function inviteUsersToEnvironment(
 
     const filteredRoles = roleIds?.filter(async (roleId) => {
       return (
+        ability.can('admin', 'All') &&
         ability.can('manage', toCaslResource('Role', await getRoleById(roleId))) &&
         ability.can(
           'create',

--- a/src/management-system-v2/lib/data/role-mappings.ts
+++ b/src/management-system-v2/lib/data/role-mappings.ts
@@ -12,15 +12,20 @@ export async function addRoleMappings(
   environmentId: string,
   roleMappings: Omit<RoleMappingInput, 'environmentId'>[],
 ) {
-  const { ability, activeEnvironment } = await getCurrentEnvironment(environmentId);
+  try {
+    const { ability, activeEnvironment } = await getCurrentEnvironment(environmentId);
 
-  await _addRoleMappings(
-    roleMappings.map((roleMapping) => ({
-      ...roleMapping,
-      environmentId: activeEnvironment.spaceId,
-    })),
-    ability,
-  );
+    await _addRoleMappings(
+      roleMappings.map((roleMapping) => ({
+        ...roleMapping,
+        environmentId: activeEnvironment.spaceId,
+      })),
+      ability,
+    );
+  } catch (error) {
+    console.error(error);
+    return userError(getErrorMessage(error));
+  }
 }
 
 export async function deleteRoleMappings(

--- a/src/management-system-v2/lib/data/role-mappings.ts
+++ b/src/management-system-v2/lib/data/role-mappings.ts
@@ -6,6 +6,7 @@ import {
   addRoleMappings as _addRoleMappings,
   RoleMappingInput,
 } from '@/lib/data/db/iam/role-mappings';
+import { getErrorMessage, userError } from '../user-error';
 
 export async function addRoleMappings(
   environmentId: string,
@@ -26,7 +27,7 @@ export async function deleteRoleMappings(
   environmentId: string,
   roleMappings: { userId: string; roleId: string }[],
 ) {
-  const errors: { roleId: string; error: Error }[] = [];
+  const errors: unknown[] = [];
 
   const { ability, activeEnvironment } = await getCurrentEnvironment(environmentId);
 
@@ -34,9 +35,25 @@ export async function deleteRoleMappings(
     try {
       await _deleteRoleMapping(userId, roleId, activeEnvironment.spaceId, ability);
     } catch (error) {
-      errors.push({ roleId, error: error as Error });
+      console.error(error);
+      errors.push(error);
     }
   }
 
-  return errors;
+  if (errors.length === 0) return;
+
+  let message: string = '';
+
+  for (let i = 0; i < errors.length; i++) {
+    const error = errors[i];
+    const last = i === errors.length - 1;
+
+    message += getErrorMessage(error);
+    if (!last) {
+      message += '\n';
+    }
+  }
+
+  console.log('error message', message);
+  return userError(message);
 }

--- a/src/management-system-v2/lib/data/role-schema.ts
+++ b/src/management-system-v2/lib/data/role-schema.ts
@@ -10,13 +10,13 @@ for (const resource of resources) {
 export const RoleInputSchema = z.object({
   id: z.string().optional(),
   environmentId: z.string(),
-  name: z.string(),
+  name: z.string().min(5).max(100),
   description: z.string().nullish().optional(),
   note: z.string().nullish().optional(),
   permissions: z.object(perms as Permissions).partial(),
   expiration: z.date().nullish().optional(),
   default: z.boolean().optional().nullable(),
-  parentId: z.string().optional(),
+  parentId: z.string().optional().nullable(),
 });
 
 export type RoleInput = z.infer<typeof RoleInputSchema>;

--- a/src/management-system-v2/lib/openapiSchema.ts
+++ b/src/management-system-v2/lib/openapiSchema.ts
@@ -401,7 +401,6 @@ export interface components {
         Role?: components['schemas']['PermissionNumber'];
         User?: components['schemas']['PermissionNumber'];
         Setting?: components['schemas']['PermissionNumber'];
-        EnvConfig?: components['schemas']['PermissionNumber'];
         All?: components['schemas']['PermissionNumber'];
       };
       expiration?: string;


### PR DESCRIPTION
## Summary

Made many changes to the roles page and other aspects of the MS that are related to permissions to everything more consistent.

## Details roles

- removed 2 unused Resource types
- small updates to role schema
- extracted static rules
- correct system admin rules: the layout wasn't using the correct permissions

## MS Layout

- Check correct permissions to adapt the sider's options

## Details role page

- fix react key + use more direct type
- removed option to set expiration
- update options
- improve error display: display actual errors in ant design notifications
- admin role: enforce at least one admin when removing a role-mapping
- removed custom behavior from all tables to make them act like other tables in the MS
- removed iconView toggle from tables because it isn't implemented
- side panel: better spacing between role members
- don't show members of @guest and @everyone
- disallow role mappings for @guest and @everyone
- role list: column sorting
- only admins can create-modify roles
- better feedback when role isn't found
- notes for @guest and @everyone roles that explain their purpose
- same save button in general data and permissions
