### PR TITLE
Persistent Executions Data: Initial Commit

### DIFF
--- a/src/engine/e2e_tests/process/deployment/deployment.e2e.test.js
+++ b/src/engine/e2e_tests/process/deployment/deployment.e2e.test.js
@@ -66,7 +66,7 @@ async function startInstance(definitionId, version, engineName, variables = {}, 
     await request
       .post(`:${engine.port}/process/${definitionId}/versions/${version}/instance`)
       .send({ variables, extras })
-  ).body.instanceId;
+  ).body.processInstanceId;
 }
 
 async function getInstanceInformation(definitionId, instanceId, engineName) {

--- a/src/engine/e2e_tests/process/processEndpoint.e2e.test.js
+++ b/src/engine/e2e_tests/process/processEndpoint.e2e.test.js
@@ -234,7 +234,7 @@ describe('Test process endpoints', () => {
           expect(getResponse.body).toStrictEqual([]);
           const postResponse = await request.post('/process/definitionId/versions/123/instance');
           expect(postResponse.status).toBe(201);
-          ({ instanceId } = postResponse.body);
+          ({ processInstanceId: instanceId } = postResponse.body);
           // allow everything to start correctly (the user task should have completely started)
           await new Promise((res) => setTimeout(res, 500));
         });

--- a/src/engine/universal/core/src/__tests__/management.test.js
+++ b/src/engine/universal/core/src/__tests__/management.test.js
@@ -151,8 +151,8 @@ describe('Management', () => {
     jest.spyOn(Engine.prototype, 'deployProcessVersion');
     jest.spyOn(Engine.prototype, 'startProcessVersion');
     distribution.db.isProcessVersionValid.mockResolvedValue(true);
-    const instanceId = await management.createInstance('0', '123', {});
-    expect(management.getEngineWithID(instanceId)).toBeInstanceOf(Engine);
+    const instance = await management.createInstance('0', '123', {});
+    expect(management.getEngineWithID(instance.processInstanceId)).toBeInstanceOf(Engine);
     expect(Engine.prototype.deployProcessVersion).toHaveBeenCalledWith('0', '123', true);
     expect(Engine.prototype.startProcessVersion).toHaveBeenCalledWith(
       '123',
@@ -166,9 +166,11 @@ describe('Management', () => {
   it('reuses an existing ProceedEngine instance when there is one for the given definitionsId to start an instance', async () => {
     jest.spyOn(Engine.prototype, 'deployProcessVersion');
     jest.spyOn(Engine.prototype, 'startProcessVersion');
-    const firstInstanceId = await management.createInstance('0', '123', {});
+    const firstInstance = await management.createInstance('0', '123', {});
+    const firstInstanceId = firstInstance.processInstanceId;
 
-    const secondInstanceId = await management.createInstance('0', '123', {});
+    const secondInstance = await management.createInstance('0', '123', {});
+    const secondInstanceId = secondInstance.processInstanceId;
 
     const firstEngine = management.getEngineWithID(firstInstanceId);
     expect(management.getEngineWithID(firstInstanceId)).toBe(

--- a/src/engine/universal/core/src/engine/engine.js
+++ b/src/engine/universal/core/src/engine/engine.js
@@ -291,7 +291,7 @@ class Engine {
     this.originalInstanceState = instance;
     this.instanceEventHandlers = {
       onStarted: (newInstance) => {
-        resolver(newInstance.id);
+        resolver(this.getInstanceInformation(newInstance.id));
         // make sure to keep the information from the original instance on the recreated instance
         if (instance && instance.callingInstance) {
           newInstance.callingInstance = instance.callingInstance;

--- a/src/engine/universal/core/src/management.js
+++ b/src/engine/universal/core/src/management.js
@@ -510,7 +510,7 @@ const Management = {
       };
     });
 
-    const instanceId = await engine.startProcessVersion(
+    const recoveredInstance = await engine.startProcessVersion(
       processVersion,
       importedInstance.variables,
       importedInstance,
@@ -526,7 +526,7 @@ const Management = {
     // if the instance was in the process of being paused => make sure that it is paused again
     // (will lead to it being paused directly since no tasks have started yet)
     if (importedInstance.instanceState[0] === 'PAUSING') {
-      await engine.pauseInstance(instanceId);
+      await engine.pauseInstance(recoveredInstance.processInstanceId);
     }
 
     // allow waiting instances to be started (and give information about tokens being interrupted which is needed to check if called instances should run)

--- a/src/engine/universal/distribution/src/routes/ProcessInstanceRoutes.js
+++ b/src/engine/universal/distribution/src/routes/ProcessInstanceRoutes.js
@@ -45,7 +45,7 @@ module.exports = (path, management) => {
       }
     }
 
-    const instanceId = await management.createInstance(
+    const instance = await management.createInstance(
       definitionId,
       version,
       variables,
@@ -57,7 +57,7 @@ module.exports = (path, management) => {
       },
     );
 
-    if (!instanceId) {
+    if (!instance) {
       throw new APIError(
         406,
         `Engine not allowed to start the instance for the process (id: ${definitionId}).`,
@@ -70,7 +70,7 @@ module.exports = (path, management) => {
     return {
       statusCode: 201,
       mimeType: 'application/json',
-      response: JSON.stringify({ instanceId }),
+      response: JSON.stringify(instance),
     };
   });
 

--- a/src/management-system-v2/app/(dashboard)/[environmentId]/(automation)/executions/[processId]/process-deployment-view.tsx
+++ b/src/management-system-v2/app/(dashboard)/[environmentId]/(automation)/executions/[processId]/process-deployment-view.tsx
@@ -44,6 +44,7 @@ import { useEnvironment } from '@/components/auth-can';
 
 import { GrDocumentUser } from 'react-icons/gr';
 import { handleOpenDocumentation } from '../../../processes/processes-helper';
+import { startInstance } from '@/lib/executions/instance-server-actions';
 
 export default function ProcessDeploymentView({
   processId,
@@ -79,7 +80,6 @@ export default function ProcessDeploymentView({
   const {
     data: deploymentInfo,
     refetch,
-    startInstance,
     resumeInstance,
     pauseInstance,
     stopInstance,
@@ -370,7 +370,7 @@ export default function ProcessDeploymentView({
 
                             setStartForm(startForm);
                           } else {
-                            return startInstance(versionId);
+                            return startInstance(spaceId, processId, versionId);
                           }
                         },
                         onSuccess: async (instanceId) => {
@@ -547,7 +547,7 @@ export default function ProcessDeploymentView({
 
             // start the instance with the initial variable values from the start form
             await wrapServerCall({
-              fn: () => startInstance(versionId, mappedVariables),
+              fn: () => startInstance(spaceId, processId, versionId, mappedVariables),
 
               onSuccess: async (instanceId) => {
                 await refetch();

--- a/src/management-system-v2/app/(dashboard)/[environmentId]/(automation)/executions/[processId]/process-deployment-view.tsx
+++ b/src/management-system-v2/app/(dashboard)/[environmentId]/(automation)/executions/[processId]/process-deployment-view.tsx
@@ -44,7 +44,13 @@ import { useEnvironment } from '@/components/auth-can';
 
 import { GrDocumentUser } from 'react-icons/gr';
 import { handleOpenDocumentation } from '../../../processes/processes-helper';
-import { startInstance } from '@/lib/executions/instance-server-actions';
+import {
+  getProcessStartForm,
+  pauseInstance,
+  resumeInstance,
+  startInstance,
+  stopInstance,
+} from '@/lib/executions/instance-server-actions';
 
 export default function ProcessDeploymentView({
   processId,
@@ -77,14 +83,7 @@ export default function ProcessDeploymentView({
   const canvasRef = useRef<BPMNCanvasRef>(null);
   const [infoPanelOpen, setInfoPanelOpen] = useState(false);
 
-  const {
-    data: deploymentInfo,
-    refetch,
-    resumeInstance,
-    pauseInstance,
-    stopInstance,
-    getStartForm,
-  } = useDeployment(processId, initialDeploymentInfo);
+  const { data: deploymentInfo, refetch } = useDeployment(processId, initialDeploymentInfo);
 
   const {
     selectedVersion,
@@ -341,7 +340,7 @@ export default function ProcessDeploymentView({
                           const latestDeployment = getLatestDeployment(deploymentInfo);
                           const versionId = latestDeployment.versionId;
 
-                          let startForm = await getStartForm(versionId);
+                          let startForm = await getProcessStartForm(spaceId, processId, versionId);
 
                           if (typeof startForm !== 'string') return startForm;
 
@@ -442,7 +441,12 @@ export default function ProcessDeploymentView({
                         onClick={async () => {
                           setResumingInstance(true);
                           await wrapServerCall({
-                            fn: () => resumeInstance(selectedInstance.processInstanceId),
+                            fn: () =>
+                              resumeInstance(
+                                spaceId,
+                                processId,
+                                selectedInstance.processInstanceId,
+                              ),
                             onSuccess: async () => await refetch(),
                           });
                           setResumingInstance(false);
@@ -460,7 +464,8 @@ export default function ProcessDeploymentView({
                         onClick={async () => {
                           setPausingInstance(true);
                           await wrapServerCall({
-                            fn: async () => pauseInstance(selectedInstance.processInstanceId),
+                            fn: async () =>
+                              pauseInstance(spaceId, processId, selectedInstance.processInstanceId),
                             onSuccess: async () => await refetch(),
                           });
                           setPausingInstance(false);
@@ -478,7 +483,8 @@ export default function ProcessDeploymentView({
                       onClick={async () => {
                         setStoppingInstance(true);
                         await wrapServerCall({
-                          fn: async () => stopInstance(selectedInstance.processInstanceId),
+                          fn: async () =>
+                            stopInstance(spaceId, processId, selectedInstance.processInstanceId),
                           onSuccess: async () => await refetch(),
                         });
                         setStoppingInstance(false);

--- a/src/management-system-v2/app/(dashboard)/[environmentId]/(automation)/executions/deployment-hook.ts
+++ b/src/management-system-v2/app/(dashboard)/[environmentId]/(automation)/executions/deployment-hook.ts
@@ -5,16 +5,8 @@ import {
   VersionInfo,
   getDeployments,
 } from '@/lib/engines/deployment';
-import {
-  pauseInstanceOnMachine,
-  resumeInstanceOnMachine,
-  stopInstanceOnMachine,
-} from '@/lib/engines/instances';
-import { Engine } from '@/lib/engines/types';
-import { getStartFormFromMachine } from '@/lib/engines/tasklist';
 import useEngines from '@/lib/engines/use-engines';
-import { asyncFilter, asyncForEach, deepEquals } from '@/lib/helpers/javascriptHelpers';
-import { getErrorMessage, userError } from '@/lib/user-error';
+import { deepEquals } from '@/lib/helpers/javascriptHelpers';
 import { useQuery } from '@tanstack/react-query';
 import { useCallback } from 'react';
 
@@ -97,79 +89,6 @@ function useDeployment(definitionId: string, initialData?: DeployedProcessInfo) 
     },
   });
 
-  const activeStates = ['PAUSED', 'RUNNING', 'READY', 'DEPLOYMENT-WAITING', 'WAITING'];
-  async function changeInstanceState(
-    instanceId: string,
-    stateValidator: (state: InstanceInfo['instanceState']) => boolean,
-    stateChangeFunction: typeof resumeInstanceOnMachine,
-  ) {
-    if (!engines) return;
-    try {
-      const targetEngines = await asyncFilter(engines, async (engine: Engine) => {
-        const deployments = await getDeployments([engine]);
-
-        return deployments.some((deployment) => {
-          if (deployment.definitionId !== definitionId) return false;
-
-          const instance = deployment.instances.find(
-            (instance) => instance.processInstanceId === instanceId,
-          );
-          if (!instance) return false;
-
-          return stateValidator(instance.instanceState);
-        });
-      });
-
-      await asyncForEach(targetEngines, async (engine) => {
-        await stateChangeFunction(definitionId, instanceId, engine);
-      });
-    } catch (e) {
-      const message = getErrorMessage(e);
-      return userError(message);
-    }
-  }
-
-  async function resumeInstance(instanceId: string) {
-    // TODO: manage permissions for starting an instance
-    return await changeInstanceState(
-      instanceId,
-      (tokenStates) => tokenStates.some((tokenState) => tokenState === 'PAUSED'),
-      resumeInstanceOnMachine,
-    );
-  }
-
-  async function pauseInstance(instanceId: string) {
-    // TODO: manage permissions for starting an instance
-    return await changeInstanceState(
-      instanceId,
-      (tokenStates) =>
-        tokenStates.some((state) => activeStates.includes(state) && state !== 'PAUSED'),
-      pauseInstanceOnMachine,
-    );
-  }
-
-  async function stopInstance(instanceId: string) {
-    // TODO: manage permissions for starting an instance
-    return await changeInstanceState(
-      instanceId,
-      (tokenStates) => tokenStates.some((state) => activeStates.includes(state)),
-      stopInstanceOnMachine,
-    );
-  }
-
-  async function getStartForm(versionId: string) {
-    if (!engines?.length) return userError('No fitting engine found');
-
-    try {
-      // TODO: in case of static deployment or different versions on different engines we will have
-      // to check if the engine can actually be used to start an instance
-      return await getStartFormFromMachine(definitionId, versionId, engines[0]);
-    } catch (e) {
-      const message = getErrorMessage(e);
-      return userError(message);
-    }
-  }
-
   const queryFn = useCallback(async () => {
     if (engines?.length) {
       // TODO: this only handles situations where we have only a single engine
@@ -199,7 +118,7 @@ function useDeployment(definitionId: string, initialData?: DeployedProcessInfo) 
     },
   });
 
-  return { ...query, resumeInstance, pauseInstance, stopInstance, getStartForm };
+  return { ...query };
 }
 
 export default useDeployment;

--- a/src/management-system-v2/app/(dashboard)/[environmentId]/(automation)/executions/deployment-hook.ts
+++ b/src/management-system-v2/app/(dashboard)/[environmentId]/(automation)/executions/deployment-hook.ts
@@ -1,4 +1,4 @@
-import { useEnvironment, useSession } from '@/components/auth-can';
+import { useEnvironment } from '@/components/auth-can';
 import {
   DeployedProcessInfo,
   InstanceInfo,
@@ -8,7 +8,6 @@ import {
 import {
   pauseInstanceOnMachine,
   resumeInstanceOnMachine,
-  startInstanceOnMachine,
   stopInstanceOnMachine,
 } from '@/lib/engines/instances';
 import { Engine } from '@/lib/engines/types';
@@ -89,7 +88,6 @@ const mergeDeployment = (
 
 function useDeployment(definitionId: string, initialData?: DeployedProcessInfo) {
   const space = useEnvironment();
-  const { data: session } = useSession();
 
   const { data: engines } = useEngines(space, {
     key: [definitionId],
@@ -98,17 +96,6 @@ function useDeployment(definitionId: string, initialData?: DeployedProcessInfo) 
       return deployments.some((d) => d.definitionId === definitionId);
     },
   });
-
-  const startInstance = async (versionId: string, variables: { [key: string]: any } = {}) => {
-    if (!engines?.length) return userError('No fitting engine found');
-
-    // TODO: in case of static deployment or different versions on different engines we will have
-    // to check if the engine can actually be used to start an instance
-    return await startInstanceOnMachine(definitionId, versionId, engines[0], variables, {
-      processInitiator: session?.user.id,
-      spaceIdOfProcessInitiator: space.spaceId,
-    });
-  };
 
   const activeStates = ['PAUSED', 'RUNNING', 'READY', 'DEPLOYMENT-WAITING', 'WAITING'];
   async function changeInstanceState(
@@ -212,7 +199,7 @@ function useDeployment(definitionId: string, initialData?: DeployedProcessInfo) 
     },
   });
 
-  return { ...query, startInstance, resumeInstance, pauseInstance, stopInstance, getStartForm };
+  return { ...query, resumeInstance, pauseInstance, stopInstance, getStartForm };
 }
 
 export default useDeployment;

--- a/src/management-system-v2/lib/data/deployment.ts
+++ b/src/management-system-v2/lib/data/deployment.ts
@@ -1,0 +1,56 @@
+'use server';
+
+import db from '@/lib/data/db';
+import { DeploymentInput, DeploymentInputSchema } from '../deployment-schema';
+import { getCurrentEnvironment } from '@/components/auth';
+import { UserErrorType, userError } from '../user-error';
+
+export async function getProcessDeployments(spaceId: string, processId: string) {
+  const { ability } = await getCurrentEnvironment(spaceId);
+
+  if (!ability.can('view', 'Execution'))
+    return userError('Invalid Permissions', UserErrorType.PermissionError);
+
+  const deployments = await db.processDeployment.findMany({
+    where: { AND: [{ version: { processId } }, { removeTime: null }] },
+    include: { version: { select: { processId: true } } },
+  });
+
+  return deployments.map((d) => ({ ...d, version: undefined, processId: d.version.processId }));
+}
+
+export async function addDeployment(spaceId: string, input: DeploymentInput) {
+  const { ability } = await getCurrentEnvironment(spaceId);
+
+  if (!ability.can('create', 'Execution'))
+    return userError('Invalid Permissions', UserErrorType.PermissionError);
+
+  const data = DeploymentInputSchema.parse(input);
+
+  const result = await db.processDeployment.createMany({
+    data: data.engineIds.map((engineId) => ({ ...data, engineIds: undefined, engineId })),
+  });
+
+  return result;
+}
+
+export async function updateDeployment(
+  spaceId: string,
+  deploymentId: string,
+  input: Partial<DeploymentInput>,
+) {
+  const { ability } = await getCurrentEnvironment(spaceId);
+
+  if (!ability.can('update', 'Execution')) {
+    return userError('Invalid Permissions', UserErrorType.PermissionError);
+  }
+
+  const data = DeploymentInputSchema.partial().strict().parse(input);
+
+  const result = await db.processDeployment.update({
+    where: { id: deploymentId },
+    data,
+  });
+
+  return result;
+}

--- a/src/management-system-v2/lib/data/deployment.ts
+++ b/src/management-system-v2/lib/data/deployment.ts
@@ -27,11 +27,9 @@ export async function addDeployment(spaceId: string, input: DeploymentInput) {
 
   const data = DeploymentInputSchema.parse(input);
 
-  const result = await db.processDeployment.createMany({
+  await db.processDeployment.createMany({
     data: data.engineIds.map((engineId) => ({ ...data, engineIds: undefined, engineId })),
   });
-
-  return result;
 }
 
 export async function updateDeployment(

--- a/src/management-system-v2/lib/data/instance.ts
+++ b/src/management-system-v2/lib/data/instance.ts
@@ -1,0 +1,24 @@
+'use server';
+
+import db from '@/lib/data/db';
+
+import { getCurrentEnvironment } from '@/components/auth';
+import { InstanceInput, InstanceInputSchema } from '../instance-schema';
+import { UserErrorType, userError } from '../user-error';
+
+export async function addInstance(
+  spaceId: string,
+  instance: InstanceInput,
+  skipAbilityCheck = false,
+) {
+  if (!skipAbilityCheck) {
+    const { ability } = await getCurrentEnvironment(spaceId);
+
+    if (!ability.can('create', 'Execution'))
+      return userError('Invalid Permissions', UserErrorType.PermissionError);
+  }
+
+  const data = InstanceInputSchema.parse(instance);
+
+  return await db.processInstance.create({ data });
+}

--- a/src/management-system-v2/lib/data/instance.ts
+++ b/src/management-system-v2/lib/data/instance.ts
@@ -48,7 +48,7 @@ export async function updateInstance(
   if (!skipAbilityCheck) {
     const { ability } = await getCurrentEnvironment(spaceId);
 
-    if (!ability.can('create', 'Execution'))
+    if (!ability.can('update', 'Execution'))
       return userError('Invalid Permissions', UserErrorType.PermissionError);
   }
 

--- a/src/management-system-v2/lib/data/instance.ts
+++ b/src/management-system-v2/lib/data/instance.ts
@@ -5,6 +5,22 @@ import db from '@/lib/data/db';
 import { getCurrentEnvironment } from '@/components/auth';
 import { InstanceInput, InstanceInputSchema } from '../instance-schema';
 import { UserErrorType, userError } from '../user-error';
+import { InstanceInfo } from '../engines/deployment';
+
+export async function getInstance(spaceId: string, instanceId: string) {
+  const { ability } = await getCurrentEnvironment(spaceId);
+
+  if (!ability.can('view', 'Execution'))
+    return userError('Invalid Permissions', UserErrorType.PermissionError);
+
+  const instanceInfo = await db.processInstance.findUnique({
+    where: { id: instanceId },
+  });
+
+  if (!instanceInfo) return null;
+
+  return instanceInfo as Omit<typeof instanceInfo, 'state'> & { state: InstanceInfo };
+}
 
 export async function addInstance(
   spaceId: string,
@@ -21,4 +37,25 @@ export async function addInstance(
   const data = InstanceInputSchema.parse(instance);
 
   return await db.processInstance.create({ data });
+}
+
+export async function updateInstance(
+  spaceId: string,
+  instanceId: string,
+  input: Partial<InstanceInput>,
+  skipAbilityCheck = false,
+) {
+  if (!skipAbilityCheck) {
+    const { ability } = await getCurrentEnvironment(spaceId);
+
+    if (!ability.can('create', 'Execution'))
+      return userError('Invalid Permissions', UserErrorType.PermissionError);
+  }
+
+  const data = InstanceInputSchema.partial().strict().parse(input);
+
+  return await db.processInstance.update({
+    where: { id: instanceId },
+    data,
+  });
 }

--- a/src/management-system-v2/lib/deployment-schema.ts
+++ b/src/management-system-v2/lib/deployment-schema.ts
@@ -1,0 +1,14 @@
+import { z } from 'zod';
+
+export const DeploymentInputSchema = z.object({
+  versionId: z.string(),
+  deployerId: z.string(),
+  deployTime: z.date(),
+  removeTime: z.date().nullable().default(null),
+  engineIds: z.string().array(),
+});
+
+export type DeploymentInput = z.input<typeof DeploymentInputSchema>;
+export type Deployment = z.output<typeof DeploymentInputSchema> & {
+  id: string;
+};

--- a/src/management-system-v2/lib/engines/instances.ts
+++ b/src/management-system-v2/lib/engines/instances.ts
@@ -6,6 +6,7 @@ import { userError } from '../user-error';
 import { env } from '../ms-config/env-vars';
 import os from 'os';
 import { truthyFilter } from '../typescript-utils';
+import { InstanceInfo } from './deployment';
 
 export async function startInstanceOnMachine(
   definitionId: string,
@@ -36,7 +37,7 @@ export async function startInstanceOnMachine(
       body: { variables, extras },
     });
 
-    return response.instanceId as string;
+    return response as InstanceInfo;
   } catch (err) {
     if (
       err instanceof Error &&

--- a/src/management-system-v2/lib/executions/deployment-server-actions.ts
+++ b/src/management-system-v2/lib/executions/deployment-server-actions.ts
@@ -16,12 +16,7 @@ import {
   getDeploymentActivation,
 } from '../engines/deployment';
 import { getCurrentUser } from '@/components/auth';
-import {
-  addDeployment,
-  getProcessDeployments,
-  removeDeployment as removeStoredDeployment,
-  updateDeployment,
-} from '../data/deployment';
+import { addDeployment, getProcessDeployments, updateDeployment } from '../data/deployment';
 
 export async function getDeployment(spaceId: string, definitionId: string, ability?: Ability) {
   const engines = await getAllAvailableEngines(spaceId, ability);

--- a/src/management-system-v2/lib/executions/deployment-server-actions.ts
+++ b/src/management-system-v2/lib/executions/deployment-server-actions.ts
@@ -1,6 +1,6 @@
 'use server';
 
-import { asyncFilter, asyncMap } from '@/lib/helpers/javascriptHelpers';
+import { asyncForEach, asyncMap } from '@/lib/helpers/javascriptHelpers';
 import Ability from '@/lib/ability/abilityHelper';
 import { UserFacingError, getErrorMessage, isUserErrorResponse, userError } from '@/lib/user-error';
 
@@ -10,13 +10,18 @@ import { Engine, SpaceEngine } from '@/lib/engines/types';
 import {
   deployProcess as _deployProcess,
   getDeployments as fetchDeployments,
-  getDeployment as fetchDeployment,
   getProcessImageFromMachine,
   removeDeploymentFromMachines,
   changeDeploymentActivation as _changeDeploymentActivation,
-  DeployedProcessInfo,
   getDeploymentActivation,
 } from '../engines/deployment';
+import { getCurrentUser } from '@/components/auth';
+import {
+  addDeployment,
+  getProcessDeployments,
+  removeDeployment as removeStoredDeployment,
+  updateDeployment,
+} from '../data/deployment';
 
 export async function getDeployment(spaceId: string, definitionId: string, ability?: Ability) {
   const engines = await getAllAvailableEngines(spaceId, ability);
@@ -36,18 +41,23 @@ export async function deployProcess(
 ) {
   try {
     // TODO: manage permissions for deploying a process
+    const { userId } = await getCurrentUser();
 
-    let engines;
+    let engines: Engine[];
     if (_forceEngine === 'PROCEED') {
       // force that only proceed engines are supposed to be used
-      engines = await getAvailableAdminEngines();
+      const res = await getAvailableAdminEngines();
 
-      if (isUserErrorResponse(engines)) return engines;
+      if (isUserErrorResponse(res)) return res;
+
+      engines = res;
     } else {
       // get all available engines
-      engines = await getAllAvailableEngines(spaceId);
+      const res = await getAllAvailableEngines(spaceId);
 
-      if (isUserErrorResponse(engines)) return engines;
+      if (isUserErrorResponse(res)) return res;
+
+      engines = res;
 
       if (_forceEngine) {
         // force a specific engine if it is available
@@ -58,48 +68,43 @@ export async function deployProcess(
 
     if (!engines.length) throw new UserFacingError('No fitting engine found.');
 
-    const processAlreadyDeployedInfo = await asyncMap(engines, async (engine) => {
-      let deployment;
-      try {
-        deployment = await fetchDeployment(engine, definitionId);
-        // ignore not found errors on engines that don't have a deployment of the process
-      } catch (err) {
-        deployment = undefined;
-      }
-      return [engine, deployment] as const;
-    });
+    const alreadyDeployed = await getProcessDeployments(spaceId, definitionId);
+    if (isUserErrorResponse(alreadyDeployed)) return alreadyDeployed;
 
-    function withDeployment(
-      info: (typeof processAlreadyDeployedInfo)[number],
-    ): info is readonly [Engine, DeployedProcessInfo] {
-      return !!info[1];
-    }
-    const enginesWithDeployment = processAlreadyDeployedInfo.filter(withDeployment);
+    const processAlreadyDeployedInfo = alreadyDeployed
+      .map((deployment) => ({
+        ...deployment,
+        engine: (engines as Engine[]).find((e) => e.id === deployment.engineId)!,
+      }))
+      .filter((d) => !!d.engine);
 
-    // check if the version is already deployed to some engine since we don't
+    // check if the version is already deployed to some reachable engine since we don't
     // need to redeploy it in that case
-    if (
-      !_forceEngine &&
-      enginesWithDeployment.some(([_, deployment]) =>
-        deployment.versions.some((version) => version.versionId === versionId),
-      )
-    ) {
+    if (processAlreadyDeployedInfo.some((i) => i.versionId === versionId)) {
       return;
     }
 
-    if (!_forceEngine && enginesWithDeployment.length) {
+    if (processAlreadyDeployedInfo.length) {
       // check if an engine already has another version in which case that engine is selected
-      engines = enginesWithDeployment.map(([engine]) => engine);
+      engines = processAlreadyDeployedInfo.map((i) => i.engine);
     }
 
     const deployedTo = await _deployProcess(definitionId, versionId, spaceId, method, engines);
 
+    await addDeployment(spaceId, {
+      versionId,
+      deployerId: userId,
+      deployTime: new Date(),
+      engineIds: deployedTo.map((engine) => engine.id),
+    });
+
     // deactivate the process on all engines that have a deployment but which were not target of the
     // new deployment
     await Promise.allSettled(
-      enginesWithDeployment.map(async ([engine]) => {
-        if (!deployedTo.some((dE) => dE.id === engine.id)) {
-          await _changeDeploymentActivation(engine, definitionId, undefined, false);
+      processAlreadyDeployedInfo.map(async (deployment) => {
+        // TODO: consider all engines to deactivate deployments on machines that are not "forced" here
+        if (deployment.engine && !deployedTo.some((engine) => engine.id === deployment.engineId)) {
+          await _changeDeploymentActivation(deployment.engine, definitionId, undefined, false);
         }
       }),
     );
@@ -111,15 +116,25 @@ export async function deployProcess(
 
 export async function removeDeployment(definitionId: string, spaceId: string) {
   try {
+    const deployments = await getProcessDeployments(spaceId, definitionId);
+    if (isUserErrorResponse(deployments)) return deployments;
+
     const availableEngines = await getAllAvailableEngines(spaceId);
     if (isUserErrorResponse(availableEngines)) return availableEngines;
-    const engines = await asyncFilter(availableEngines, async (engine) => {
-      const deployments = await fetchDeployments([engine]);
+    await asyncForEach(deployments, async (deployment) => {
+      try {
+        const engine = availableEngines.find((aE) => aE.id === deployment.engineId);
 
-      return deployments.some((deployment) => deployment.definitionId === definitionId);
+        if (engine) {
+          // TODO: we might have deployments of multiple versions of the same process to the same
+          // engine => we don't need to call this for every version but only once per engine per
+          // process
+          await removeDeploymentFromMachines([engine], deployment.processId);
+          await updateDeployment(spaceId, deployment.id, { removeTime: new Date() });
+          return;
+        }
+      } catch (err) {}
     });
-
-    await removeDeploymentFromMachines(engines, definitionId);
   } catch (e) {
     const message = getErrorMessage(e);
     return userError(message);
@@ -132,20 +147,26 @@ export async function getProcessActivationStatus(
   version: string,
 ) {
   try {
+    let deployments = await getProcessDeployments(spaceId, definitionId);
+    if (isUserErrorResponse(deployments)) return deployments;
+    deployments = deployments.filter((deployment) => deployment.versionId === version);
+
     const availableEngines = await getAllAvailableEngines(spaceId);
     if (isUserErrorResponse(availableEngines)) return availableEngines;
-    const engines = await asyncFilter(availableEngines, async (engine) => {
-      const deployments = await fetchDeployments([engine]);
-      return deployments.some(
-        (deployment) =>
-          deployment.definitionId === definitionId &&
-          deployment.versions.some((v) => v.versionId === version),
-      );
+
+    const res = await asyncMap(deployments, async (deployment) => {
+      try {
+        const engine = availableEngines.find((aE) => aE.id === deployment.engineId);
+
+        if (engine) {
+          return await getDeploymentActivation(engine, definitionId, version);
+        }
+      } catch (err) {}
+
+      return false;
     });
 
-    if (!engines.length) return false;
-
-    return await getDeploymentActivation(engines[0], definitionId, version);
+    return res.some((isActive) => isActive);
   } catch (e) {
     const message = getErrorMessage(e);
     return userError(message);
@@ -159,22 +180,23 @@ export async function changeDeploymentActivation(
   value: boolean,
 ) {
   try {
-    const availableEngines = await getAllAvailableEngines(spaceId);
+    let deployments = await getProcessDeployments(spaceId, definitionId);
+    if (isUserErrorResponse(deployments)) return deployments;
+    const versionDeployments = deployments.filter((deployment) => deployment.versionId === version);
+
+    if (!deployments.length) return userError('This version is not deployed');
+
+    let availableEngines = await getAllAvailableEngines(spaceId);
     if (isUserErrorResponse(availableEngines)) return availableEngines;
-    const engines = await asyncFilter(availableEngines, async (engine) => {
-      const deployments = await fetchDeployments([engine]);
 
-      return deployments.some(
-        (deployment) =>
-          deployment.definitionId === definitionId &&
-          deployment.versions.some((v) => v.versionId === version),
-      );
-    });
+    availableEngines = availableEngines.filter((e) =>
+      versionDeployments.some((d) => d.engineId === e.id),
+    );
 
-    if (!engines.length)
+    if (!availableEngines.length)
       throw new Error('There is no available engine with the requested process version.');
 
-    await _changeDeploymentActivation(engines[0], definitionId, version, value);
+    await _changeDeploymentActivation(availableEngines[0], definitionId, version, value);
   } catch (e) {
     const message = getErrorMessage(e);
     return userError(message);
@@ -183,20 +205,23 @@ export async function changeDeploymentActivation(
 
 export async function getProcessImage(spaceId: string, definitionId: string, fileName: string) {
   try {
-    // find the engine the instance is running on
+    let deployments = await getProcessDeployments(spaceId, definitionId);
+    if (isUserErrorResponse(deployments)) return deployments;
+
     const availableEngines = await getAllAvailableEngines(spaceId);
     if (isUserErrorResponse(availableEngines)) return availableEngines;
-    let engines = await asyncFilter(availableEngines, async (engine) => {
-      const deployments = await fetchDeployments([engine]);
 
-      // TODO: when we start to have assignments of processes to multiple machines we need to check
-      // if the deployment on the machine actually contains the image
-      return deployments.some((deployment) => deployment.definitionId === definitionId);
-    });
+    for (const deployment of deployments) {
+      const engine = availableEngines.find((e) => e.id === deployment.engineId);
 
-    if (!engines.length) throw new Error('Failed to an engine the process was deployed to!');
+      if (engine) {
+        try {
+          return await getProcessImageFromMachine(engine, definitionId, fileName);
+        } catch (err) {}
+      }
+    }
 
-    return await getProcessImageFromMachine(engines[0], definitionId, fileName);
+    return userError('Failed to fetch the image from the engines the process is deployed to.');
   } catch (err) {
     const message = getErrorMessage(err);
     return userError(message);

--- a/src/management-system-v2/lib/executions/deployment-server-actions.ts
+++ b/src/management-system-v2/lib/executions/deployment-server-actions.ts
@@ -2,7 +2,13 @@
 
 import { asyncForEach, asyncMap } from '@/lib/helpers/javascriptHelpers';
 import Ability from '@/lib/ability/abilityHelper';
-import { UserFacingError, getErrorMessage, isUserErrorResponse, userError } from '@/lib/user-error';
+import {
+  UserErrorType,
+  UserFacingError,
+  getErrorMessage,
+  isUserErrorResponse,
+  userError,
+} from '@/lib/user-error';
 
 import { getAllAvailableEngines, getAvailableAdminEngines } from '@/lib/data/engines';
 
@@ -15,7 +21,7 @@ import {
   changeDeploymentActivation as _changeDeploymentActivation,
   getDeploymentActivation,
 } from '../engines/deployment';
-import { getCurrentUser } from '@/components/auth';
+import { getCurrentEnvironment, getCurrentUser } from '@/components/auth';
 import { addDeployment, getProcessDeployments, updateDeployment } from '../data/deployment';
 
 export async function getDeployment(spaceId: string, definitionId: string, ability?: Ability) {
@@ -35,7 +41,11 @@ export async function deployProcess(
   _forceEngine?: SpaceEngine | 'PROCEED',
 ) {
   try {
-    // TODO: manage permissions for deploying a process
+    const { ability } = await getCurrentEnvironment(spaceId);
+
+    if (!ability.can('create', 'Execution'))
+      return userError('Invalid Permissions', UserErrorType.PermissionError);
+
     const { userId } = await getCurrentUser();
 
     let engines: Engine[];

--- a/src/management-system-v2/lib/executions/instance-server-actions.ts
+++ b/src/management-system-v2/lib/executions/instance-server-actions.ts
@@ -1,14 +1,14 @@
 'use server';
 
-import { asyncFilter, asyncForEach } from '@/lib/helpers/javascriptHelpers';
-import { getCurrentEnvironment, getCurrentUser } from '@/components/auth';
-import { UserFacingError, getErrorMessage, isUserErrorResponse, userError } from '@/lib/user-error';
+import { asyncForEach } from '@/lib/helpers/javascriptHelpers';
+import { getCurrentUser } from '@/components/auth';
+import { UserErrorType, getErrorMessage, isUserErrorResponse, userError } from '@/lib/user-error';
 
 import { getAllAvailableEngines } from '@/lib/data/engines';
 
 import {
   deployProcess as _deployProcess,
-  getDeployments as fetchDeployments,
+  getDeployment,
   changeDeploymentActivation as _changeDeploymentActivation,
 } from '@/lib/engines/deployment';
 import {
@@ -18,7 +18,7 @@ import {
 } from '@/lib/engines/instances';
 import { Engine } from '../engines/types';
 import { getProcessDeployments } from '../data/deployment';
-import { addInstance } from '../data/instance';
+import { addInstance, getInstance, updateInstance } from '../data/instance';
 
 export async function startInstance(
   spaceId: string,
@@ -82,21 +82,32 @@ export async function updateVariables(
   variables: Record<string, any>,
 ) {
   try {
-    // find the engine the instance is running on
-    const availableEngines = await getAllAvailableEngines(spaceId);
-    if (isUserErrorResponse(availableEngines)) return availableEngines;
-    const engines = await asyncFilter(availableEngines, async (engine) => {
-      const deployments = await fetchDeployments([engine]);
+    const instance = await getInstance(spaceId, instanceId);
+    if (isUserErrorResponse(instance)) return instance;
+    if (!instance) {
+      return userError('Could not find the instance to change.', UserErrorType.NotFoundError);
+    }
 
-      return deployments.some((deployment) =>
-        deployment.instances.some((i) => i.processInstanceId === instanceId),
-      );
-    });
+    // find the engine the instance is running on
+    let availableEngines = await getAllAvailableEngines(spaceId);
+    if (isUserErrorResponse(availableEngines)) return availableEngines;
+    availableEngines = availableEngines.filter((engine) => instance.engineIds.includes(engine.id));
 
     await asyncForEach(
-      engines,
+      availableEngines,
       async (engine) => await updateVariablesOnMachine(definitionId, instanceId, engine, variables),
     );
+
+    // TODO: try to get the engine to only return when the update has actually been applied to the
+    // state instead of waiting an arbitrary amount of time
+    await new Promise((res) => setTimeout(res, 1000));
+
+    // TODO: handle that we need to merge data if the instance exists on multiple machines
+    const newData = await getDeployment(availableEngines[0], definitionId);
+
+    const newInstanceData = newData.instances.find((i) => i.processInstanceId === instanceId);
+
+    await updateInstance(spaceId, instanceId, { state: newInstanceData });
   } catch (err) {
     const message = getErrorMessage(err);
     return userError(message);
@@ -109,27 +120,25 @@ export async function getFile(
   instanceId: string,
   fileName: string,
 ) {
-  const { ability } = await getCurrentEnvironment(spaceId);
+  const instance = await getInstance(spaceId, instanceId);
+  if (isUserErrorResponse(instance)) return instance;
+  if (!instance) {
+    return userError('Unknown Instance', UserErrorType.NotFoundError);
+  }
 
   try {
     // find the engine the instance is running on
-    const availableEngines = await getAllAvailableEngines(spaceId);
+    let availableEngines = await getAllAvailableEngines(spaceId);
     if (isUserErrorResponse(availableEngines)) return availableEngines;
-    let engines = await asyncFilter(availableEngines, async (engine) => {
-      const deployments = await fetchDeployments([engine]);
+    availableEngines = availableEngines.filter((engine) => instance.engineIds.includes(engine.id));
 
-      return deployments.some((deployment) =>
-        deployment.instances.some((i) => i.processInstanceId === instanceId),
-      );
-    });
-
-    engines = ability ? ability.filter('view', 'Machine', engines) : engines;
-
-    if (!engines.length) {
-      throw new UserFacingError('Failed to find the engine the instance is running on!');
+    if (!availableEngines.length) {
+      return userError('Failed to find the engine the instance is running on!');
     }
 
-    return await getFileFromMachine(definitionId, instanceId, fileName, engines[0]);
+    const file = await getFileFromMachine(definitionId, instanceId, fileName, availableEngines[0]);
+
+    return file;
   } catch (err) {
     const message = getErrorMessage(err);
     return userError(message);

--- a/src/management-system-v2/lib/executions/instance-server-actions.ts
+++ b/src/management-system-v2/lib/executions/instance-server-actions.ts
@@ -1,7 +1,7 @@
 'use server';
 
-import { asyncForEach } from '@/lib/helpers/javascriptHelpers';
-import { getCurrentUser } from '@/components/auth';
+import { asyncForEach, asyncMap } from '@/lib/helpers/javascriptHelpers';
+import { getCurrentEnvironment, getCurrentUser } from '@/components/auth';
 import { UserErrorType, getErrorMessage, isUserErrorResponse, userError } from '@/lib/user-error';
 
 import { getAllAvailableEngines } from '@/lib/data/engines';
@@ -10,15 +10,39 @@ import {
   deployProcess as _deployProcess,
   getDeployment,
   changeDeploymentActivation as _changeDeploymentActivation,
+  InstanceInfo,
 } from '@/lib/engines/deployment';
 import {
   getFileFromMachine,
   startInstanceOnMachine,
+  pauseInstanceOnMachine,
+  resumeInstanceOnMachine,
+  stopInstanceOnMachine,
   updateVariablesOnMachine,
 } from '@/lib/engines/instances';
 import { Engine } from '../engines/types';
 import { getProcessDeployments } from '../data/deployment';
-import { addInstance, getInstance, updateInstance } from '../data/instance';
+import { addInstance, getInstance, updateInstance } from '@/lib/data/instance';
+import { getProcessBPMN, getProcessHtmlFormHTML } from '@/lib/data/processes';
+import { getStartFormFileNameMapping } from '@proceed/bpmn-helper';
+import { truthyFilter } from '@/lib/typescript-utils';
+
+export async function getProcessStartForm(
+  spaceId: string,
+  definitionId: string,
+  versionId: string,
+) {
+  try {
+    const bpmn = await getProcessBPMN(definitionId, spaceId, versionId);
+    const [startForm] = Object.values(await getStartFormFileNameMapping(bpmn)).filter(truthyFilter);
+    if (!startForm) return '';
+
+    return getProcessHtmlFormHTML(definitionId, startForm, spaceId);
+  } catch (e) {
+    const message = getErrorMessage(e);
+    return userError(message);
+  }
+}
 
 export async function startInstance(
   spaceId: string,
@@ -143,4 +167,115 @@ export async function getFile(
     const message = getErrorMessage(err);
     return userError(message);
   }
+}
+
+const activeStates = ['PAUSED', 'RUNNING', 'READY', 'DEPLOYMENT-WAITING', 'WAITING'];
+async function changeInstanceState(
+  spaceId: string,
+  definitionId: string,
+  instanceId: string,
+  stateValidator: (state: InstanceInfo['instanceState']) => boolean,
+  stateChangeFunction: typeof resumeInstanceOnMachine,
+) {
+  const { ability } = await getCurrentEnvironment(spaceId);
+
+  if (!ability.can('update', 'Execution')) {
+    return userError('Invalid Permissions', UserErrorType.PermissionError);
+  }
+
+  const instance = await getInstance(spaceId, instanceId);
+
+  if (isUserErrorResponse(instance)) return instance;
+  if (!instance) return userError('Unknown instance!', UserErrorType.NotFoundError);
+
+  if (!instance.engineIds.length) return userError('The instance is not being executed anymore.');
+
+  try {
+    // TODO: how do we handle this correctly if some engines are reachable but others aren't?
+    const engines = await getAllAvailableEngines(spaceId);
+    if (isUserErrorResponse(engines)) return engines;
+    const engineMap = engines.reduce(
+      (acc, curr) => {
+        acc[curr.id] = curr;
+        return acc;
+      },
+      {} as Record<string, Engine>,
+    );
+
+    let instanceMachinesToChange = await asyncMap(instance.engineIds, async (id) => {
+      const machine = engineMap[id];
+      if (!machine) return false;
+
+      try {
+        const deployment = await getDeployment(machine, definitionId);
+
+        const instance = deployment.instances.find(
+          (instance) => instance.processInstanceId === instanceId,
+        );
+
+        if (!instance) return 'Instance not found';
+
+        const hasState = !stateValidator(instance.instanceState);
+
+        if (hasState) return false;
+
+        return machine;
+      } catch (err) {
+        return false;
+      }
+    });
+    instanceMachinesToChange = instanceMachinesToChange.filter((res) => !!res);
+
+    if (instanceMachinesToChange.some((res) => typeof res === 'string')) {
+      return userError('Instance information was lost from one of the executing engines.');
+    }
+
+    await asyncForEach(instanceMachinesToChange as Engine[], async (machine) => {
+      await stateChangeFunction(definitionId, instanceId, machine);
+
+      // TODO: handle this better (the engine should only return after the state change has
+      // completed
+      await new Promise((res) => setTimeout(res, 1000));
+      // TODO: actually handle that the instance might exist on multiple engines
+      const newDeploymentData = await getDeployment(machine, definitionId);
+      const newInstanceData = newDeploymentData.instances.find(
+        (instance) => instance.processInstanceId === instanceId,
+      );
+      await updateInstance(spaceId, instanceId, { state: newInstanceData });
+    });
+  } catch (e) {
+    const message = getErrorMessage(e);
+    return userError(message);
+  }
+}
+
+export async function resumeInstance(spaceId: string, definitionId: string, instanceId: string) {
+  return await changeInstanceState(
+    spaceId,
+    definitionId,
+    instanceId,
+    (tokenStates) => tokenStates.some((tokenState) => tokenState === 'PAUSED'),
+    resumeInstanceOnMachine,
+  );
+}
+
+export async function pauseInstance(spaceId: string, definitionId: string, instanceId: string) {
+  return await changeInstanceState(
+    spaceId,
+    definitionId,
+    instanceId,
+    (tokenStates) =>
+      tokenStates.some((state) => activeStates.includes(state) && state !== 'PAUSED'),
+    pauseInstanceOnMachine,
+  );
+}
+
+export async function stopInstance(spaceId: string, definitionId: string, instanceId: string) {
+  return await changeInstanceState(
+    spaceId,
+    definitionId,
+    instanceId,
+    (tokenStates) => tokenStates.some((state) => activeStates.includes(state)),
+    stopInstanceOnMachine,
+  );
 }

--- a/src/management-system-v2/lib/executions/instance-server-actions.ts
+++ b/src/management-system-v2/lib/executions/instance-server-actions.ts
@@ -18,6 +18,7 @@ import {
 } from '@/lib/engines/instances';
 import { Engine } from '../engines/types';
 import { getProcessDeployments } from '../data/deployment';
+import { addInstance } from '../data/instance';
 
 export async function startInstance(
   spaceId: string,
@@ -52,14 +53,26 @@ export async function startInstance(
     const engine = engineMap[deployment.engineId];
 
     if (engine) {
-      return await startInstanceOnMachine(definitionId, versionId, engine, variables, {
+      const result = await startInstanceOnMachine(definitionId, versionId, engine, variables, {
         processInitiator: userId,
         spaceIdOfProcessInitiator: spaceId,
       });
+
+      if (isUserErrorResponse(result)) continue;
+
+      await addInstance(spaceId, {
+        id: result.processInstanceId,
+        deploymentId: deployment.id,
+        engineIds: [engine.id],
+        initiatorId: userId,
+        state: result,
+      });
+
+      return result.processInstanceId;
     }
   }
 
-  return userError('Failed to start the instance.');
+  return userError('Failed to start an instance.');
 }
 
 export async function updateVariables(

--- a/src/management-system-v2/lib/executions/instance-server-actions.ts
+++ b/src/management-system-v2/lib/executions/instance-server-actions.ts
@@ -1,7 +1,7 @@
 'use server';
 
 import { asyncFilter, asyncForEach } from '@/lib/helpers/javascriptHelpers';
-import { getCurrentEnvironment } from '@/components/auth';
+import { getCurrentEnvironment, getCurrentUser } from '@/components/auth';
 import { UserFacingError, getErrorMessage, isUserErrorResponse, userError } from '@/lib/user-error';
 
 import { getAllAvailableEngines } from '@/lib/data/engines';
@@ -11,7 +11,56 @@ import {
   getDeployments as fetchDeployments,
   changeDeploymentActivation as _changeDeploymentActivation,
 } from '@/lib/engines/deployment';
-import { getFileFromMachine, updateVariablesOnMachine } from '@/lib/engines/instances';
+import {
+  getFileFromMachine,
+  startInstanceOnMachine,
+  updateVariablesOnMachine,
+} from '@/lib/engines/instances';
+import { Engine } from '../engines/types';
+import { getProcessDeployments } from '../data/deployment';
+
+export async function startInstance(
+  spaceId: string,
+  definitionId: string,
+  versionId: string,
+  variables: { [key: string]: any } = {},
+) {
+  const engines = await getAllAvailableEngines(spaceId);
+  if (isUserErrorResponse(engines)) return engines;
+
+  const engineMap = engines.reduce(
+    (acc, curr) => {
+      acc[curr.id] = curr;
+      return acc;
+    },
+    {} as Record<string, Engine>,
+  );
+
+  const deployments = await getProcessDeployments(spaceId, definitionId);
+  if (isUserErrorResponse(deployments)) return deployments;
+
+  const { userId } = await getCurrentUser();
+
+  const versionDeployments = deployments.filter((d) => {
+    return d.versionId === versionId;
+  });
+
+  // TODO: automatically deploy the version if possible
+  if (!versionDeployments.length) return userError('This process version is not deployed.');
+
+  for (const deployment of deployments) {
+    const engine = engineMap[deployment.engineId];
+
+    if (engine) {
+      return await startInstanceOnMachine(definitionId, versionId, engine, variables, {
+        processInitiator: userId,
+        spaceIdOfProcessInitiator: spaceId,
+      });
+    }
+  }
+
+  return userError('Failed to start the instance.');
+}
 
 export async function updateVariables(
   spaceId: string,

--- a/src/management-system-v2/lib/instance-schema.ts
+++ b/src/management-system-v2/lib/instance-schema.ts
@@ -1,0 +1,14 @@
+import { z } from 'zod';
+import { InstanceInfo } from './engines/deployment';
+
+export const InstanceInputSchema = z.object({
+  id: z.string(),
+  deploymentId: z.string(),
+  initiatorId: z.string().nullish().default(null),
+  engineIds: z.string().array(),
+  state: z.object({}).passthrough(),
+});
+
+export type InstanceInput = Omit<z.input<typeof InstanceInputSchema>, 'state'> & {
+  state: InstanceInfo;
+};

--- a/src/management-system-v2/lib/tasks/server-actions.ts
+++ b/src/management-system-v2/lib/tasks/server-actions.ts
@@ -40,6 +40,7 @@ import {
   setTasklistEntryMilestoneValuesOnMachine,
   setTasklistEntryVariableValuesOnMachine,
 } from '@/lib/engines/tasklist';
+import { getInstance } from '@/lib/data/instance';
 
 export async function getAvailableTaskListEntries(spaceId: string, engines: Engine[]) {
   try {
@@ -302,16 +303,12 @@ export async function getTasklistEntryHTML(
     let globalVars: Record<string, any> = {};
 
     if (storedUserTask.instanceID) {
-      if (!engine) throw new Error('Cannot retrieve the instance initiator information.');
-      const [definitionId] = storedUserTask.instanceID.split('-_');
-      const deployment = await fetchDeployment(engine, definitionId);
-      const instance = deployment.instances.find(
-        (i) => i.processInstanceId === storedUserTask.instanceID,
-      );
-      if (!instance) throw new Error('Unknown instance');
-      if (!instance.processInitiator) throw new Error('Missing initiator information');
+      const instance = await getInstance(spaceId, storedUserTask.instanceID);
+      if (isUserErrorResponse(instance)) return instance;
+      if (!instance) throw new Error('Cannot retrieve the instance initiator information.');
+      if (!instance.initiatorId) throw new Error('Missing initiator information');
 
-      globalVars = await getGlobalVariablesForHTML(spaceId, instance.processInitiator, html);
+      globalVars = await getGlobalVariablesForHTML(spaceId, instance.initiatorId, html);
     }
 
     variableChanges = { ...variableChanges, ...globalVars };

--- a/src/management-system-v2/prisma/migrations/20260521112231_persistent_deployment_data/migration.sql
+++ b/src/management-system-v2/prisma/migrations/20260521112231_persistent_deployment_data/migration.sql
@@ -1,0 +1,17 @@
+-- CreateTable
+CREATE TABLE "process_deployment" (
+    "id" TEXT NOT NULL,
+    "versionId" TEXT NOT NULL,
+    "deployerId" TEXT NOT NULL,
+    "deployTime" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "removeTime" TIMESTAMP(3),
+    "engineId" TEXT NOT NULL,
+
+    CONSTRAINT "process_deployment_pkey" PRIMARY KEY ("id")
+);
+
+-- AddForeignKey
+ALTER TABLE "process_deployment" ADD CONSTRAINT "process_deployment_versionId_fkey" FOREIGN KEY ("versionId") REFERENCES "version"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "process_deployment" ADD CONSTRAINT "process_deployment_deployerId_fkey" FOREIGN KEY ("deployerId") REFERENCES "user"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/src/management-system-v2/prisma/migrations/20260521120944_persistent_instance_data/migration.sql
+++ b/src/management-system-v2/prisma/migrations/20260521120944_persistent_instance_data/migration.sql
@@ -1,0 +1,16 @@
+-- CreateTable
+CREATE TABLE "process_instance" (
+    "id" TEXT NOT NULL,
+    "deploymentId" TEXT NOT NULL,
+    "initiatorId" TEXT,
+    "engineIds" TEXT[],
+    "state" JSONB NOT NULL,
+
+    CONSTRAINT "process_instance_pkey" PRIMARY KEY ("id")
+);
+
+-- AddForeignKey
+ALTER TABLE "process_instance" ADD CONSTRAINT "process_instance_deploymentId_fkey" FOREIGN KEY ("deploymentId") REFERENCES "process_deployment"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "process_instance" ADD CONSTRAINT "process_instance_initiatorId_fkey" FOREIGN KEY ("initiatorId") REFERENCES "user"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/src/management-system-v2/prisma/schema.prisma
+++ b/src/management-system-v2/prisma/schema.prisma
@@ -49,6 +49,7 @@ model User {
   emailVerificationTokens EmailVerificationToken[] @relation("verificationToken")
   mcpPairingCodes         McpPairingCode[]         @relation("pairingCode")
   Config                  Config[]
+  deployments             ProcessDeployment[]
 
   @@map("user")
 }
@@ -210,6 +211,7 @@ model Version {
   createdOn                 DateTime                   @unique @updatedAt
   bpmnFilePath              String
   artifactVersionReferences ArtifactVersionReference[]
+  deployments               ProcessDeployment[]
 
   @@map("version")
 }
@@ -431,4 +433,20 @@ model UserOrganigram {
   backOfficeRole Role?       @relation("backOfficeRole", fields: [backOfficeRoleId], references: [id], onDelete: SetNull)
 
   @@map("user_organigram")
+}
+
+model ProcessDeployment {
+  id            String     @id @default(uuid())
+  versionId     String
+  version       Version    @relation(fields: [versionId], references: [id], onDelete: Cascade)
+  deployerId    String
+  deployer      User?      @relation(fields: [deployerId], references: [id], onDelete: SetNull)
+  deployTime    DateTime   @default(now())
+  removeTime    DateTime?
+
+  // This is not the "Engine" which we store here in the DB but the actual engine the process is deployed on
+  // an "Engine" can represent multiple engines in case it is an "MQTT-Engine"
+  engineId      String
+
+  @@map("process_deployment")
 }

--- a/src/management-system-v2/prisma/schema.prisma
+++ b/src/management-system-v2/prisma/schema.prisma
@@ -50,6 +50,7 @@ model User {
   mcpPairingCodes         McpPairingCode[]         @relation("pairingCode")
   Config                  Config[]
   deployments             ProcessDeployment[]
+  instances               ProcessInstance[]
 
   @@map("user")
 }
@@ -448,5 +449,21 @@ model ProcessDeployment {
   // an "Engine" can represent multiple engines in case it is an "MQTT-Engine"
   engineId      String
 
+  instances     ProcessInstance[]
+
   @@map("process_deployment")
+}
+
+model ProcessInstance {
+  id                  String            @id
+  deploymentId        String
+  deployment          ProcessDeployment @relation(fields: [deploymentId], references: [id], onDelete: Cascade)
+  initiatorId         String?
+  initiator           User?             @relation(fields: [initiatorId], references: [id], onDelete: SetNull)
+  // These are not the "Engines" which we store here in the DB but the actual engines the process is running on
+  // an "Engine" can represent multiple engines in case it is an "MQTT-Engine"
+  engineIds           String[]
+  state               Json
+
+  @@map("process_instance")
 }

--- a/src/management-system-v2/tools/startProcess.ts
+++ b/src/management-system-v2/tools/startProcess.ts
@@ -90,7 +90,7 @@ export default async function startProcess({
 
     if (isUserErrorResponse(deployment)) return deployment.error.message;
 
-    const instanceId = await startInstanceOnMachine(
+    const instance = await startInstanceOnMachine(
       processId,
       process.version.id,
       engine,
@@ -102,11 +102,11 @@ export default async function startProcess({
       },
     );
 
-    if (isUserErrorResponse(instanceId)) {
-      return instanceId.error.message;
+    if (isUserErrorResponse(instance)) {
+      return instance.error.message;
     }
 
-    return `Started the process with instance id ${instanceId}. Please check the PROCEED website to inspect the execution state.`;
+    return `Started the process with instance id ${instance.processInstanceId}. Please check the PROCEED website to inspect the execution state.`;
   } catch (err) {
     if (err instanceof Error) return err.message;
     else return 'Error: Something went wrong';


### PR DESCRIPTION
## Summary

First parts of our persistent execution data implementation. Added db tables to store information about process deployments and instances and update the data on user input.

## Details

Engine
- the endpoint for starting instances will now return the initial state of the started instance instead of only the id of the instance

Management System
- added a db table for process deployments that stores information about the deployed version, the user that deployed the process, the engine the process was deployed to and potentially instances that were started from this deployment
- added a db table for process instances that stores information about the user that started the instance, the engines the instance is running on, and the deployment the instance was started from
- using the new persistent information to reduce the need for fetching when trying to manage a deployment or instance
- moved some of the instance management logic from the frontend to the backend by using the new persistently stored data instead of the in memory data we were using before
- TODO: continuously refetch the deployment and instance data to keep the state in the DB fresh without user interaction