### PR TITLE
ms2/miscellanous fixes

### DIFF
--- a/src/management-system-v2/app/(dashboard)/[environmentId]/(automation)/executions-dashboard/dashboard-view.tsx
+++ b/src/management-system-v2/app/(dashboard)/[environmentId]/(automation)/executions-dashboard/dashboard-view.tsx
@@ -2,7 +2,7 @@
 
 import { useMemo } from 'react';
 import useDeployments from './use-deployments';
-import { Card, Col, Row, Statistic } from 'antd';
+import { Card, Col, Row, Skeleton, Statistic } from 'antd';
 
 const DashboardView: React.FC = () => {
   const { engines, deployments } = useDeployments(
@@ -92,7 +92,7 @@ const DashboardView: React.FC = () => {
     };
   }, [engines, deployments]);
 
-  if (!stats) return <>Loading</>;
+  if (!stats) return <Skeleton active />;
 
   return (
     <>

--- a/src/management-system-v2/app/(dashboard)/[environmentId]/processes/[processId]/blockly-editor.tsx
+++ b/src/management-system-v2/app/(dashboard)/[environmentId]/processes/[processId]/blockly-editor.tsx
@@ -59,7 +59,13 @@ const BlocklyEditor = ({ onChange, initialXml, editorRef, blocklyOptions }: Bloc
   };
 
   useEffect(() => {
-    if (blocklyEditorRef.current && blocklyEditorRef.current.rendered && initialXml) {
+    if (blocklyEditorRef.current && initialXml) {
+      if (!blocklyEditorRef.current.rendered) {
+        throw new Error(
+          'Tried to render xml, but the blockly editor was in headless mode (probably unmounted)',
+        );
+      }
+
       const xml = Blockly.utils.xml.textToDom(initialXml);
       Blockly.Xml.clearWorkspaceAndLoadFromXml(xml, blocklyEditorRef.current);
       blocklyEditorRef.current.scrollCenter();
@@ -119,13 +125,6 @@ const BlocklyEditor = ({ onChange, initialXml, editorRef, blocklyOptions }: Bloc
     onChangeFunc.current?.(isBlockScriptValid, { xml: xmlText, js: javascriptCode });
   }, []);
 
-  useEffect(() => {
-    if (!blocklyEditorRef.current || initialXml === '') return;
-    const xml = Blockly.utils.xml.textToDom(initialXml);
-    Blockly.Xml.clearWorkspaceAndLoadFromXml(xml, blocklyEditorRef.current);
-    blocklyEditorRef.current.scrollCenter();
-  }, [initialXml]);
-
   // react blockly doesn't when readOnly changes and it can even lead to issues if the workspace was
   // readonly and changed to editable
   // For this reason, when reaOnly changes, we unmount the BlocklyWorkspace and mount a new one
@@ -146,6 +145,9 @@ const BlocklyEditor = ({ onChange, initialXml, editorRef, blocklyOptions }: Bloc
         ...blocklyOptions,
       }}
       onWorkspaceChange={onWorkspaceChange}
+      onInject={(newWorkspace) => {
+        blocklyEditorRef.current = newWorkspace;
+      }}
     />
   ) : (
     <BlocklyWorkspace

--- a/src/management-system-v2/app/(dashboard)/[environmentId]/processes/[processId]/modeler.tsx
+++ b/src/management-system-v2/app/(dashboard)/[environmentId]/processes/[processId]/modeler.tsx
@@ -126,11 +126,13 @@ const Modeler = ({ versionName, process, ...divProps }: ModelerProps) => {
     }
     const debouncedSaveXmlFn = debounce(saveXml, 2000);
 
-    return function (xml: string, invalidate: boolean = false) {
+    const wrappedDebouncedSaveFuncion = function (xml?: string, invalidate: boolean = false) {
+      if (!xml) return;
+
       if (!beforeWindowUnloadEventHandler.current) {
         function onBeforeUnload(e: BeforeUnloadEvent) {
           e.preventDefault();
-          saveXml(xml, invalidate);
+          saveXml(xml!, invalidate);
           if (beforeWindowUnloadEventHandler.current) {
             window.removeEventListener('beforeunload', beforeWindowUnloadEventHandler.current);
             beforeWindowUnloadEventHandler.current = undefined;
@@ -143,6 +145,11 @@ const Modeler = ({ versionName, process, ...divProps }: ModelerProps) => {
 
       debouncedSaveXmlFn(xml, invalidate);
     };
+
+    wrappedDebouncedSaveFuncion.immediate = debouncedSaveXmlFn.immediate;
+    wrappedDebouncedSaveFuncion.asyncImmediate = debouncedSaveXmlFn.asyncImmediate;
+
+    return wrappedDebouncedSaveFuncion;
   }, [process.id]);
 
   useEffect(() => {

--- a/src/management-system-v2/components/header-actions.tsx
+++ b/src/management-system-v2/components/header-actions.tsx
@@ -27,6 +27,7 @@ import { UserSpacesContext } from '@/app/(dashboard)/[environmentId]/layout-clie
 import { FaSignOutAlt } from 'react-icons/fa';
 import { EnvVarsContext } from './env-vars-context';
 import { TbUserEdit } from 'react-icons/tb';
+import { useRouter } from 'next/navigation';
 
 const HeaderActions: FC = () => {
   const session = useSession();
@@ -37,6 +38,7 @@ const HeaderActions: FC = () => {
   const userSpaces = useContext(UserSpacesContext);
   const activeSpace = useEnvironment();
   const envVars = use(EnvVarsContext);
+  const router = useRouter();
 
   if (!loggedIn) {
     return (
@@ -105,26 +107,42 @@ const HeaderActions: FC = () => {
           <Select
             options={userSpaces.map((space) => {
               const name = space.isOrganization ? space.name : 'My Space';
+              const label = <Typography.Text>{name}</Typography.Text>;
               return {
                 label: (
                   <Tooltip title={name} placement="left">
-                    <Link
-                      style={{ display: 'block' }}
-                      href={spaceURL(
-                        {
-                          spaceId: space?.id ?? '',
-                          isOrganization: space?.isOrganization ?? false,
-                        },
-                        `/processes`,
-                      )}
-                    >
-                      <Typography.Text>{name}</Typography.Text>
-                    </Link>
+                    {/** The active space cannot be a link, otherwise clicking the select will direct
+                      the user to the process page of the active space. */}
+                    {activeSpace.spaceId === space.id ? (
+                      label
+                    ) : (
+                      <Link
+                        style={{ display: 'block' }}
+                        href={spaceURL(
+                          {
+                            spaceId: space?.id ?? '',
+                            isOrganization: space?.isOrganization ?? false,
+                          },
+                          `/processes`,
+                        )}
+                      >
+                        {label}
+                      </Link>
+                    )}
                   </Tooltip>
                 ),
                 value: space.id,
+                _space: space,
               };
             })}
+            // Sometimes the click can select the option, but not click the anchor tag.
+            // Next dedupes the duplicate, in case the anchor tag was clicked route so the browser history is not polluted.
+            onChange={(spaceId) => {
+              const space = userSpaces.find((s) => s.id === spaceId)!;
+              router.push(
+                spaceURL({ spaceId: space.id, isOrganization: space.isOrganization }, '/processes'),
+              );
+            }}
             defaultValue={activeSpace.spaceId}
             style={{ width: '23ch' }}
           />

--- a/src/management-system-v2/components/process-description.tsx
+++ b/src/management-system-v2/components/process-description.tsx
@@ -1,0 +1,8 @@
+import { Skeleton } from 'antd';
+import dynamic from 'next/dynamic';
+
+export const ProcessDescription = dynamic(() => import('@/components/text-viewer'), {
+  ssr: false,
+  // Skeleton width is arbitrary
+  loading: () => <Skeleton.Node style={{ width: 150 }} active />,
+});

--- a/src/management-system-v2/components/process-info-card-content.tsx
+++ b/src/management-system-v2/components/process-info-card-content.tsx
@@ -1,22 +1,19 @@
 'use client';
 
-import { Divider, Spin } from 'antd';
-import React, { FC, Suspense } from 'react';
+import { Divider } from 'antd';
+import { FC, Suspense } from 'react';
 import Viewer from './bpmn-viewer';
 import { ProcessListProcess } from './processes/types';
-import { useUserPreferences } from '@/lib/user-preferences';
 import ProceedLoadingIndicator from './loading-proceed';
 import { generateDateString } from '@/lib/utils';
+import { ProcessDescription } from './process-description';
 
 type MetaDataContentType = {
   selectedElement?: ProcessListProcess;
 };
 
 const MetaDataContent: FC<MetaDataContentType> = ({ selectedElement }) => {
-  const hydrated = useUserPreferences.use._hydrated();
-
-  if (!hydrated) return null;
-
+  console.log('MetaDataContent', selectedElement?.description.value);
   return (
     // Viewer
     <div
@@ -45,26 +42,32 @@ const MetaDataContent: FC<MetaDataContentType> = ({ selectedElement }) => {
           )}
 
           <h3>Meta Data</h3>
+
           <h5>
             <b>Last Edited</b>
           </h5>
           <p>{generateDateString(selectedElement.lastEditedOn!, true)}</p>
+
           <h5>
             <b>Created On</b>
           </h5>
           <p>{generateDateString(selectedElement.createdOn!, true)}</p>
+
           <h5>
             <b>File Size</b>
           </h5>
           <p>X KB</p>
+
           <h5>
             <b>Owner</b>
           </h5>
           <p>Obi Wan Kenobi</p>
+
           <h5>
             <b>Description</b>
           </h5>
-          <p>{selectedElement.description.value}</p>
+          <ProcessDescription initialValue={selectedElement.description.value} />
+
           {selectedElement.type === 'process' && (
             <>
               <h5>

--- a/src/management-system-v2/components/process-info-card.tsx
+++ b/src/management-system-v2/components/process-info-card.tsx
@@ -6,6 +6,8 @@ import { useUserPreferences } from '@/lib/user-preferences';
 import { ProcessListProcess } from './processes/types';
 import ResizableElement, { ResizableElementRefType } from './ResizableElement';
 import MetaDataContent from './process-info-card-content';
+import dynamic from 'next/dynamic';
+const TextViewer = dynamic(() => import('@/components/text-viewer'), { ssr: false });
 
 type MetaDataType = {
   selectedElement?: ProcessListProcess;

--- a/src/management-system-v2/components/share-modal/export.tsx
+++ b/src/management-system-v2/components/share-modal/export.tsx
@@ -210,23 +210,30 @@ export function ProcessExportSubmitButton({
   type,
   state,
   exportProcesses,
-  moreThanOne,
+  moreThanOneProcess,
   isExporting,
   closeModal,
 }: {
   type: ProcessExportTypes;
   state: ExportOptionState;
   exportProcesses: ExportProcessesFunction;
-  moreThanOne: boolean;
+  moreThanOneProcess: boolean;
   isExporting: ExportingState;
   closeModal?: () => void;
 }) {
   return (
     <>
-      {!['pdf', 'svg'].includes(type) && !moreThanOne && (
+      {!['pdf', 'svg'].includes(type) && !moreThanOneProcess && (
         <Button
           loading={isExporting === 'copying'}
-          disabled={state[type].selectedOptions.length > 0 || !!isExporting}
+          disabled={
+            // Don't disable copy to clipboard if onlySelection is selected
+            (state[type].selectedOptions.length === 1 &&
+              state[type].selectedOptions[0] !== 'onlySelection') ||
+            // Two options are selected -> likely more than one process -> zip file -> disable copy to clipboard
+            state[type].selectedOptions.length >= 2 ||
+            !!isExporting
+          }
           type="primary"
           onClick={async () => {
             await exportProcesses(type, 'clipboard');
@@ -238,7 +245,7 @@ export function ProcessExportSubmitButton({
       )}
       <Button
         loading={isExporting === 'exporting'}
-        disabled={!!isExporting || (type === 'pdf' && moreThanOne)}
+        disabled={!!isExporting || (type === 'pdf' && moreThanOneProcess)}
         type="primary"
         onClick={async () => {
           await exportProcesses(type, 'download');

--- a/src/management-system-v2/components/share-modal/export.tsx
+++ b/src/management-system-v2/components/share-modal/export.tsx
@@ -14,7 +14,7 @@ import useModelerStateStore from '@/app/(dashboard)/[environmentId]/processes/[p
 import { is as bpmnIs } from 'bpmn-js/lib/util/ModelUtil';
 import { ProcessMetadata } from '@/lib/data/process-schema';
 import useProcessVersion from './use-process-version';
-import { UserError, UserErrorType } from '@/lib/user-error';
+import { UserError, UserErrorType, isUserErrorResponse } from '@/lib/user-error';
 import { FaRegQuestionCircle } from 'react-icons/fa';
 
 export type ProcessExportTypes = ProcessExportOptions['type'] | 'pdf';
@@ -164,13 +164,17 @@ export function useExportProcess(
           const { definitionId, processVersion } = processes[0];
 
           // the timestamp does not matter here since it is overridden by the user being an owner of the process
-          return generateSharedViewerUrl(
+          const url = await generateSharedViewerUrl(
             { processId: definitionId, timestamp: 0 },
             processVersion,
             selectedOptions as string[],
           );
+
+          if (isUserErrorResponse(url)) throw url;
+
+          return url;
         } else {
-          const error = await exportProcessesAsFile(
+          const { fallback, blob } = await exportProcessesAsFile(
             {
               type: type,
               artefacts: selectedOptions.includes('artefacts'),
@@ -184,17 +188,34 @@ export function useExportProcess(
             spaceId,
           );
 
-          if (error) throw { message: error, type: UserErrorType.UnknownError } as UserError;
+          if (fallback) throw { message: fallback, type: UserErrorType.UnknownError } as UserError;
+
+          return await blob;
         }
       },
-      onSuccess: (url) => {
+      onSuccess: async (urlOrBlob) => {
         if (type === 'pdf') {
+          if (!urlOrBlob || typeof urlOrBlob !== 'string')
+            throw new Error('No URL returned for PDF export');
+
           const { definitionId, processVersion } = processes[0];
-          window.open(url, `${definitionId}-${processVersion}-tab`);
-        } else {
-          if (method === 'clipboard') app.message.success('Copied to clipboard');
+          window.open(urlOrBlob, `${definitionId}-${processVersion}-tab`);
+        } else if (method === 'clipboard') {
+          if (typeof urlOrBlob !== 'string' && urlOrBlob.blob.type === 'image/png') {
+            const dataUrl = URL.createObjectURL(urlOrBlob.blob);
+
+            app.message.success(
+              <Space direction="vertical">
+                <img src={dataUrl} style={{ maxWidth: '5rem', maxHeight: '5rem' }} />
+                Copied to clipboard
+              </Space>,
+            );
+          } else {
+            app.message.success('Copied to clipboard');
+          }
         }
       },
+
       app,
     });
 

--- a/src/management-system-v2/components/share-modal/share-modal.tsx
+++ b/src/management-system-v2/components/share-modal/share-modal.tsx
@@ -331,7 +331,7 @@ export const ShareModal: FC<ShareModalProps> = ({ processes, open, setOpen, defa
               type={tabs[activeIndex]?.key as any}
               exportProcesses={exportProcesses}
               isExporting={isExporting}
-              moreThanOne={processes.length > 1}
+              moreThanOneProcess={processes.length > 1}
               state={exportState[0]}
               closeModal={() => setOpen(false)}
             />

--- a/src/management-system-v2/lib/auth.ts
+++ b/src/management-system-v2/lib/auth.ts
@@ -1,4 +1,4 @@
-import NextAuth, { NextAuthConfig } from 'next-auth';
+import NextAuth, { AuthError, NextAuthConfig } from 'next-auth';
 import { JWT } from 'next-auth/jwt';
 import { User as ProviderUser } from '@auth/core/types';
 
@@ -133,6 +133,19 @@ const nextAuthOptions: NextAuthConfig = {
   pages: {
     signIn: '/signin',
     error: '/signin',
+  },
+  logger: {
+    error(error) {
+      if (error instanceof AuthError) {
+        if (['AdapterError', 'CallbackRouteError', 'OAuthProfileParseError'].includes(error.type)) {
+          console.error(error);
+        } else {
+          console.error('NextAuth error:', error.type);
+        }
+      } else {
+        console.error(error);
+      }
+    },
   },
 };
 

--- a/src/management-system-v2/lib/auth.ts
+++ b/src/management-system-v2/lib/auth.ts
@@ -220,18 +220,16 @@ if (env.PROCEED_PUBLIC_IAM_PERSONAL_SPACES_ACTIVE) {
 }
 
 if (env.NODE_ENV === 'development') {
-  const developmentUsers = [
-    {
-      username: 'johndoe',
-      firstName: 'John',
-      lastName: 'Doe',
-      email: 'johndoe@proceed-labs.org',
-      id: 'development-id|johndoe',
-      isGuest: false,
-      emailVerifiedOn: null,
-      profileImage: null,
-    },
-  ] satisfies User[];
+  const johnDoeTemplate = {
+    username: 'johndoe',
+    firstName: 'John',
+    lastName: 'Doe',
+    email: 'johndoe@proceed-labs.org',
+    id: 'development-id|johndoe',
+    isGuest: false,
+    emailVerifiedOn: null,
+    profileImage: null,
+  };
 
   nextAuthOptions.providers.push(
     CredentialsProvider({
@@ -246,13 +244,14 @@ if (env.NODE_ENV === 'development') {
         },
       },
       async authorize(credentials) {
-        const userTemplate = developmentUsers.find(
-          (user) => user.username === credentials?.username,
-        );
-        if (!userTemplate) return null;
+        let user: User | null = null;
 
-        let user = await getUserByUsername(userTemplate.username);
-        if (!user) user = await addUser(userTemplate);
+        if (credentials.username === 'johndoe') {
+          user = await getUserByUsername('johndoe');
+          if (!user) user = await addUser(johnDoeTemplate);
+        } else if (credentials.username === 'admin') {
+          user = await getUserByUsername('admin');
+        }
 
         return user;
       },

--- a/src/management-system-v2/lib/process-export/index.ts
+++ b/src/management-system-v2/lib/process-export/index.ts
@@ -139,12 +139,11 @@ export async function getExportblob(
  * @param options the options that were selected by the user
  * @param processes the processes(and versions) to export
  */
-export function exportProcesses(
+export async function exportProcesses(
   options: ProcessExportOptions,
   processes: ExportProcessInfo,
   spaceId: string,
 ) {
   const blob = getExportblob(options, processes, spaceId);
-
-  return handleExportMethod(blob, options);
+  return { fallback: await handleExportMethod(blob, options), blob };
 }


### PR DESCRIPTION
## Summary

Some miscellaneous fixes in the ms

## Details

- ms2/share-modal: allow copy to clipboard with selection
- ms2/space-select: more consistent behaviour
  - Previously when the select was clicked and it happened to fall in the
    anchor tag, the user would be redirected to the process page of the
    current space. That is not what is expected when opening the space
    select.
  - When the click selected the option but was just outside the anchor tag,
    nothing happened, although the select showed that the space was
    changed.
- ms2/share-modal: preview of images copied to clipboard
- ms2/executions-dashboard: skeleton for loading animation
- ms2/blockly-editor: remove duplicate effect + update ref when changing to read only
- ms2/auth: dev user sign no longer creates admin user + sign in to seed file admin user
- ms2/auth: less verbose error logging
- ms2/modeler: warning when closing tab when there are unsaved changes
- ms2/process-list: use wysiwyg editor/view for processes
