### PR TITLE
User Task Shortcuts

### DIFF
--- a/src/management-system-v2/app/(dashboard)/[environmentId]/processes/[processId]/_user-task-builder/Toolbar.tsx
+++ b/src/management-system-v2/app/(dashboard)/[environmentId]/processes/[processId]/_user-task-builder/Toolbar.tsx
@@ -14,6 +14,7 @@ import styles from './index.module.scss';
 
 import { useEditor, Node } from '@craftjs/core';
 import { useCanEdit } from '../modeler';
+import useEditorControls from './use-editor-controls';
 
 export type EditorLayout = 'computer' | 'mobile';
 
@@ -28,38 +29,7 @@ export const Toolbar: React.FC<ToolbarProps> = ({
   iframeLayout,
   onLayoutChange,
 }) => {
-  const { actions, canUndo, canRedo, onDelete } = useEditor((state, query) => {
-    const currentColumn = Array.from(state.events.selected)
-      .map((id) => state.nodes[id])
-      .find((node) => node && node.data.name === 'Column');
-
-    let onDelete;
-
-    if (currentColumn) {
-      const parentRow = currentColumn.data.parent && state.nodes[currentColumn.data.parent];
-      let deleteId = currentColumn.id;
-
-      if (parentRow && parentRow.data.nodes.length === 1) {
-        deleteId = parentRow.id;
-      }
-
-      const childNodeId = currentColumn.data.nodes[0];
-      const childNode = state.nodes[childNodeId];
-
-      onDelete = async () => {
-        if (childNode.data.custom.onDelete) {
-          await (childNode.data.custom.onDelete as (node: Node) => Promise<void>)(childNode);
-        }
-        actions.delete(deleteId!);
-      };
-    }
-
-    return {
-      onDelete,
-      canUndo: query.history.canUndo(),
-      canRedo: query.history.canRedo(),
-    };
-  });
+  const { canUndo, canRedo, undo, redo, selected, deleteElement } = useEditorControls();
 
   const editingEnabled = useCanEdit();
 
@@ -74,13 +44,13 @@ export const Toolbar: React.FC<ToolbarProps> = ({
                 type="text"
                 icon={<UndoOutlined style={{ color: canUndo ? 'blue' : undefined }} />}
                 disabled={!canUndo}
-                onClick={() => actions.history.undo()}
+                onClick={() => undo()}
               />
               <Button
                 type="text"
                 icon={<RedoOutlined style={{ color: canRedo ? 'blue' : undefined }} />}
                 disabled={!canRedo}
-                onClick={() => actions.history.redo()}
+                onClick={() => redo()}
               />
             </>
           )}
@@ -110,11 +80,11 @@ export const Toolbar: React.FC<ToolbarProps> = ({
               <Divider type="vertical" />
               <Button
                 danger
-                disabled={!onDelete}
+                disabled={!selected}
                 type="text"
                 icon={<DeleteOutlined />}
                 onClick={async () => {
-                  await onDelete!();
+                  selected && deleteElement(selected);
                 }}
               />
             </>

--- a/src/management-system-v2/app/(dashboard)/[environmentId]/processes/[processId]/_user-task-builder/_utils/EditableText.tsx
+++ b/src/management-system-v2/app/(dashboard)/[environmentId]/processes/[processId]/_user-task-builder/_utils/EditableText.tsx
@@ -79,6 +79,20 @@ function EditableText<T extends keyof JSX.IntrinsicElements>({
                 e.stopPropagation();
                 selectingText.current = true;
               },
+              onKeyDown: (e: KeyboardEvent) => {
+                if (e.key === 'Escape') {
+                  e.stopPropagation();
+
+                  async function submit() {
+                    if (editorRef.current) {
+                      onChange((await editorRef.current.getCurrentValue()) || '');
+                    }
+                    onStopEditing?.();
+                  }
+
+                  submit();
+                }
+              },
               ...props,
             });
           })}

--- a/src/management-system-v2/app/(dashboard)/[environmentId]/processes/[processId]/_user-task-builder/index.tsx
+++ b/src/management-system-v2/app/(dashboard)/[environmentId]/processes/[processId]/_user-task-builder/index.tsx
@@ -38,6 +38,7 @@ import { Element as BpmnElement } from 'bpmn-js/lib/model/Types';
 import { useCanEdit } from '../modeler';
 import { Element } from 'diagram-js/lib/model/Types';
 import { wrapServerCall } from '@/lib/wrap-server-call';
+import ShortcutHandler from './shortcut-handler';
 
 type BuilderProps = {
   processId: string;
@@ -252,6 +253,7 @@ const EditorModal: React.FC<BuilderModalProps> = ({
                 mountTarget="#mountHere"
                 contentDidMount={() => setIframeMounted(true)}
               >
+                {open && <ShortcutHandler onClose={onClose} />}
                 <Frame />
               </IFrame>
             </Col>

--- a/src/management-system-v2/app/(dashboard)/[environmentId]/processes/[processId]/_user-task-builder/shortcut-handler.tsx
+++ b/src/management-system-v2/app/(dashboard)/[environmentId]/processes/[processId]/_user-task-builder/shortcut-handler.tsx
@@ -1,0 +1,89 @@
+import React, { useEffect } from 'react';
+import { useFrame } from 'react-frame-component';
+import useEditorControls from './use-editor-controls';
+import { useAddControlCallback } from '@/lib/controls-store';
+import AddUserControls from '@/components/add-user-controls';
+import useBuilderStateStore from './use-builder-state-store';
+
+type ShortcutHandlerProps = {
+  onClose?: () => void;
+};
+
+const ShortcutHandler: React.FC<ShortcutHandlerProps> = ({ onClose }) => {
+  const { document } = useFrame();
+
+  const { selected, deleteElement, canUndo, canRedo, undo, redo } = useEditorControls();
+
+  const isTextEditing = useBuilderStateStore((state) => state.isTextEditing);
+
+  useEffect(() => {
+    if (document && !isTextEditing) {
+      // handle events that are only thrown inside the iframe and cannot be handled by react
+      // handlers
+      const onDelete = (e: KeyboardEvent) => {
+        if (selected && e.key === 'Delete') {
+          deleteElement(selected);
+        }
+      };
+      document.body.addEventListener('keydown', onDelete);
+
+      const onEscape = (e: KeyboardEvent) => {
+        if (e.key === 'Escape') {
+          onClose?.();
+        }
+      };
+      document.body.addEventListener('keydown', onEscape);
+
+      const onUndo = (e: KeyboardEvent) => {
+        if (canUndo && e.ctrlKey && e.key === 'z') undo();
+      };
+      document.body.addEventListener('keydown', onUndo);
+
+      const onRedo = (e: KeyboardEvent) => {
+        if (canRedo && e.ctrlKey && e.key === 'y') redo();
+      };
+      document.body.addEventListener('keydown', onRedo);
+
+      return () => {
+        document.body.removeEventListener('keydown', onDelete);
+        document.body.removeEventListener('keydown', onEscape);
+        document.body.removeEventListener('keydown', onUndo);
+        document.body.removeEventListener('keydown', onRedo);
+      };
+    }
+  }, [document, selected, onClose, isTextEditing, canUndo, canRedo, undo, redo]);
+
+  // handle events thrown outside the iframe
+  useAddControlCallback(
+    'html-editor',
+    'del',
+    () => {
+      if (selected) {
+        deleteElement(selected);
+      }
+    },
+    { dependencies: [selected] },
+  );
+
+  useAddControlCallback(
+    'html-editor',
+    'undo',
+    () => {
+      if (canUndo) undo();
+    },
+    { dependencies: [canUndo, undo] },
+  );
+
+  useAddControlCallback(
+    'html-editor',
+    'redo',
+    () => {
+      if (canRedo) redo();
+    },
+    { dependencies: [canRedo, redo] },
+  );
+
+  return <AddUserControls name="html-editor" />;
+};
+
+export default ShortcutHandler;

--- a/src/management-system-v2/app/(dashboard)/[environmentId]/processes/[processId]/_user-task-builder/shortcut-handler.tsx
+++ b/src/management-system-v2/app/(dashboard)/[environmentId]/processes/[processId]/_user-task-builder/shortcut-handler.tsx
@@ -18,7 +18,7 @@ const ShortcutHandler: React.FC<ShortcutHandlerProps> = ({ onClose }) => {
 
   useEffect(() => {
     if (document && !isTextEditing) {
-      // handle events that are only thrown inside the iframe and cannot be handled by react
+      // handle events that are thrown inside the iframe and cannot be handled by react
       // handlers
       const onDelete = (e: KeyboardEvent) => {
         if (selected && e.key === 'Delete') {

--- a/src/management-system-v2/app/(dashboard)/[environmentId]/processes/[processId]/_user-task-builder/use-editor-controls.tsx
+++ b/src/management-system-v2/app/(dashboard)/[environmentId]/processes/[processId]/_user-task-builder/use-editor-controls.tsx
@@ -1,0 +1,50 @@
+import { Node, useEditor } from '@craftjs/core';
+import { useCallback } from 'react';
+
+export default function useEditorControls() {
+  const { query, actions, selected, canUndo, canRedo } = useEditor((state, query) => {
+    const currentColumn = Array.from(state.events.selected)
+      .map((id) => state.nodes[id])
+      .find((node) => node && node.data.name === 'Column');
+
+    return {
+      selected: currentColumn?.id,
+      canUndo: query.history.canUndo(),
+      canRedo: query.history.canRedo(),
+    };
+  });
+
+  const deleteElement = useCallback(
+    (idOrNode: string | Node) => {
+      let node = typeof idOrNode === 'string' ? undefined : idOrNode;
+
+      if (typeof idOrNode === 'string') {
+        node = query.node(idOrNode).get();
+      }
+
+      while (node?.data.parent && node.data.name !== 'Column') {
+        node = query.node(node.data.parent).get();
+      }
+
+      if (node) {
+        const parentRow = node.data.parent && query.node(node.data.parent).get();
+
+        if (parentRow && parentRow.data.nodes.length === 1) {
+          actions.delete(parentRow.id);
+        } else {
+          actions.delete(node.id);
+        }
+      }
+    },
+    [actions, query],
+  );
+
+  return {
+    selected,
+    deleteElement,
+    canUndo,
+    canRedo,
+    undo: actions.history.undo,
+    redo: actions.history.redo,
+  };
+}


### PR DESCRIPTION
<!--
  Thank you for your contribution to this project!

  Please provide the following information about your changes,
  in order for us to approve and merge your proposal as quickly as possible.
-->

## Summary

Added support for keyboard shortcuts in the user task editor

## Details

- pressing escape while editing the text of an element will apply the changes and disable the text editing
- Fixed: pressing escape while the iframe containing the user task html is selected will not close the user task editor
- pressing CTRL+z will undo the last change
- pressing CTRL+y will redo the last change that was undone
- pressing the Delete key will delete the currently selected element
