### PR TITLE
Engine: Activate Instance Recovery

### DIFF
--- a/.github/workflows/deploy_with_db.yml
+++ b/.github/workflows/deploy_with_db.yml
@@ -36,7 +36,7 @@ jobs:
           FILE="FeatureFlags.js"
 
           # Define exempted flags
-          EXEMPTED_FLAGS=("enableMessaging" "enableUseDB" "enableUseFileManager")
+          EXEMPTED_FLAGS=("enableMessaging" "enableUseDB" "enableUseFileManager" "enableInterruptedInstanceRecovery")
 
           # Find all flags set to `true`
           FLAGS_WITH_TRUE=$(grep -E '^\s*enable[a-zA-Z0-9_]+\s*:\s*true' "$FILE" | awk -F: '{print $1}' | tr -d ' ')

--- a/FeatureFlags.js
+++ b/FeatureFlags.js
@@ -31,7 +31,7 @@ module.exports = {
   // -----------------------------------------------------------------------------
 
   // Features needed for the recovery of instances that were interrupted unexpectedly (e.g. when the engine crashes and is restarted)
-  enableInterruptedInstanceRecovery: false,
+  enableInterruptedInstanceRecovery: true,
 
   // Features needed to send data to messaging servers (currently only using mqtt)
   enableMessaging: true,

--- a/src/engine/native/node/native-fs/src/__tests__/index.test.js
+++ b/src/engine/native/node/native-fs/src/__tests__/index.test.js
@@ -12,6 +12,7 @@ describe('Native-FS', () => {
       fs.mkdirSync.mockReset();
       fs.readFile.mockReset();
       fs.writeFile.mockReset();
+      fs.rename.mockReset();
       exitHook.mockReset();
     });
 
@@ -210,6 +211,7 @@ describe('Native-FS', () => {
         _cb = cb || cbOrEncoding;
       });
       fs.writeFile.mockImplementation((path, content, cb) => cb());
+      fs.rename.mockImplementation((oldPath, newPath, cb) => cb());
 
       const nfs = new NativeFS({ dir: '/Path/To/Dir' });
       const writeP = nfs.write(['table.json/test', 'data']);
@@ -232,6 +234,7 @@ describe('Native-FS', () => {
       fs.statSync.mockReset();
       fs.readFile.mockReset();
       fs.writeFile.mockReset();
+      fs.rename.mockReset();
       fs.rm.mockReset();
     });
 
@@ -242,6 +245,7 @@ describe('Native-FS', () => {
       fs.writeFile.mockImplementationOnce((path, content, cb) => {
         cb();
       });
+      fs.rename.mockImplementation((oldPath, newPath, cb) => cb());
 
       const nfs = new NativeFS({ dir: '/Path/To/Dir' });
       const writeP = nfs.write(['table.json/test', 'data']);
@@ -251,12 +255,18 @@ describe('Native-FS', () => {
         '/Path/To/Dir/data_files/table.json',
         expect.any(Function),
       );
+      // it writes the data to a temporary file first
       expect(fs.writeFile).toHaveBeenCalledWith(
-        '/Path/To/Dir/data_files/table.json',
+        '/Path/To/Dir/data_files/table.json.tmp',
         JSON.stringify({
           foo: 'bar',
           test: 'data',
         }),
+        expect.any(Function),
+      );
+      expect(fs.rename).toHaveBeenCalledWith(
+        '/Path/To/Dir/data_files/table.json.tmp',
+        '/Path/To/Dir/data_files/table.json',
         expect.any(Function),
       );
     });
@@ -270,11 +280,17 @@ describe('Native-FS', () => {
         cb(error);
       });
       fs.writeFile.mockImplementationOnce((path, content, cb) => cb());
+      fs.rename.mockImplementationOnce((oldPath, newPath, cb) => cb());
       const res = nfs.write(['table.json/test', 'data']);
       await expect(res).resolves.toBeUndefined();
       expect(fs.writeFile).toHaveBeenCalledWith(
-        '/Path/To/Dir/data_files/table.json',
+        '/Path/To/Dir/data_files/table.json.tmp',
         JSON.stringify({ test: 'data' }),
+        expect.any(Function),
+      );
+      expect(fs.rename).toHaveBeenCalledWith(
+        '/Path/To/Dir/data_files/table.json.tmp',
+        '/Path/To/Dir/data_files/table.json',
         expect.any(Function),
       );
     });
@@ -286,11 +302,17 @@ describe('Native-FS', () => {
         cb(null, JSON.stringify({ foo: 'bar', test: 'data' }));
       });
       fs.writeFile.mockImplementationOnce((path, content, cb) => cb());
+      fs.rename.mockImplementationOnce((oldPath, newPath, cb) => cb());
       const res = nfs.write(['table.json/test', null]);
       await expect(res).resolves.toBeUndefined();
       expect(fs.writeFile).toHaveBeenCalledWith(
-        '/Path/To/Dir/data_files/table.json',
+        '/Path/To/Dir/data_files/table.json.tmp',
         JSON.stringify({ foo: 'bar' }),
+        expect.any(Function),
+      );
+      expect(fs.rename).toHaveBeenCalledWith(
+        '/Path/To/Dir/data_files/table.json.tmp',
+        '/Path/To/Dir/data_files/table.json',
         expect.any(Function),
       );
 
@@ -300,11 +322,17 @@ describe('Native-FS', () => {
         cb(error);
       });
       fs.writeFile.mockImplementationOnce((path, content, cb) => cb());
+      fs.rename.mockImplementationOnce((oldPath, newPath, cb) => cb());
       const res2 = nfs.write(['table.json/test', null]);
       await expect(res2).resolves.toBeUndefined();
       expect(fs.writeFile).toHaveBeenCalledWith(
-        '/Path/To/Dir/data_files/table.json',
+        '/Path/To/Dir/data_files/table.json.tmp',
         JSON.stringify({}),
+        expect.any(Function),
+      );
+      expect(fs.rename).toHaveBeenCalledWith(
+        '/Path/To/Dir/data_files/table.json.tmp',
+        '/Path/To/Dir/data_files/table.json',
         expect.any(Function),
       );
     });
@@ -372,6 +400,20 @@ describe('Native-FS', () => {
       });
       const res5 = nfs.write(['table.json', null]);
       await expect(res5).rejects.toBeInstanceOf(Error);
+
+      fs.readFile.mockImplementationOnce((path, cb) => {
+        cb(null, JSON.stringify({ foo: 'bar' }));
+      });
+      fs.writeFile.mockImplementationOnce((path, content, cb) => {
+        cb();
+      });
+      fs.rename.mockImplementationOnce((oldPath, newPath, cb) => {
+        const error = new Error();
+        error.code = 'ENOENT';
+        cb(error);
+      });
+      const res6 = nfs.write(['table.json/test', 'data']);
+      await expect(res6).rejects.toBeInstanceOf(Error);
     });
 
     it("Doesn't schedule the write if a read operation is ongoing", async () => {
@@ -388,12 +430,14 @@ describe('Native-FS', () => {
         _cb = cb || cbOrEncoding;
       });
       fs.writeFile.mockImplementation((path, content, cb) => cb());
+      fs.rename.mockImplementationOnce((oldPath, newPath, cb) => cb());
 
       const nfs = new NativeFS({ dir: '/Path/To/Dir' });
       const readP = nfs.read(['table.json/test']);
       const writeP = nfs.write(['table.json/test', 'data']);
       expect(fs.readFile).toHaveBeenCalledTimes(1);
       expect(fs.writeFile).toHaveBeenCalledTimes(0);
+      expect(fs.rename).toHaveBeenCalledTimes(0);
 
       // Resolve read op
       _cb(null, JSON.stringify({ test: 'data' }));
@@ -404,6 +448,7 @@ describe('Native-FS', () => {
       await expect(writeP).resolves.toBeUndefined();
       expect(fs.readFile).toHaveBeenCalledTimes(2);
       expect(fs.writeFile).toHaveBeenCalledTimes(1);
+      expect(fs.rename).toHaveBeenCalledTimes(1);
     });
 
     it('Blocks the same table when two writes occur', async () => {
@@ -414,6 +459,7 @@ describe('Native-FS', () => {
       fs.writeFile.mockImplementation((path, content, cb) => {
         cb();
       });
+      fs.rename.mockImplementation((oldPath, newPath, cb) => cb());
 
       const nfs = new NativeFS({ dir: '/Path/To/Dir' });
       const write1 = nfs.write(['table.json/test1', 'data1']);
@@ -422,16 +468,22 @@ describe('Native-FS', () => {
 
       expect(fs.readFile).toHaveBeenCalledTimes(1);
       expect(fs.writeFile).not.toHaveBeenCalled();
+      expect(fs.rename).not.toHaveBeenCalled();
 
       // Resolve first write
       _cb(null, JSON.stringify({ foo: 'bar' }));
       expect(write1).resolves.toBeUndefined();
       expect(fs.writeFile).toHaveBeenLastCalledWith(
-        '/Path/To/Dir/data_files/table.json',
+        '/Path/To/Dir/data_files/table.json.tmp',
         JSON.stringify({
           foo: 'bar',
           test1: 'data1',
         }),
+        expect.any(Function),
+      );
+      expect(fs.rename).toHaveBeenLastCalledWith(
+        '/Path/To/Dir/data_files/table.json.tmp',
+        '/Path/To/Dir/data_files/table.json',
         expect.any(Function),
       );
       // Wait for promise flush
@@ -442,11 +494,16 @@ describe('Native-FS', () => {
       _cb(null, JSON.stringify({ foo: 'bar', test1: 'data1' }));
       expect(write2).resolves.toBeUndefined();
       expect(fs.writeFile).toHaveBeenLastCalledWith(
-        '/Path/To/Dir/data_files/table.json',
+        '/Path/To/Dir/data_files/table.json.tmp',
         JSON.stringify({
           foo: 'bar',
           test1: 'data2',
         }),
+        expect.any(Function),
+      );
+      expect(fs.rename).toHaveBeenLastCalledWith(
+        '/Path/To/Dir/data_files/table.json.tmp',
+        '/Path/To/Dir/data_files/table.json',
         expect.any(Function),
       );
       await new Promise((resolve) => setTimeout(resolve, 0));
@@ -456,11 +513,16 @@ describe('Native-FS', () => {
       _cb(null, JSON.stringify({ foo: 'bar', test1: 'data2' }));
       expect(write3).resolves.toBeUndefined();
       expect(fs.writeFile).toHaveBeenLastCalledWith(
-        '/Path/To/Dir/data_files/table.json',
+        '/Path/To/Dir/data_files/table.json.tmp',
         JSON.stringify({
           foo: 'bar',
           test1: 'data3',
         }),
+        expect.any(Function),
+      );
+      expect(fs.rename).toHaveBeenLastCalledWith(
+        '/Path/To/Dir/data_files/table.json.tmp',
+        '/Path/To/Dir/data_files/table.json',
         expect.any(Function),
       );
     });
@@ -474,6 +536,7 @@ describe('Native-FS', () => {
       fs.writeFile.mockImplementation((path, content, cb) => {
         cb();
       });
+      fs.rename.mockImplementation((oldPath, newPath, cb) => cb());
 
       const nfs = new NativeFS({ dir: '/Path/To/Dir' });
       const write1 = nfs.write(['table.json/test1', 'data1']);
@@ -482,16 +545,22 @@ describe('Native-FS', () => {
 
       expect(fs.readFile).toHaveBeenCalledTimes(2);
       expect(fs.writeFile).not.toHaveBeenCalled();
+      expect(fs.rename).not.toHaveBeenCalled();
 
       // Resolve first write
       _cb.shift()(null, JSON.stringify({ foo: 'bar' }));
       expect(write1).resolves.toBeUndefined();
       expect(fs.writeFile).toHaveBeenLastCalledWith(
-        '/Path/To/Dir/data_files/table.json',
+        '/Path/To/Dir/data_files/table.json.tmp',
         JSON.stringify({
           foo: 'bar',
           test1: 'data1',
         }),
+        expect.any(Function),
+      );
+      expect(fs.rename).toHaveBeenLastCalledWith(
+        '/Path/To/Dir/data_files/table.json.tmp',
+        '/Path/To/Dir/data_files/table.json',
         expect.any(Function),
       );
 
@@ -499,11 +568,16 @@ describe('Native-FS', () => {
       _cb.shift()(null, JSON.stringify({ otherFoo: 'bar' }));
       expect(write3).resolves.toBeUndefined();
       expect(fs.writeFile).toHaveBeenLastCalledWith(
-        '/Path/To/Dir/data_files/table2.json',
+        '/Path/To/Dir/data_files/table2.json.tmp',
         JSON.stringify({
           otherFoo: 'bar',
           test2: 'data3',
         }),
+        expect.any(Function),
+      );
+      expect(fs.rename).toHaveBeenCalledWith(
+        '/Path/To/Dir/data_files/table2.json.tmp',
+        '/Path/To/Dir/data_files/table2.json',
         expect.any(Function),
       );
       // Wait for promise flush
@@ -514,11 +588,16 @@ describe('Native-FS', () => {
       _cb.shift()(null, JSON.stringify({ foo: 'bar', test1: 'data1' }));
       expect(write2).resolves.toBeUndefined();
       expect(fs.writeFile).toHaveBeenLastCalledWith(
-        '/Path/To/Dir/data_files/table.json',
+        '/Path/To/Dir/data_files/table.json.tmp',
         JSON.stringify({
           foo: 'bar',
           test1: 'data2',
         }),
+        expect.any(Function),
+      );
+      expect(fs.rename).toHaveBeenLastCalledWith(
+        '/Path/To/Dir/data_files/table.json.tmp',
+        '/Path/To/Dir/data_files/table.json',
         expect.any(Function),
       );
     });

--- a/src/engine/native/node/native-fs/src/index.js
+++ b/src/engine/native/node/native-fs/src/index.js
@@ -191,6 +191,28 @@ class NativeFS extends NativeModule {
     }
     this._mutex.add(table);
 
+    /**
+     * Function that writes a file in a way that prevents partially written files
+     * (these did occur when the engine crashed mid write and prevented the engine from restarting)
+     **/
+    function saveWrite(path, data, cb) {
+      fs.writeFile(path + '.tmp', data, (writeError) => {
+        if (writeError) {
+          cb(writeError);
+          return;
+        }
+
+        fs.rename(path + '.tmp', path, (renameError) => {
+          if (renameError) {
+            cb(renameError);
+            return;
+          }
+
+          cb();
+        });
+      });
+    }
+
     // Delete
     if (value === null) {
       // delete given attribute inside json
@@ -210,7 +232,7 @@ class NativeFS extends NativeModule {
           // File is JSON with key-value-objects as elements
           const file = newFile ? {} : JSON.parse(data);
           delete file[id];
-          fs.writeFile(fullPath, JSON.stringify(file), (err2) => {
+          saveWrite(fullPath, JSON.stringify(file), (err2) => {
             if (err2) {
               fail(err2);
               return;
@@ -255,7 +277,7 @@ class NativeFS extends NativeModule {
           // File is JSON with key-value-objects as elements
           const file = newFile ? {} : JSON.parse(data);
           file[id] = value;
-          fs.writeFile(fullPath, JSON.stringify(file), (err2) => {
+          saveWrite(fullPath, JSON.stringify(file), (err2) => {
             if (err2) {
               fail(err2);
               return;
@@ -272,7 +294,7 @@ class NativeFS extends NativeModule {
           fs.mkdirSync(fileDir, { recursive: true });
         }
 
-        fs.writeFile(fullPath, value, (err) => {
+        saveWrite(fullPath, value, (err) => {
           if (err) {
             fail(err);
             return;

--- a/src/engine/universal/core/src/__tests__/management.test.js
+++ b/src/engine/universal/core/src/__tests__/management.test.js
@@ -153,7 +153,7 @@ describe('Management', () => {
     distribution.db.isProcessVersionValid.mockResolvedValue(true);
     const instanceId = await management.createInstance('0', '123', {});
     expect(management.getEngineWithID(instanceId)).toBeInstanceOf(Engine);
-    expect(Engine.prototype.deployProcessVersion).toHaveBeenCalledWith('0', '123');
+    expect(Engine.prototype.deployProcessVersion).toHaveBeenCalledWith('0', '123', true);
     expect(Engine.prototype.startProcessVersion).toHaveBeenCalledWith(
       '123',
       {},
@@ -215,7 +215,7 @@ describe('Management', () => {
     // try to continue instance which was never started on this engine
     const engine = await management.continueInstance('0', instance);
     expect(engine).toBeInstanceOf(Engine);
-    expect(Engine.prototype.deployProcessVersion).toHaveBeenCalledWith('0', '789');
+    expect(Engine.prototype.deployProcessVersion).toHaveBeenCalledWith('0', '789', false);
     expect(Engine.prototype.startProcessVersion).toHaveBeenCalledWith(
       '789',
       {},

--- a/src/engine/universal/core/src/__tests__/processRecovery.test.js
+++ b/src/engine/universal/core/src/__tests__/processRecovery.test.js
@@ -106,15 +106,29 @@ describe('Tests for the restart of interrupted processes at engine startup', () 
     it('will create an execution engine for a process that has interrupted instances and load the correct process versions', async () => {
       distribution.db.getAllProcesses.mockResolvedValue(['Process 1']);
       distribution.db.getArchivedInstances.mockResolvedValue({
-        instance1: { processVersion: 123, tokens: [], instanceState: ['ENDED'], some: 'data' },
+        instance1: {
+          processInstanceId: 'instance1',
+          processVersion: 123,
+          tokens: [],
+          instanceState: ['ENDED'],
+          some: 'data',
+        },
         instance2: {
+          processInstanceId: 'instance2',
           processVersion: 123,
           tokens: [],
           instanceState: ['RUNNING'],
           isCurrentlyExecutedInBpmnEngine: true,
         },
-        instance3: { processVersion: 456, tokens: [], instanceState: ['TERMINATED'], some: 'data' },
+        instance3: {
+          processInstanceId: 'instance3',
+          processVersion: 456,
+          tokens: [],
+          instanceState: ['TERMINATED'],
+          some: 'data',
+        },
         instance4: {
+          processInstanceId: 'instance4',
           processVersion: 789,
           tokens: [],
           instanceState: ['DEPLOYMENT-WAITING'],
@@ -133,12 +147,12 @@ describe('Tests for the restart of interrupted processes at engine startup', () 
       await management.restoreInterruptedInstances();
 
       expect(ensureExecutionEngine).toBeCalledTimes(2);
-      expect(ensureExecutionEngine).toHaveBeenCalledWith('Process 1', 123);
-      expect(ensureExecutionEngine).toHaveBeenCalledWith('Process 1', 789);
+      expect(ensureExecutionEngine).toHaveBeenCalledWith('Process 1', 123, false);
+      expect(ensureExecutionEngine).toHaveBeenCalledWith('Process 1', 789, false);
 
       expect(deployVersionInEngine).toBeCalledTimes(2);
-      expect(deployVersionInEngine).toHaveBeenCalledWith('Process 1', 123);
-      expect(deployVersionInEngine).toHaveBeenCalledWith('Process 1', 789);
+      expect(deployVersionInEngine).toHaveBeenCalledWith('Process 1', 123, false);
+      expect(deployVersionInEngine).toHaveBeenCalledWith('Process 1', 789, false);
 
       expect(management.getAllEngines().length).toBe(1);
 
@@ -296,6 +310,7 @@ describe('Tests for the restart of interrupted processes at engine startup', () 
       expect(instanceInformation).toEqual({
         ...archivedState,
         instanceState: ['ENDED'],
+        extras: {},
         tokens: [
           {
             ...archivedState.tokens[0],
@@ -524,6 +539,7 @@ describe('Tests for the restart of interrupted processes at engine startup', () 
             },
           ],
           userTasks: [],
+          extras: {},
           isCurrentlyExecutedInBpmnEngine: undefined,
         },
       );
@@ -1154,6 +1170,7 @@ describe('Tests for the restart of interrupted processes at engine startup', () 
             },
           ],
           userTasks: [],
+          extras: {},
           isCurrentlyExecutedInBpmnEngine: undefined,
         },
       );

--- a/src/engine/universal/core/src/engine/__tests__/hookCallbacks.test.js
+++ b/src/engine/universal/core/src/engine/__tests__/hookCallbacks.test.js
@@ -56,7 +56,7 @@ describe('Test for the function that sets up callbacks for the different lifecyc
     };
 
     mockStateStream = {
-      subscribe: jest.fn().mockImplementation(function(cb) {
+      subscribe: jest.fn().mockImplementation(function (cb) {
         this.subscriber = cb;
       }),
       subscriber: null,
@@ -68,31 +68,31 @@ describe('Test for the function that sets up callbacks for the different lifecyc
       logExecution: jest.fn(),
       updateLog: jest.fn(),
       completeActivity: jest.fn(),
-      getLog$: jest.fn().mockImplementation(function() {
+      getLog$: jest.fn().mockImplementation(function () {
         return { subscribe: (cb) => (this.logCallback = cb) };
       }),
-      onEnded: jest.fn().mockImplementation(function(cb) {
+      onEnded: jest.fn().mockImplementation(function (cb) {
         this.endedCallback = cb;
       }),
-      onAborted: jest.fn().mockImplementation(function(cb) {
+      onAborted: jest.fn().mockImplementation(function (cb) {
         this.abortedCallback = cb;
       }),
-      onUserTaskInterrupted: jest.fn().mockImplementation(function(cb) {
+      onUserTaskInterrupted: jest.fn().mockImplementation(function (cb) {
         this.userTaskInterruptedCallback = cb;
       }),
-      onCallActivityInterrupted: jest.fn().mockImplementation(function(cb) {
+      onCallActivityInterrupted: jest.fn().mockImplementation(function (cb) {
         this.callActivityInterruptedCallback = cb;
       }),
-      onScriptTaskError: jest.fn().mockImplementation(function(cb) {
+      onScriptTaskError: jest.fn().mockImplementation(function (cb) {
         this.scriptTaskErrorCallback = cb;
       }),
-      onTokenEnded: jest.fn().mockImplementation(function(cb) {
+      onTokenEnded: jest.fn().mockImplementation(function (cb) {
         this.tokenEndedCallback = cb;
       }),
-      onFlowNodeExecuted: jest.fn().mockImplementation(function(cb) {
+      onFlowNodeExecuted: jest.fn().mockImplementation(function (cb) {
         this.flowNodeExecutedCallback = cb;
       }),
-      onInstanceStateChange: jest.fn().mockImplementation(function(cb) {
+      onInstanceStateChange: jest.fn().mockImplementation(function (cb) {
         this.instanceStateChangeCallback = cb;
       }),
       logCallback: null,
@@ -105,31 +105,31 @@ describe('Test for the function that sets up callbacks for the different lifecyc
       flowNodeExecutedCallback: null,
       instanceStateChangeCallback: null,
 
-      log: jest.fn().mockImplementation(function(log) {
+      log: jest.fn().mockImplementation(function (log) {
         this.logCallback(log);
       }),
-      ended: jest.fn().mockImplementation(async function() {
+      ended: jest.fn().mockImplementation(async function () {
         await this.endedCallback();
       }),
-      aborted: jest.fn().mockImplementation(function() {
+      aborted: jest.fn().mockImplementation(function () {
         this.abortedCallback();
       }),
-      scriptTaskError: jest.fn().mockImplementation(function(token) {
+      scriptTaskError: jest.fn().mockImplementation(function (token) {
         this.scriptTaskErrorCallback(token);
       }),
-      userTaskInterrupted: jest.fn().mockImplementation(function(token) {
+      userTaskInterrupted: jest.fn().mockImplementation(function (token) {
         this.userTaskInterruptedCallback(token);
       }),
-      callActivityInterrupted: jest.fn().mockImplementation(function(token) {
+      callActivityInterrupted: jest.fn().mockImplementation(function (token) {
         this.callActivityInterruptedCallback(token);
       }),
-      tokenEnded: jest.fn().mockImplementation(function(token) {
+      tokenEnded: jest.fn().mockImplementation(function (token) {
         this.tokenEndedCallback(token);
       }),
-      flowNodeExecuted: jest.fn().mockImplementation(function(execution) {
+      flowNodeExecuted: jest.fn().mockImplementation(function (execution) {
         this.flowNodeExecutedCallback(execution);
       }),
-      instanceStateChange: jest.fn().mockImplementation(function(state) {
+      instanceStateChange: jest.fn().mockImplementation(function (state) {
         this.instanceStateChangeCallback(state);
       }),
 

--- a/src/engine/universal/core/src/engine/__tests__/hookCallbacks.test.js
+++ b/src/engine/universal/core/src/engine/__tests__/hookCallbacks.test.js
@@ -44,6 +44,7 @@ describe('Test for the function that sets up callbacks for the different lifecyc
       _versionProcessMapping: {},
       _instanceIdProcessMapping: {},
       _versionBpmnMapping: {},
+      _instanceIdExtraInfoMapping: {},
       getInstanceInformation: jest.fn().mockReturnValue({}),
       instanceEventHandlers: { onStarted, onEnded, onTokenEnded },
       _management: {
@@ -55,7 +56,7 @@ describe('Test for the function that sets up callbacks for the different lifecyc
     };
 
     mockStateStream = {
-      subscribe: jest.fn().mockImplementation(function (cb) {
+      subscribe: jest.fn().mockImplementation(function(cb) {
         this.subscriber = cb;
       }),
       subscriber: null,
@@ -67,31 +68,31 @@ describe('Test for the function that sets up callbacks for the different lifecyc
       logExecution: jest.fn(),
       updateLog: jest.fn(),
       completeActivity: jest.fn(),
-      getLog$: jest.fn().mockImplementation(function () {
+      getLog$: jest.fn().mockImplementation(function() {
         return { subscribe: (cb) => (this.logCallback = cb) };
       }),
-      onEnded: jest.fn().mockImplementation(function (cb) {
+      onEnded: jest.fn().mockImplementation(function(cb) {
         this.endedCallback = cb;
       }),
-      onAborted: jest.fn().mockImplementation(function (cb) {
+      onAborted: jest.fn().mockImplementation(function(cb) {
         this.abortedCallback = cb;
       }),
-      onUserTaskInterrupted: jest.fn().mockImplementation(function (cb) {
+      onUserTaskInterrupted: jest.fn().mockImplementation(function(cb) {
         this.userTaskInterruptedCallback = cb;
       }),
-      onCallActivityInterrupted: jest.fn().mockImplementation(function (cb) {
+      onCallActivityInterrupted: jest.fn().mockImplementation(function(cb) {
         this.callActivityInterruptedCallback = cb;
       }),
-      onScriptTaskError: jest.fn().mockImplementation(function (cb) {
+      onScriptTaskError: jest.fn().mockImplementation(function(cb) {
         this.scriptTaskErrorCallback = cb;
       }),
-      onTokenEnded: jest.fn().mockImplementation(function (cb) {
+      onTokenEnded: jest.fn().mockImplementation(function(cb) {
         this.tokenEndedCallback = cb;
       }),
-      onFlowNodeExecuted: jest.fn().mockImplementation(function (cb) {
+      onFlowNodeExecuted: jest.fn().mockImplementation(function(cb) {
         this.flowNodeExecutedCallback = cb;
       }),
-      onInstanceStateChange: jest.fn().mockImplementation(function (cb) {
+      onInstanceStateChange: jest.fn().mockImplementation(function(cb) {
         this.instanceStateChangeCallback = cb;
       }),
       logCallback: null,
@@ -104,31 +105,31 @@ describe('Test for the function that sets up callbacks for the different lifecyc
       flowNodeExecutedCallback: null,
       instanceStateChangeCallback: null,
 
-      log: jest.fn().mockImplementation(function (log) {
+      log: jest.fn().mockImplementation(function(log) {
         this.logCallback(log);
       }),
-      ended: jest.fn().mockImplementation(async function () {
+      ended: jest.fn().mockImplementation(async function() {
         await this.endedCallback();
       }),
-      aborted: jest.fn().mockImplementation(function () {
+      aborted: jest.fn().mockImplementation(function() {
         this.abortedCallback();
       }),
-      scriptTaskError: jest.fn().mockImplementation(function (token) {
+      scriptTaskError: jest.fn().mockImplementation(function(token) {
         this.scriptTaskErrorCallback(token);
       }),
-      userTaskInterrupted: jest.fn().mockImplementation(function (token) {
+      userTaskInterrupted: jest.fn().mockImplementation(function(token) {
         this.userTaskInterruptedCallback(token);
       }),
-      callActivityInterrupted: jest.fn().mockImplementation(function (token) {
+      callActivityInterrupted: jest.fn().mockImplementation(function(token) {
         this.callActivityInterruptedCallback(token);
       }),
-      tokenEnded: jest.fn().mockImplementation(function (token) {
+      tokenEnded: jest.fn().mockImplementation(function(token) {
         this.tokenEndedCallback(token);
       }),
-      flowNodeExecuted: jest.fn().mockImplementation(function (execution) {
+      flowNodeExecuted: jest.fn().mockImplementation(function(execution) {
         this.flowNodeExecutedCallback(execution);
       }),
-      instanceStateChange: jest.fn().mockImplementation(function (state) {
+      instanceStateChange: jest.fn().mockImplementation(function(state) {
         this.instanceStateChangeCallback(state);
       }),
 
@@ -260,6 +261,11 @@ describe('Test for the function that sets up callbacks for the different lifecyc
             some: 'data',
             other: 123,
           });
+          mockEngine._instanceIdExtraInfoMapping['newInstanceId'] = {
+            processInitiator: 'user-id',
+            spaceIdOfProcessInitiator: 'space-id',
+            managementSystemLocation: 'some-address',
+          };
           mockNewInstance.isEnded.mockReturnValue(false);
 
           mockStateStream.subscriber(mockEngine, mockNewInstance);
@@ -269,6 +275,11 @@ describe('Test for the function that sets up callbacks for the different lifecyc
           expect(db.archiveInstance).toHaveBeenCalledWith('processFile', 'newInstanceId', {
             some: 'data',
             other: 123,
+            extras: {
+              processInitiator: 'user-id',
+              spaceIdOfProcessInitiator: 'space-id',
+              managementSystemLocation: 'some-address',
+            },
             isCurrentlyExecutedInBpmnEngine: true,
           });
         });
@@ -290,6 +301,11 @@ describe('Test for the function that sets up callbacks for the different lifecyc
         it('will archive the instance only with the latest state in case of fast consecutive state changes', async () => {
           mockNewInstance.isEnded.mockReturnValue(false);
 
+          mockEngine._instanceIdExtraInfoMapping['newInstanceId'] = {
+            processInitiator: 'user-id',
+            spaceIdOfProcessInitiator: 'space-id',
+            managementSystemLocation: 'some-address',
+          };
           mockEngine.getInstance.mockReturnValue(mockNewInstance);
           mockEngine.getInstanceInformation.mockReturnValue({
             some: 'data',
@@ -321,6 +337,11 @@ describe('Test for the function that sets up callbacks for the different lifecyc
           expect(db.archiveInstance).toHaveBeenCalledWith('processFile', 'newInstanceId', {
             some: 'data',
             other: 789,
+            extras: {
+              processInitiator: 'user-id',
+              spaceIdOfProcessInitiator: 'space-id',
+              managementSystemLocation: 'some-address',
+            },
             isCurrentlyExecutedInBpmnEngine: true,
           });
         });

--- a/src/engine/universal/core/src/engine/engine.js
+++ b/src/engine/universal/core/src/engine/engine.js
@@ -127,17 +127,21 @@ class Engine {
    *
    * @param {string} definitionId The name of the file of the (main) process (as stored in the `data`)
    * @param {string} the version of the process to deploy
+   * @param {boolean} [active=true] defines if the deployed process is allowed to spawn instances
+   * automatically
    */
-  async deployProcessVersion(definitionId, versionId) {
-    const otherVersions = this.versions.filter((version) => version !== versionId);
-    otherVersions.forEach((version) => {
-      const process = this._versionProcessMapping[version];
+  async deployProcessVersion(definitionId, versionId, active = true) {
+    if (active) {
+      const otherVersions = this.versions.filter((version) => version !== versionId);
+      otherVersions.forEach((version) => {
+        const process = this._versionProcessMapping[version];
 
-      // deactivate other versions so they don't keep spawning new instances automatically
-      if (process) {
-        process.undeploy();
-      }
-    });
+        // deactivate other versions so they don't keep spawning new instances automatically
+        if (process) {
+          process.undeploy();
+        }
+      });
+    }
 
     if (!this._versionProcessMapping[versionId]) {
       // Fetch the stored BPMN
@@ -211,7 +215,7 @@ class Engine {
         shouldActivateFlowNodeHook: getShouldActivateFlowNode(this),
       });
 
-      process.deploy();
+      if (active) process.deploy();
 
       // Subscribe to the new process instances stream before we start the execution
       process.getInstance$().subscribe(getNewInstanceHandler(this));
@@ -226,7 +230,7 @@ class Engine {
     } else if (!this._versionProcessMapping[versionId].isDeployed()) {
       // activate the process so auto-start events like timer events are allowed to trigger new
       // instances
-      this._versionProcessMapping[versionId].deploy();
+      if (active) this._versionProcessMapping[versionId].deploy();
     }
   }
 

--- a/src/engine/universal/core/src/engine/hookCallbacks.js
+++ b/src/engine/universal/core/src/engine/hookCallbacks.js
@@ -200,6 +200,7 @@ function saveIntermediateInstanceState(engine, instance) {
   if (!instance.isEnded() && engine.getInstance(instance.id)) {
     distribution.db.archiveInstance(engine.definitionId, instance.id, {
       ...engine.getInstanceInformation(instance.id),
+      extras: engine._instanceIdExtraInfoMapping[instance.id],
       isCurrentlyExecutedInBpmnEngine: true,
     });
   }

--- a/src/engine/universal/core/src/management.js
+++ b/src/engine/universal/core/src/management.js
@@ -49,13 +49,14 @@ const Management = {
    *
    * @param {String} definitionId
    * @param {Number} version
+   * @param {boolean} [active=true] defines if the version is allowed to spawn instances automatically
    * @returns {Promise<Engine>} the instance of
    */
-  async ensureProcessEngineWithVersion(definitionId, version) {
+  async ensureProcessEngineWithVersion(definitionId, version, active = true) {
     const engine = this.ensureProcessEngine(definitionId);
 
     // ensure that the version is deployed
-    await engine.deployProcessVersion(definitionId, version);
+    await engine.deployProcessVersion(definitionId, version, active);
 
     return engine;
   },
@@ -107,7 +108,7 @@ const Management = {
       }
     }
 
-    const engine = await this.ensureProcessEngineWithVersion(definitionId, version);
+    const engine = await this.ensureProcessEngineWithVersion(definitionId, version, true);
 
     return await engine.startProcessVersion(version, variables, activityID, onStarted, onEnded);
   },
@@ -158,7 +159,7 @@ const Management = {
 
       const { processVersion, importedInstance, extras } = this.importInstance(archivedInstance);
 
-      engine = await this.ensureProcessEngineWithVersion(definitionId, processVersion);
+      engine = await this.ensureProcessEngineWithVersion(definitionId, processVersion, false);
 
       await engine.startProcessVersion(
         processVersion,
@@ -266,7 +267,7 @@ const Management = {
       const { processVersion, importedInstance, extras } =
         this.importInstance(startingInstanceInfo);
 
-      engine = await this.ensureProcessEngineWithVersion(definitionId, processVersion);
+      engine = await this.ensureProcessEngineWithVersion(definitionId, processVersion, false);
 
       await engine.startProcessVersion(
         processVersion,
@@ -396,7 +397,7 @@ const Management = {
 
       const { processVersion, importedInstance } = this.importInstance(resumedInstanceInformation);
       /** @type {Engine} */
-      const engine = await this.ensureProcessEngineWithVersion(definitionId, processVersion);
+      const engine = await this.ensureProcessEngineWithVersion(definitionId, processVersion, false);
 
       engine.startProcessVersion(
         processVersion,
@@ -452,7 +453,11 @@ const Management = {
     }
 
     /** @type {Engine} */
-    const engine = await this.ensureProcessEngineWithVersion(definitionId, instance.processVersion);
+    const engine = await this.ensureProcessEngineWithVersion(
+      definitionId,
+      instance.processVersion,
+      false,
+    );
     // transform instance information into the form used by the neo-engine
     const { processVersion, importedInstance, extras } = this.importInstance(instance);
 

--- a/src/engine/universal/distribution/src/routes/ProcessInstanceRoutes.js
+++ b/src/engine/universal/distribution/src/routes/ProcessInstanceRoutes.js
@@ -287,6 +287,8 @@ module.exports = (path, management) => {
           `Updating the variables in the instance (id: ${instanceId}) for the process (id: ${definitionId}) failed. Reason: ${err.message}`,
         );
       }
+
+      return { response: '', mimeType: 'text' };
     },
   );
 


### PR DESCRIPTION
## Summary

Set the feature flag for the instance recovery feature to true.

## Details

- added option to deploy a version in an active or inactive state
- set default value of the "enableInterruptedInstanceRecovery" feature flag to "true"
  - instances states are not only saved when an instance ends but every time the instance state changes
  - when an engine restarts all instances that were running before the engine went offline are restarted automatically
- Fixed: files that are written to when an engine crashes are potentially not completed and therefore in an invalid state; if the engine relies on those files when it starts (e.g. logging files) the engine will instantly crash again
- Fixed: the endpoint that allows setting instance variable values does not return a response that the ms expects
 