### PR TITLE
feat(ms2/engine-endpointBuilder): filter undefined query params

### DIFF
--- a/src/management-system-v2/lib/engines/endpoints/endpoint-builder.ts
+++ b/src/management-system-v2/lib/engines/endpoints/endpoint-builder.ts
@@ -74,7 +74,14 @@ export function _endpointBuilder(
   );
 
   if (options?.queryParams && Object.keys(options.queryParams).length > 0) {
-    const searchParams = new URLSearchParams(options.queryParams);
+    const searchParams = new URLSearchParams();
+
+    for (const [key, paramValue] of Object.entries(options.queryParams)) {
+      if (paramValue !== undefined) {
+        searchParams.set(key, paramValue);
+      }
+    }
+
     builtEndpoint += `?${searchParams.toString()}`;
   }
 


### PR DESCRIPTION
## Summary

Filter query parameters that have value `undefined`. This was causing entries to be `"undefined"` (as a string) in endpoints for fetching processes from engines via http, which made that the engines returned a list of empty objects (`[{}, ...}`).
