### PR TITLE
hotfix: page receives props as promise

### DIFF
--- a/src/management-system-v2/app/(dashboard)/[environmentId]/settings/@tdsSettings/page.tsx
+++ b/src/management-system-v2/app/(dashboard)/[environmentId]/settings/@tdsSettings/page.tsx
@@ -4,11 +4,11 @@ import SettingsInjector from '../settings-injector';
 import Wrapper from './wrapper';
 import { settings } from './settings';
 
-const Page = async ({ params }: { params: { environmentId: string } }) => {
+const Page = async (props: { params: Promise<{ environmentId: string }> }) => {
+  const params = await props.params;
   const {
     activeEnvironment: { spaceId },
   } = await getCurrentEnvironment(params.environmentId);
-
   await populateSpaceSettingsGroup(spaceId, settings);
 
   return (


### PR DESCRIPTION
Hotfix to properly handle the props of the organization settings page as promise.