### PR TITLE
MS: Improved Instance Information

### DIFF
--- a/src/management-system-v2/app/(dashboard)/[environmentId]/(automation)/executions/[processId]/element-status.tsx
+++ b/src/management-system-v2/app/(dashboard)/[environmentId]/(automation)/executions/[processId]/element-status.tsx
@@ -1,7 +1,7 @@
 import { ReactNode } from 'react';
 import { Alert, Checkbox, Image, Progress, ProgressProps, Space, Typography } from 'antd';
 import { ClockCircleFilled } from '@ant-design/icons';
-import { getPlanDelays, getTimeInfo, statusToType } from './instance-helpers';
+import { getPlanDelays, statusToType } from './instance-helpers';
 import { getMetaDataFromElement } from '@proceed/bpmn-helper';
 import { DisplayTable } from './instance-info-panel';
 import endpointBuilder from '@/lib/engines/endpoints/endpoint-builder';
@@ -153,15 +153,21 @@ export function ElementStatus({
   // Documentation
   statusEntries.push(['Documentation:', element.businessObject?.documentation?.[0]?.text]);
 
-  // Activity time calculation
-  const { start, end, duration } = getTimeInfo({
-    element: element,
-    instance: instance,
-    logInfo,
-    token,
-  });
+  let timing: NonNullable<ExtendedInstanceInfo['tokens'][number]['timing']> = {
+    actual: { start: undefined, end: undefined, duration: undefined },
+    plan: { start: undefined, end: undefined, duration: undefined },
+    delays: { start: undefined, end: undefined, duration: undefined },
+  };
 
-  const { plan } = getPlanDelays({ elementMetaData: metaData, start, end, duration });
+  if (logInfo) {
+    if (logInfo.timing) timing = logInfo.timing;
+  } else if (token) {
+    if (token.timing) timing = token.timing;
+  } else if (instance && isRootElement) {
+    if (instance.timing) timing = instance.timing;
+  }
+
+  const { plan } = getPlanDelays({ elementMetaData: metaData, ...timing.actual });
 
   // Real Costs
   // TODO: Set real costs
@@ -193,19 +199,6 @@ export function ElementStatus({
     }
 
     statusEntries.push(['Real Costs:', costs]);
-  }
-
-  let timing: NonNullable<ExtendedInstanceInfo['tokens'][number]['timing']> = {
-    actual: { start: undefined, end: undefined, duration: undefined },
-    plan: { start: undefined, end: undefined, duration: undefined },
-    delays: { start: undefined, end: undefined, duration: undefined },
-  };
-  if (token) {
-    if (token.timing) timing = token.timing;
-  } else if (logInfo) {
-    if (logInfo.timing) timing = logInfo.timing;
-  } else if (instance) {
-    if (instance.timing) timing = instance.timing;
   }
 
   // Activity time

--- a/src/management-system-v2/app/(dashboard)/[environmentId]/(automation)/executions/[processId]/element-status.tsx
+++ b/src/management-system-v2/app/(dashboard)/[environmentId]/(automation)/executions/[processId]/element-status.tsx
@@ -6,8 +6,8 @@ import { getMetaDataFromElement } from '@proceed/bpmn-helper';
 import { DisplayTable } from './instance-info-panel';
 import endpointBuilder from '@/lib/engines/endpoints/endpoint-builder';
 import { generateDateString, generateDurationString, generateNumberString } from '@/lib/utils';
-import { InstanceInfo } from '@/lib/engines/deployment';
 import type { ElementLike } from 'diagram-js/lib/core/Types';
+import { ExtendedInstanceInfo } from '@/lib/data/instance';
 
 export function ElementStatus({
   processId,
@@ -16,7 +16,7 @@ export function ElementStatus({
 }: {
   processId: string;
   element: ElementLike;
-  instance?: InstanceInfo;
+  instance?: ExtendedInstanceInfo;
 }) {
   const statusEntries: ReactNode[][] = [];
 

--- a/src/management-system-v2/app/(dashboard)/[environmentId]/(automation)/executions/[processId]/element-status.tsx
+++ b/src/management-system-v2/app/(dashboard)/[environmentId]/(automation)/executions/[processId]/element-status.tsx
@@ -1,7 +1,7 @@
 import { ReactNode } from 'react';
 import { Alert, Checkbox, Image, Progress, ProgressProps, Space, Typography } from 'antd';
 import { ClockCircleFilled } from '@ant-design/icons';
-import { getPlannedTimeInfo, statusToType } from './instance-helpers';
+import { getPlannedTimeInfo, getTiming, statusToType } from './instance-helpers';
 import { getMetaDataFromElement } from '@proceed/bpmn-helper';
 import { DisplayTable } from './instance-info-panel';
 import endpointBuilder from '@/lib/engines/endpoints/endpoint-builder';
@@ -153,22 +153,6 @@ export function ElementStatus({
   // Documentation
   statusEntries.push(['Documentation:', element.businessObject?.documentation?.[0]?.text]);
 
-  let timing: NonNullable<ExtendedInstanceInfo['tokens'][number]['timing']> = {
-    actual: { start: undefined, end: undefined, duration: undefined },
-    plan: { start: undefined, end: undefined, duration: undefined },
-    delays: { start: undefined, end: undefined, duration: undefined },
-  };
-
-  if (logInfo) {
-    if (logInfo.timing) timing = logInfo.timing;
-  } else if (token) {
-    if (token.timing) timing = token.timing;
-  } else if (instance && isRootElement) {
-    if (instance.timing) timing = instance.timing;
-  } else {
-    timing.plan = getPlannedTimeInfo(metaData);
-  }
-
   // Real Costs
   // TODO: Set real costs
   if (instance) {
@@ -200,6 +184,14 @@ export function ElementStatus({
 
     statusEntries.push(['Real Costs:', costs]);
   }
+
+  const timing = getTiming({
+    isRootElement,
+    metaData,
+    token,
+    logInfo,
+    instance,
+  });
 
   // Activity time
   statusEntries.push([

--- a/src/management-system-v2/app/(dashboard)/[environmentId]/(automation)/executions/[processId]/element-status.tsx
+++ b/src/management-system-v2/app/(dashboard)/[environmentId]/(automation)/executions/[processId]/element-status.tsx
@@ -1,7 +1,7 @@
 import { ReactNode } from 'react';
 import { Alert, Checkbox, Image, Progress, ProgressProps, Space, Typography } from 'antd';
 import { ClockCircleFilled } from '@ant-design/icons';
-import { getPlannedTimeInfo, getTiming, statusToType } from './instance-helpers';
+import { getTiming, statusToType } from './instance-helpers';
 import { getMetaDataFromElement } from '@proceed/bpmn-helper';
 import { DisplayTable } from './instance-info-panel';
 import endpointBuilder from '@/lib/engines/endpoints/endpoint-builder';

--- a/src/management-system-v2/app/(dashboard)/[environmentId]/(automation)/executions/[processId]/element-status.tsx
+++ b/src/management-system-v2/app/(dashboard)/[environmentId]/(automation)/executions/[processId]/element-status.tsx
@@ -1,7 +1,7 @@
 import { ReactNode } from 'react';
 import { Alert, Checkbox, Image, Progress, ProgressProps, Space, Typography } from 'antd';
 import { ClockCircleFilled } from '@ant-design/icons';
-import { getPlanDelays, statusToType } from './instance-helpers';
+import { getPlannedTimeInfo, statusToType } from './instance-helpers';
 import { getMetaDataFromElement } from '@proceed/bpmn-helper';
 import { DisplayTable } from './instance-info-panel';
 import endpointBuilder from '@/lib/engines/endpoints/endpoint-builder';
@@ -165,9 +165,9 @@ export function ElementStatus({
     if (token.timing) timing = token.timing;
   } else if (instance && isRootElement) {
     if (instance.timing) timing = instance.timing;
+  } else {
+    timing.plan = getPlannedTimeInfo(metaData);
   }
-
-  const { plan } = getPlanDelays({ elementMetaData: metaData, ...timing.actual });
 
   // Real Costs
   // TODO: Set real costs
@@ -211,7 +211,7 @@ export function ElementStatus({
     <Space key="planned-start">
       <ClockCircleFilled style={{ fontSize: '1rem' }} />
       <Typography.Text strong>Planned Start:</Typography.Text>
-      <Typography.Text>{generateDateString(plan.start, true) || ''}</Typography.Text>
+      <Typography.Text>{generateDateString(timing.plan.start, true) || ''}</Typography.Text>
     </Space>,
     <Space key="start-delay">
       <ClockCircleFilled style={{ fontSize: '1rem' }} />
@@ -233,7 +233,7 @@ export function ElementStatus({
     <Space key="duration-planned">
       <ClockCircleFilled style={{ fontSize: '1rem' }} />
       <Typography.Text strong>Planned Duration:</Typography.Text>
-      <Typography.Text>{generateDurationString(plan.duration)}</Typography.Text>
+      <Typography.Text>{generateDurationString(timing.plan.duration)}</Typography.Text>
     </Space>,
     <Space key="duration-delay">
       <ClockCircleFilled style={{ fontSize: '1rem' }} />
@@ -255,7 +255,7 @@ export function ElementStatus({
     <Space key="end-planned">
       <ClockCircleFilled style={{ fontSize: '1rem' }} />
       <Typography.Text strong>Planned End:</Typography.Text>
-      <Typography.Text>{generateDateString(plan.end, true) || ''}</Typography.Text>
+      <Typography.Text>{generateDateString(timing.plan.end, true) || ''}</Typography.Text>
     </Space>,
     <Space key="end-delay">
       <ClockCircleFilled style={{ fontSize: '1rem' }} />

--- a/src/management-system-v2/app/(dashboard)/[environmentId]/(automation)/executions/[processId]/element-status.tsx
+++ b/src/management-system-v2/app/(dashboard)/[environmentId]/(automation)/executions/[processId]/element-status.tsx
@@ -150,16 +150,6 @@ export function ElementStatus({
       }),
   ]);
 
-  // Real Costs
-  // TODO: Set real costs
-  if (instance && !isRootElement) {
-    let costs: string | undefined = undefined;
-    if (token) costs = token.costsRealSetByOwner;
-    else if (logInfo) costs = logInfo.costsRealSetByOwner;
-
-    statusEntries.push(['Real Costs:', costs]);
-  }
-
   // Documentation
   statusEntries.push(['Documentation:', element.businessObject?.documentation?.[0]?.text]);
 
@@ -171,14 +161,59 @@ export function ElementStatus({
     token,
   });
 
-  const { delays, plan } = getPlanDelays({ elementMetaData: metaData, start, end, duration });
+  const { plan } = getPlanDelays({ elementMetaData: metaData, start, end, duration });
+
+  // Real Costs
+  // TODO: Set real costs
+  if (instance) {
+    let costs: string | undefined = undefined;
+    if (token)
+      costs =
+        token.costsRealSetByOwner &&
+        generateNumberString(+token.costsRealSetByOwner.value, {
+          style: 'currency',
+          currency: token.costsRealSetByOwner.unit,
+        });
+    else if (logInfo)
+      costs =
+        logInfo.costsRealSetByOwner &&
+        generateNumberString(+logInfo.costsRealSetByOwner.value, {
+          style: 'currency',
+          currency: logInfo.costsRealSetByOwner.unit,
+        });
+    else {
+      costs = instance.executionCosts
+        ?.map((c) =>
+          generateNumberString(+c.value, {
+            style: 'currency',
+            currency: c.unit,
+          }),
+        )
+        .join(' + ');
+    }
+
+    statusEntries.push(['Real Costs:', costs]);
+  }
+
+  let timing: NonNullable<ExtendedInstanceInfo['tokens'][number]['timing']> = {
+    actual: { start: undefined, end: undefined, duration: undefined },
+    plan: { start: undefined, end: undefined, duration: undefined },
+    delays: { start: undefined, end: undefined, duration: undefined },
+  };
+  if (token) {
+    if (token.timing) timing = token.timing;
+  } else if (logInfo) {
+    if (logInfo.timing) timing = logInfo.timing;
+  } else if (instance) {
+    if (instance.timing) timing = instance.timing;
+  }
 
   // Activity time
   statusEntries.push([
     <Space key="started">
       <ClockCircleFilled style={{ fontSize: '1rem' }} />
       <Typography.Text strong>Started:</Typography.Text>
-      <Typography.Text>{generateDateString(start, true)}</Typography.Text>
+      <Typography.Text>{generateDateString(timing.actual.start, true)}</Typography.Text>
     </Space>,
     <Space key="planned-start">
       <ClockCircleFilled style={{ fontSize: '1rem' }} />
@@ -188,8 +223,10 @@ export function ElementStatus({
     <Space key="start-delay">
       <ClockCircleFilled style={{ fontSize: '1rem' }} />
       <Typography.Text strong>Delay:</Typography.Text>
-      <Typography.Text type={delays.start && delays.start >= 1000 ? 'danger' : undefined}>
-        {generateDurationString(delays.start)}
+      <Typography.Text
+        type={timing.delays.start && timing.delays.start >= 1000 ? 'danger' : undefined}
+      >
+        {generateDurationString(timing.delays.start)}
       </Typography.Text>
     </Space>,
   ]);
@@ -198,7 +235,7 @@ export function ElementStatus({
     <Space key="duration">
       <ClockCircleFilled style={{ fontSize: '1rem' }} />
       <Typography.Text strong>Duration:</Typography.Text>
-      <Typography.Text>{generateDurationString(duration)}</Typography.Text>
+      <Typography.Text>{generateDurationString(timing.actual.duration)}</Typography.Text>
     </Space>,
     <Space key="duration-planned">
       <ClockCircleFilled style={{ fontSize: '1rem' }} />
@@ -208,8 +245,10 @@ export function ElementStatus({
     <Space key="duration-delay">
       <ClockCircleFilled style={{ fontSize: '1rem' }} />
       <Typography.Text strong>Delay:</Typography.Text>
-      <Typography.Text type={delays.duration && delays.duration >= 1000 ? 'danger' : undefined}>
-        {generateDurationString(delays.duration)}
+      <Typography.Text
+        type={timing.delays.duration && timing.delays.duration >= 1000 ? 'danger' : undefined}
+      >
+        {generateDurationString(timing.delays.duration)}
       </Typography.Text>
     </Space>,
   ]);
@@ -218,7 +257,7 @@ export function ElementStatus({
     <Space key="end">
       <ClockCircleFilled style={{ fontSize: '1rem' }} />
       <Typography.Text strong>Ended:</Typography.Text>
-      <Typography.Text>{generateDateString(end, true)}</Typography.Text>
+      <Typography.Text>{generateDateString(timing.actual.end, true)}</Typography.Text>
     </Space>,
     <Space key="end-planned">
       <ClockCircleFilled style={{ fontSize: '1rem' }} />
@@ -228,8 +267,8 @@ export function ElementStatus({
     <Space key="end-delay">
       <ClockCircleFilled style={{ fontSize: '1rem' }} />
       <Typography.Text strong>Delay:</Typography.Text>
-      <Typography.Text type={delays.end && delays.end >= 1000 ? 'danger' : undefined}>
-        {generateDurationString(delays.end)}
+      <Typography.Text type={timing.delays.end && timing.delays.end >= 1000 ? 'danger' : undefined}>
+        {generateDurationString(timing.delays.end)}
       </Typography.Text>
     </Space>,
   ]);

--- a/src/management-system-v2/app/(dashboard)/[environmentId]/(automation)/executions/[processId]/instance-coloring.ts
+++ b/src/management-system-v2/app/(dashboard)/[environmentId]/(automation)/executions/[processId]/instance-coloring.ts
@@ -1,7 +1,7 @@
 import { BPMNCanvasRef } from '@/components/bpmn-canvas';
-import { InstanceInfo } from '@/lib/engines/deployment';
 import { getMetaDataFromElement } from '@proceed/bpmn-helper/src/getters';
 import { getPlanDelays, getTimeInfo } from './instance-helpers';
+import { ExtendedInstanceInfo } from '@/lib/data/instance';
 
 export const colorOptions = [
   {
@@ -69,7 +69,7 @@ export function progressToColor(
 
 export function flowElementsStyling(
   bpmnViewer: BPMNCanvasRef,
-  instance: InstanceInfo,
+  instance: ExtendedInstanceInfo,
   colors: ColorOptions,
 ) {
   const instanceFlowElements = bpmnViewer.getAllElements();

--- a/src/management-system-v2/app/(dashboard)/[environmentId]/(automation)/executions/[processId]/instance-coloring.ts
+++ b/src/management-system-v2/app/(dashboard)/[environmentId]/(automation)/executions/[processId]/instance-coloring.ts
@@ -1,6 +1,6 @@
 import { BPMNCanvasRef } from '@/components/bpmn-canvas';
 import { getMetaDataFromElement } from '@proceed/bpmn-helper/src/getters';
-import { getPlanDelays, getTimeInfo, getTiming } from './instance-helpers';
+import { getTimeInfo, getTiming } from './instance-helpers';
 import { ExtendedInstanceInfo } from '@/lib/data/instance';
 
 export const colorOptions = [

--- a/src/management-system-v2/app/(dashboard)/[environmentId]/(automation)/executions/[processId]/instance-coloring.ts
+++ b/src/management-system-v2/app/(dashboard)/[environmentId]/(automation)/executions/[processId]/instance-coloring.ts
@@ -1,6 +1,6 @@
 import { BPMNCanvasRef } from '@/components/bpmn-canvas';
 import { getMetaDataFromElement } from '@proceed/bpmn-helper/src/getters';
-import { getPlanDelays, getTimeInfo } from './instance-helpers';
+import { getPlanDelays, getTimeInfo, getTiming } from './instance-helpers';
 import { ExtendedInstanceInfo } from '@/lib/data/instance';
 
 export const colorOptions = [
@@ -42,25 +42,25 @@ export function getExecutionColor(executionState: string, wasInterrupted: boolea
 }
 
 export function progressToColor(
-  timeInfo: ReturnType<typeof getTimeInfo>,
-  planInfo: ReturnType<typeof getPlanDelays>,
+  actualTime: ReturnType<typeof getTimeInfo>,
+  plan: ReturnType<typeof getTimeInfo>,
 ) {
-  if (planInfo.plan.duration && timeInfo.start) {
-    const criticalTime = Math.floor(0.7 * planInfo.plan.duration);
-    const currentDate = timeInfo.end ? timeInfo.end.getTime() : Date.now();
+  if (plan.duration && actualTime.start) {
+    const criticalTime = Math.floor(0.7 * plan.duration);
+    const currentDate = actualTime.end ? actualTime.end.getTime() : Date.now();
 
-    if (currentDate < timeInfo.start.getTime() + criticalTime) {
+    if (currentDate < actualTime.start.getTime() + criticalTime) {
       return 'green';
-    } else if (currentDate < timeInfo.start.getTime() + planInfo.plan.duration) {
+    } else if (currentDate < actualTime.start.getTime() + plan.duration) {
       return 'orange';
     } else {
       return 'red';
     }
   }
 
-  if (timeInfo.end) {
-    if (!planInfo.plan.end) return 'white';
-    if (planInfo.plan.end.getTime() >= timeInfo.end.getTime()) return 'green';
+  if (actualTime.end) {
+    if (!plan.end) return 'white';
+    if (plan.end.getTime() >= actualTime.end.getTime()) return 'green';
     else return 'red';
   }
 
@@ -94,9 +94,14 @@ export function flowElementsStyling(
       switch (colors) {
         case 'timeColors':
           const metaData = getMetaDataFromElement(element.businessObject);
-          const timeInfo = getTimeInfo({ element, logInfo: logEntry, token, instance });
-          const planInfo = getPlanDelays({ elementMetaData: metaData, ...timeInfo });
-          color = progressToColor(timeInfo, planInfo);
+          const timing = getTiming({
+            isRootElement: false,
+            metaData,
+            logInfo: logEntry,
+            token,
+            instance,
+          });
+          color = progressToColor(timing.actual, timing.plan);
           break;
         case 'noColors':
           color = 'white';

--- a/src/management-system-v2/app/(dashboard)/[environmentId]/(automation)/executions/[processId]/instance-helpers.ts
+++ b/src/management-system-v2/app/(dashboard)/[environmentId]/(automation)/executions/[processId]/instance-helpers.ts
@@ -51,7 +51,7 @@ export function getTimeInfo({
   /** Token where currentFlowElementId is the element   */
   token?: ExtendedInstanceInfo['tokens'][number];
   instance?: ExtendedInstanceInfo;
-}) {
+}): { start?: Date; end?: Date; duration?: number } {
   if (!instance) return { start: undefined, end: undefined, duration: undefined };
 
   const isRootElement = element && element.type === 'bpmn:Process';
@@ -82,6 +82,7 @@ export function getTimeInfo({
 
   let duration: number | undefined;
   if (start && end) duration = end.getTime() - start.getTime();
+  else if (start) duration = Date.now() - start.getTime();
 
   return { start, end, duration };
 }
@@ -125,9 +126,10 @@ export function getPlanDelays({
     plan.duration = plan.end.getTime() - plan.start.getTime();
 
   const delays = {
-    start: plan.start && start && start.getTime() - plan.start.getTime(),
-    end: plan.end && end && end.getTime() - plan.end.getTime(),
-    duration: plan.duration && duration && duration - plan.duration,
+    start:
+      (plan.start && start && Math.max(start.getTime() - plan.start.getTime(), 0)) || undefined,
+    end: (plan.end && end && Math.max(end.getTime() - plan.end.getTime(), 0)) || undefined,
+    duration: (plan.duration && duration && Math.max(duration - plan.duration, 0)) || undefined,
   };
 
   return { plan, delays };

--- a/src/management-system-v2/app/(dashboard)/[environmentId]/(automation)/executions/[processId]/instance-helpers.ts
+++ b/src/management-system-v2/app/(dashboard)/[environmentId]/(automation)/executions/[processId]/instance-helpers.ts
@@ -1,5 +1,5 @@
 import { StoredDeployment } from '@/lib/data/deployment';
-import { InstanceInfo } from '@/lib/engines/deployment';
+import { ExtendedInstanceInfo } from '@/lib/data/instance';
 import { convertISODurationToMiliseconds } from '@proceed/bpmn-helper/src/getters';
 import type { ElementLike } from 'diagram-js/lib/core/Types';
 
@@ -47,10 +47,10 @@ export function getTimeInfo({
 }: {
   element: ElementLike;
   /** Log entry for element in instance information */
-  logInfo?: InstanceInfo['log'][number];
+  logInfo?: ExtendedInstanceInfo['log'][number];
   /** Token where currentFlowElementId is the element   */
-  token?: InstanceInfo['tokens'][number];
-  instance?: InstanceInfo;
+  token?: ExtendedInstanceInfo['tokens'][number];
+  instance?: ExtendedInstanceInfo;
 }) {
   if (!instance) return { start: undefined, end: undefined, duration: undefined };
 
@@ -133,7 +133,7 @@ export function getPlanDelays({
   return { plan, delays };
 }
 
-export function getVersionInstances(instances: InstanceInfo[], version?: string) {
+export function getVersionInstances(instances: ExtendedInstanceInfo[], version?: string) {
   if (!version) return instances;
   return instances.filter((instance) => instance.processVersion === version);
 }
@@ -150,7 +150,7 @@ export function getLatestDeployment(deployments: StoredDeployment[]) {
   );
 }
 
-export function getYoungestInstance<T extends InstanceInfo[]>(instances: T) {
+export function getYoungestInstance<T extends ExtendedInstanceInfo[]>(instances: T) {
   if (instances.length === 0) return undefined;
 
   let firstInstance = 0;

--- a/src/management-system-v2/app/(dashboard)/[environmentId]/(automation)/executions/[processId]/instance-helpers.ts
+++ b/src/management-system-v2/app/(dashboard)/[environmentId]/(automation)/executions/[processId]/instance-helpers.ts
@@ -87,6 +87,18 @@ export function getTimeInfo({
   return { start, end, duration };
 }
 
+export function getPlannedTimeInfo(elementMetaData: Record<string, any>) {
+  return {
+    end: elementMetaData.timePlannedEnd ? new Date(elementMetaData.timePlannedEnd) : undefined,
+    start: elementMetaData.timePlannedOccurrence
+      ? new Date(elementMetaData.timePlannedOccurrence)
+      : undefined,
+    duration: elementMetaData.timePlannedDuration
+      ? convertISODurationToMiliseconds(elementMetaData.timePlannedDuration)
+      : undefined,
+  };
+}
+
 export function getPlanDelays({
   elementMetaData,
   start,
@@ -101,15 +113,7 @@ export function getPlanDelays({
   end?: Date;
   duration?: number;
 }) {
-  const plan = {
-    end: elementMetaData.timePlannedEnd ? new Date(elementMetaData.timePlannedEnd) : undefined,
-    start: elementMetaData.timePlannedOccurrence
-      ? new Date(elementMetaData.timePlannedOccurrence)
-      : undefined,
-    duration: elementMetaData.timePlannedDuration
-      ? convertISODurationToMiliseconds(elementMetaData.timePlannedDuration)
-      : undefined,
-  };
+  const plan = getPlannedTimeInfo(elementMetaData);
 
   // The order in which missing times are derived from the others is irrelevant
   // If there is only one -> not possible to derive the others

--- a/src/management-system-v2/app/(dashboard)/[environmentId]/(automation)/executions/[processId]/instance-helpers.ts
+++ b/src/management-system-v2/app/(dashboard)/[environmentId]/(automation)/executions/[processId]/instance-helpers.ts
@@ -139,6 +139,40 @@ export function getPlanDelays({
   return { plan, delays };
 }
 
+export function getTiming({
+  isRootElement,
+  metaData,
+  logInfo,
+  token,
+  instance,
+}: {
+  isRootElement: boolean;
+  metaData: Record<string, any>;
+  /** Log entry for element in instance information */
+  logInfo?: ExtendedInstanceInfo['log'][number];
+  /** Token where currentFlowElementId is the element   */
+  token?: ExtendedInstanceInfo['tokens'][number];
+  instance?: ExtendedInstanceInfo;
+}) {
+  let timing: NonNullable<ExtendedInstanceInfo['tokens'][number]['timing']> = {
+    actual: { start: undefined, end: undefined, duration: undefined },
+    plan: { start: undefined, end: undefined, duration: undefined },
+    delays: { start: undefined, end: undefined, duration: undefined },
+  };
+
+  if (logInfo) {
+    if (logInfo.timing) timing = logInfo.timing;
+  } else if (token) {
+    if (token.timing) timing = token.timing;
+  } else if (instance && isRootElement) {
+    if (instance.timing) timing = instance.timing;
+  } else {
+    timing.plan = getPlannedTimeInfo(metaData);
+  }
+
+  return timing;
+}
+
 export function getVersionInstances(instances: ExtendedInstanceInfo[], version?: string) {
   if (!version) return instances;
   return instances.filter((instance) => instance.processVersion === version);

--- a/src/management-system-v2/app/(dashboard)/[environmentId]/(automation)/executions/[processId]/instance-info-panel.tsx
+++ b/src/management-system-v2/app/(dashboard)/[environmentId]/(automation)/executions/[processId]/instance-info-panel.tsx
@@ -1,11 +1,11 @@
 import ResizableElement, { ResizableElementRefType } from '@/components/ResizableElement';
 import CollapsibleCard from '@/components/collapsible-card';
 import { ReactNode, useRef } from 'react';
-import { InstanceInfo } from '@/lib/engines/deployment';
 import { Drawer, Grid, Tabs } from 'antd';
 import type { ElementLike } from 'diagram-js/lib/core/Types';
 import { ElementStatus } from './element-status';
 import InstanceVariables from './instance-variables';
+import { ExtendedInstanceInfo } from '@/lib/data/instance';
 
 export function DisplayTable({ data }: { data: ReactNode[][] }) {
   // TODO: make this responsive
@@ -42,7 +42,7 @@ export default function InstanceInfoPanel({
   open: boolean;
   processId: string;
   version: { bpmn: string };
-  instance?: InstanceInfo;
+  instance?: ExtendedInstanceInfo;
   element?: ElementLike;
   refetch: () => void;
 }) {

--- a/src/management-system-v2/app/(dashboard)/[environmentId]/(automation)/executions/[processId]/instance-tokens.ts
+++ b/src/management-system-v2/app/(dashboard)/[environmentId]/(automation)/executions/[processId]/instance-tokens.ts
@@ -1,10 +1,10 @@
 import { BPMNCanvasRef } from '@/components/bpmn-canvas';
-import { InstanceInfo } from '@/lib/engines/deployment';
+import { ExtendedInstanceInfo } from '@/lib/data/instance';
 
 import type { Element } from 'bpmn-js/lib/model/Types';
 import type { Connection } from 'diagram-js/lib/util/Elements';
 
-type TokenInfo = InstanceInfo['tokens'][number];
+type TokenInfo = ExtendedInstanceInfo['tokens'][number];
 
 export function getTokenPosition(
   token: TokenInfo,
@@ -84,11 +84,14 @@ export function getTokenPosition(
   return { top, right, left, targetElementId: targetFlowElement.id };
 }
 
-function isPausingToken(token: TokenInfo, instance: InstanceInfo) {
+function isPausingToken(token: TokenInfo, instance: ExtendedInstanceInfo) {
   return instance?.instanceState.includes('PAUSING') && token.state === 'RUNNING';
 }
 
-function getTokenTooltip(token: InstanceInfo['tokens'][number], instance: InstanceInfo) {
+function getTokenTooltip(
+  token: ExtendedInstanceInfo['tokens'][number],
+  instance: ExtendedInstanceInfo,
+) {
   if (isPausingToken(token, instance)) {
     return 'Token is in state RUNNING, switching to PAUSE state after current task is finished';
   }
@@ -111,7 +114,7 @@ function getTokenTooltip(token: InstanceInfo['tokens'][number], instance: Instan
   return token.state;
 }
 
-export function getTokenColor(token: TokenInfo, instance: InstanceInfo) {
+export function getTokenColor(token: TokenInfo, instance: ExtendedInstanceInfo) {
   if (isPausingToken(token, instance)) {
     return '#faad14';
   }
@@ -155,7 +158,11 @@ export function getTokenColor(token: TokenInfo, instance: InstanceInfo) {
   return 'white';
 }
 
-export function addToken(token: TokenInfo, instance: InstanceInfo, bpmnViewer: BPMNCanvasRef) {
+export function addToken(
+  token: TokenInfo,
+  instance: ExtendedInstanceInfo,
+  bpmnViewer: BPMNCanvasRef,
+) {
   const tokenColor: string = getTokenColor(token, instance);
   const tokenTooltip = getTokenTooltip(token, instance);
 

--- a/src/management-system-v2/app/(dashboard)/[environmentId]/(automation)/executions/[processId]/instance-variables.tsx
+++ b/src/management-system-v2/app/(dashboard)/[environmentId]/(automation)/executions/[processId]/instance-variables.tsx
@@ -9,12 +9,12 @@ import TextArea from 'antd/es/input/TextArea';
 import { wrapServerCall } from '@/lib/wrap-server-call';
 import useInstanceVariables, { Variable } from './use-instance-variables';
 import { textFormatMap, typeLabelMap } from '@/lib/process-variable-schema';
-import { InstanceInfo } from '@/lib/engines/deployment';
+import { ExtendedInstanceInfo } from '@/lib/data/instance';
 
 type InstanceVariableProps = {
   processId: string;
   version: { bpmn: string };
-  instance: InstanceInfo | undefined;
+  instance: ExtendedInstanceInfo | undefined;
   refetch: () => void;
 };
 

--- a/src/management-system-v2/app/(dashboard)/[environmentId]/(automation)/executions/[processId]/process-deployment-view.tsx
+++ b/src/management-system-v2/app/(dashboard)/[environmentId]/(automation)/executions/[processId]/process-deployment-view.tsx
@@ -56,7 +56,7 @@ import { useQuery } from '@tanstack/react-query';
 import { getProcessDeployments } from '@/lib/data/deployment';
 import { isSuccessResponse, isUserErrorResponse, userError } from '@/lib/user-error';
 import { getInstance } from '@/lib/data/instance';
-import { asyncMap } from '@/lib/helpers/javascriptHelpers';
+import { asyncMap, pick } from '@/lib/helpers/javascriptHelpers';
 import { getProcessBPMN } from '@/lib/data/processes';
 import { enableInstanceCSVExport } from 'FeatureFlags';
 import jsonToCsvExport from 'json-to-csv-export';
@@ -171,32 +171,14 @@ export default function ProcessDeploymentView({ processId }: { processId: string
       if (isUserErrorResponse(instance)) return null;
       if (!instance) return null;
 
-      return { ...instance.state, engines: instance.engines };
+      return {
+        ...instance.state,
+        ...pick(instance, ['engines', 'executionStatus', 'pausing', 'paused', 'offline']),
+      };
     },
     enabled: !!selectedInstanceId,
     refetchInterval: 1000,
   });
-
-  const { instanceIsRunning, instanceIsPausing, instanceIsPaused, offline } = useMemo(() => {
-    let instanceIsRunning = false;
-    let instanceIsPausing = false;
-    let instanceIsPaused = false;
-    let offline = false;
-
-    const activeStates = ['PAUSED', 'RUNNING', 'READY', 'DEPLOYMENT-WAITING', 'WAITING'];
-
-    if (currentInstance) {
-      instanceIsRunning = currentInstance.instanceState.some((state) =>
-        activeStates.includes(state),
-      );
-      instanceIsPausing = currentInstance.instanceState.some((state) => state === 'PAUSING');
-      instanceIsPaused = currentInstance.instanceState.some((state) => state === 'PAUSED');
-
-      offline = currentInstance.engines.some((e) => e.online === false);
-    }
-
-    return { instanceIsRunning, instanceIsPausing, instanceIsPaused, offline };
-  }, [currentInstance]);
 
   const {
     data: isProcessActivated,
@@ -314,7 +296,7 @@ export default function ProcessDeploymentView({ processId }: { processId: string
                 placeholder="Select an instance"
               />
 
-              {offline && (
+              {currentInstance?.offline && (
                 <Tooltip title="Some of the engines this process is executed on are not reachable!">
                   <Avatar
                     icon={
@@ -499,17 +481,19 @@ export default function ProcessDeploymentView({ processId }: { processId: string
             <div>
               {currentInstance && (
                 <ToolbarGroup>
-                  {instanceIsPaused || instanceIsPausing ? (
+                  {currentInstance.paused || currentInstance.pausing ? (
                     // Show Resume (Play) when paused or pausing
                     <Tooltip
                       title={
-                        instanceIsPausing ? 'Abort pausing the instance' : 'Resume the instance'
+                        currentInstance.pausing
+                          ? 'Abort pausing the instance'
+                          : 'Resume the instance'
                       }
                     >
                       <Button
                         className={styles.PlayIcon}
                         icon={<CaretRightOutlined />}
-                        disabled={offline}
+                        disabled={currentInstance.offline}
                         loading={resumingInstance}
                         onClick={async () => {
                           setResumingInstance(true);
@@ -529,7 +513,9 @@ export default function ProcessDeploymentView({ processId }: { processId: string
                         className={styles.PauseIcon}
                         icon={<PauseOutlined />}
                         loading={pausingInstance}
-                        disabled={offline || !instanceIsRunning}
+                        disabled={
+                          currentInstance.offline || currentInstance.executionStatus !== 'Running'
+                        }
                         onClick={async () => {
                           setPausingInstance(true);
                           await wrapServerCall({
@@ -548,7 +534,9 @@ export default function ProcessDeploymentView({ processId }: { processId: string
                       className={styles.StopIcon}
                       icon={<StopOutlined />}
                       loading={stoppingInstance}
-                      disabled={offline || !instanceIsRunning}
+                      disabled={
+                        currentInstance.offline || currentInstance.executionStatus !== 'Running'
+                      }
                       onClick={async () => {
                         setStoppingInstance(true);
                         await wrapServerCall({

--- a/src/management-system-v2/app/(dashboard)/[environmentId]/(automation)/executions/[processId]/process-deployment-view.tsx
+++ b/src/management-system-v2/app/(dashboard)/[environmentId]/(automation)/executions/[processId]/process-deployment-view.tsx
@@ -1,7 +1,7 @@
 // TODO: remove the use client if this page is used in server
 'use client';
 
-import { Button, Select, Tooltip, Space, Dropdown, Result, Skeleton } from 'antd';
+import { Button, Select, Tooltip, Space, Dropdown, Result, Skeleton, Avatar } from 'antd';
 import Content from '@/components/content';
 import BPMNCanvas, { BPMNCanvasRef } from '@/components/bpmn-canvas';
 import { Toolbar, ToolbarGroup } from '@/components/toolbar';
@@ -13,6 +13,7 @@ import {
   PauseOutlined,
   StopOutlined,
   ExportOutlined,
+  WarningTwoTone,
 } from '@ant-design/icons';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import contentStyles from './content.module.scss';
@@ -170,16 +171,17 @@ export default function ProcessDeploymentView({ processId }: { processId: string
       if (isUserErrorResponse(instance)) return null;
       if (!instance) return null;
 
-      return { ...instance.state, engineIds: instance.engineIds };
+      return { ...instance.state, engines: instance.engines };
     },
     enabled: !!selectedInstanceId,
     refetchInterval: 1000,
   });
 
-  const { instanceIsRunning, instanceIsPausing, instanceIsPaused } = useMemo(() => {
+  const { instanceIsRunning, instanceIsPausing, instanceIsPaused, offline } = useMemo(() => {
     let instanceIsRunning = false;
     let instanceIsPausing = false;
     let instanceIsPaused = false;
+    let offline = false;
 
     const activeStates = ['PAUSED', 'RUNNING', 'READY', 'DEPLOYMENT-WAITING', 'WAITING'];
 
@@ -189,9 +191,11 @@ export default function ProcessDeploymentView({ processId }: { processId: string
       );
       instanceIsPausing = currentInstance.instanceState.some((state) => state === 'PAUSING');
       instanceIsPaused = currentInstance.instanceState.some((state) => state === 'PAUSED');
+
+      offline = currentInstance.engines.some((e) => e.online === false);
     }
 
-    return { instanceIsRunning, instanceIsPausing, instanceIsPaused };
+    return { instanceIsRunning, instanceIsPausing, instanceIsPaused, offline };
   }, [currentInstance]);
 
   const {
@@ -309,6 +313,21 @@ export default function ProcessDeploymentView({ processId }: { processId: string
                 }))}
                 placeholder="Select an instance"
               />
+
+              {offline && (
+                <Tooltip title="Some of the engines this process is executed on are not reachable!">
+                  <Avatar
+                    icon={
+                      <WarningTwoTone
+                        twoToneColor="orange"
+                        style={{ width: '16px', height: '16px' }}
+                      />
+                    }
+                    size={40}
+                    style={{ backgroundColor: 'inherit' }}
+                  />
+                </Tooltip>
+              )}
 
               <Tooltip title="Filter by version">
                 <Dropdown
@@ -490,6 +509,7 @@ export default function ProcessDeploymentView({ processId }: { processId: string
                       <Button
                         className={styles.PlayIcon}
                         icon={<CaretRightOutlined />}
+                        disabled={offline}
                         loading={resumingInstance}
                         onClick={async () => {
                           setResumingInstance(true);
@@ -509,7 +529,7 @@ export default function ProcessDeploymentView({ processId }: { processId: string
                         className={styles.PauseIcon}
                         icon={<PauseOutlined />}
                         loading={pausingInstance}
-                        disabled={!instanceIsRunning}
+                        disabled={offline || !instanceIsRunning}
                         onClick={async () => {
                           setPausingInstance(true);
                           await wrapServerCall({
@@ -528,7 +548,7 @@ export default function ProcessDeploymentView({ processId }: { processId: string
                       className={styles.StopIcon}
                       icon={<StopOutlined />}
                       loading={stoppingInstance}
-                      disabled={!instanceIsRunning}
+                      disabled={offline || !instanceIsRunning}
                       onClick={async () => {
                         setStoppingInstance(true);
                         await wrapServerCall({

--- a/src/management-system-v2/app/(dashboard)/[environmentId]/(automation)/executions/[processId]/use-colors.tsx
+++ b/src/management-system-v2/app/(dashboard)/[environmentId]/(automation)/executions/[processId]/use-colors.tsx
@@ -1,13 +1,13 @@
 import { RefObject, useCallback, useEffect, useRef } from 'react';
 
 import { ColorOptions, flowElementsStyling } from './instance-coloring';
-import { InstanceInfo } from '@/lib/engines/deployment';
 import { BPMNCanvasRef } from '@/components/bpmn-canvas';
+import { ExtendedInstanceInfo } from '@/lib/data/instance';
 
 const useColors = (
   selectedBpmn: { bpmn: string } | undefined,
   selectedColoring: ColorOptions,
-  selectedInstance: InstanceInfo | undefined,
+  selectedInstance: ExtendedInstanceInfo | undefined,
   canvasRef: RefObject<BPMNCanvasRef | null>,
 ) => {
   const appliedStylingRef = useRef<{ elementId: string; color: string }[]>([]);

--- a/src/management-system-v2/app/(dashboard)/[environmentId]/(automation)/executions/[processId]/use-instance-variables.tsx
+++ b/src/management-system-v2/app/(dashboard)/[environmentId]/(automation)/executions/[processId]/use-instance-variables.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useState } from 'react';
 import { getProcessIds, getVariablesFromElementById } from '@proceed/bpmn-helper';
-import { InstanceInfo } from '@/lib/engines/deployment';
 import { ProcessVariable, ProcessVariableSchema } from '@/lib/process-variable-schema';
+import { ExtendedInstanceInfo } from '@/lib/data/instance';
 
 export type Variable = {
   name: string;
@@ -11,7 +11,10 @@ export type Variable = {
   value: any;
 };
 
-const useInstanceVariables = (info: { version?: { bpmn: string }; instance?: InstanceInfo }) => {
+const useInstanceVariables = (info: {
+  version?: { bpmn: string };
+  instance?: ExtendedInstanceInfo;
+}) => {
   const [variableDefinitions, setVariableDefinitions] = useState<ProcessVariable[]>([]);
 
   useEffect(() => {

--- a/src/management-system-v2/app/(dashboard)/[environmentId]/(automation)/executions/[processId]/use-tokens.tsx
+++ b/src/management-system-v2/app/(dashboard)/[environmentId]/(automation)/executions/[processId]/use-tokens.tsx
@@ -1,10 +1,13 @@
 import { RefObject, useCallback, useEffect, useRef } from 'react';
 
-import { InstanceInfo } from '@/lib/engines/deployment';
 import { BPMNCanvasRef } from '@/components/bpmn-canvas';
 import { addToken } from './instance-tokens';
+import { ExtendedInstanceInfo } from '@/lib/data/instance';
 
-const useTokens = (instance: InstanceInfo | null, canvasRef: RefObject<BPMNCanvasRef | null>) => {
+const useTokens = (
+  instance: ExtendedInstanceInfo | null,
+  canvasRef: RefObject<BPMNCanvasRef | null>,
+) => {
   // provide a function that allows BpmnCanvas to reapply the tokens after the bpmn was imported
   // but prevent unnecessary reimports of the bpmn from occuring every time there is a change in the
   // instance information

--- a/src/management-system-v2/app/shared-viewer/documentation-page-utils.ts
+++ b/src/management-system-v2/app/shared-viewer/documentation-page-utils.ts
@@ -24,7 +24,6 @@ import {
 
 import { getSVGFromBPMN } from '@/lib/process-export/util';
 
-import { InstanceInfo } from '@/lib/engines/deployment';
 import schema from '@/lib/schema';
 
 import { ResourceViewModule } from '@/lib/modeler-extensions/GenericResources/index';
@@ -36,6 +35,7 @@ import {
 import { ElementInfo } from './table-of-content';
 import { AnchorLinkItemProps } from 'antd/es/anchor/Anchor';
 import { BPMNCanvasRef } from '@/components/bpmn-canvas';
+import { ExtendedInstanceInfo } from '@/lib/data/instance';
 
 // generate the title of an elements section based on the type of the element
 export function getTitle(el: any) {
@@ -251,7 +251,7 @@ export async function getElementSVG(
 // returns the svg of BPMN diagram for instance documention page with correcct token position
 export async function getSVGWithInstanceColoring(
   bpmn: string,
-  instance: InstanceInfo,
+  instance: ExtendedInstanceInfo,
   coloring: ColorOptions,
 ): Promise<string> {
   const viewer = await getViewer(bpmn);
@@ -465,7 +465,7 @@ export function isInstanceElementEmpty(node: ElementInfo): boolean {
 }
 
 // variable changes for each individial event or element
-function hasVariableChangesForElement(instance: InstanceInfo, node: ElementInfo): boolean {
+function hasVariableChangesForElement(instance: ExtendedInstanceInfo, node: ElementInfo): boolean {
   return instance.log
     .filter((l) => l.flowElementId === node.id)
     .some((l) => l.variableChanges && Object.keys(l.variableChanges).length > 0);
@@ -473,7 +473,7 @@ function hasVariableChangesForElement(instance: InstanceInfo, node: ElementInfo)
 
 // get variables changed by or during an element
 export function getVariablesForElement(
-  instance: InstanceInfo,
+  instance: ExtendedInstanceInfo,
   elementId: string,
 ): { name: string; oldValue?: string; value: string; changedTime: number }[] {
   const result: { name: string; oldValue?: string; value: string; changedTime: number }[] = [];
@@ -841,7 +841,7 @@ export function buildProcessTocItems(
 export function buildInstanceTocItems(
   hierarchy: ElementInfo,
   settings: Record<string, boolean>,
-  instance: InstanceInfo,
+  instance: ExtendedInstanceInfo,
   linksDisabled = false,
 ): AnchorLinkItemProps[] {
   const href = (id: string) => (linksDisabled ? '' : id);

--- a/src/management-system-v2/app/shared-viewer/instance-document-content.tsx
+++ b/src/management-system-v2/app/shared-viewer/instance-document-content.tsx
@@ -4,7 +4,6 @@ import { useSearchParams } from 'next/navigation';
 import { Alert, Grid, Image, Table, Typography } from 'antd';
 import cn from 'classnames';
 import { getProcess } from '@/lib/data/db/process';
-import { InstanceInfo } from '@/lib/engines/deployment';
 import { generateDateString } from '@/lib/utils';
 import { useEnvironment } from '@/components/auth-can';
 import { useFileManager } from '@/lib/useFileManager';
@@ -30,6 +29,7 @@ import ElementSections from '@/components/doc-element-sections';
 import ExecutionLogTable from '../../components/instance-doc-tables/execution-log-table';
 import FinalVariablesTable from '../../components/instance-doc-tables/final-variables-table';
 import ImportedProcessSectionHeader from '@/components/doc-imported-process-header';
+import { ExtendedInstanceInfo } from '@/lib/data/instance';
 
 const { Title, Text, Paragraph } = Typography;
 
@@ -37,7 +37,7 @@ type Props = {
   processData: Awaited<ReturnType<typeof getProcess>>;
   processHierarchy: ElementInfo;
   versionInfo: VersionInfo;
-  instance: InstanceInfo;
+  instance: ExtendedInstanceInfo;
   settings: Record<string, boolean>;
 };
 
@@ -155,7 +155,7 @@ const InstanceDocumentContent: React.FC<Props> = ({
         executionState: string;
         startTime?: number;
         endTime?: number;
-        machine?: InstanceInfo['log'][number]['machine'];
+        machine?: ExtendedInstanceInfo['log'][number]['machine'];
       }[] = [];
 
       if (hasLog) {

--- a/src/management-system-v2/app/shared-viewer/instance-documentation-page.tsx
+++ b/src/management-system-v2/app/shared-viewer/instance-documentation-page.tsx
@@ -4,7 +4,6 @@ import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { Spin } from 'antd';
 import { getProcess } from '@/lib/data/db/process';
 import { Environment } from '@/lib/data/environment-schema';
-import { InstanceInfo } from '@/lib/engines/deployment';
 import { instanceSettings } from './settings-modal';
 import {
   ImportsInfo,
@@ -17,6 +16,7 @@ import InstanceDocumentContent from './instance-document-content';
 import { useProcessHierarchy } from './use-process-hierarchy';
 import { ColorOptions } from '../(dashboard)/[environmentId]/(automation)/executions/[processId]/instance-coloring';
 import { AnchorLinkItemProps } from 'antd/es/anchor/Anchor';
+import { ExtendedInstanceInfo } from '@/lib/data/instance';
 
 const defaultInstanceSettingValues = instanceSettings.map(({ value }) => value);
 
@@ -26,7 +26,7 @@ type InstanceDocumentationPageProps = {
   userWorkspaces: Environment[];
   defaultSettings?: string[];
   availableImports: ImportsInfo;
-  instance: InstanceInfo;
+  instance: ExtendedInstanceInfo;
   coloring: ColorOptions;
 };
 

--- a/src/management-system-v2/app/shared-viewer/page.tsx
+++ b/src/management-system-v2/app/shared-viewer/page.tsx
@@ -297,7 +297,15 @@ const SharedViewer = async (props: PageProps) => {
 
   const ownerName = await resolveUserDisplayName(processData?.creatorId);
 
-  const processInitiatorName = await resolveUserDisplayName(instanceData?.processInitiator);
+  let processInitiatorName = 'Unknown';
+  const initiator = instanceData?.processInitiator;
+  if (initiator) {
+    if (typeof initiator === 'string') {
+      processInitiatorName = initiator;
+    } else {
+      processInitiatorName = initiator.fullName || initiator.username || initiator.id;
+    }
+  }
 
   // Inject both ownerName and processInitiatorName into processData
   const enrichedProcessData = {

--- a/src/management-system-v2/app/shared-viewer/table-of-content.tsx
+++ b/src/management-system-v2/app/shared-viewer/table-of-content.tsx
@@ -9,8 +9,8 @@ import { truthyFilter } from '@/lib/typescript-utils';
 import styles from './table-of-content.module.scss';
 
 import { ActiveSettings } from './settings-modal';
-import { InstanceInfo } from '@/lib/engines/deployment';
 import { getElementTypeLabel } from './documentation-page-utils';
+import { ExtendedInstanceInfo } from '@/lib/data/instance';
 
 type MetaInformation = {
   name?: string;
@@ -46,8 +46,8 @@ export type ElementInfo = MetaInformation & {
     versionCreatedOn?: string;
   };
   instanceStatus?: {
-    token?: InstanceInfo['tokens'][number];
-    logEntries?: InstanceInfo['log'];
+    token?: ExtendedInstanceInfo['tokens'][number];
+    logEntries?: ExtendedInstanceInfo['log'];
   };
 };
 

--- a/src/management-system-v2/components/instance-doc-tables/execution-log-table.tsx
+++ b/src/management-system-v2/components/instance-doc-tables/execution-log-table.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import { Alert, Table } from 'antd';
-import { InstanceInfo } from '@/lib/engines/deployment';
 import { generateDateString, generateDurationString } from '@/lib/utils';
 import { statusToType } from '@/app/(dashboard)/[environmentId]/(automation)/executions/[processId]/instance-helpers';
+import { ExtendedInstanceInfo } from '@/lib/data/instance';
 
 type LogRow = {
   key: string;
@@ -10,7 +10,7 @@ type LogRow = {
   startTime?: number | string;
   endTime?: number | string;
   duration?: string;
-  machine?: InstanceInfo['log'][number]['machine'];
+  machine?: ExtendedInstanceInfo['log'][number]['machine'];
 };
 
 const columns = [
@@ -58,7 +58,7 @@ const columns = [
     dataIndex: 'machine',
     key: 'machine',
     width: 150,
-    render: (m?: InstanceInfo['log'][number]['machine']) => (m ? m.name : '—'),
+    render: (m?: ExtendedInstanceInfo['log'][number]['machine']) => (m ? m.name : '—'),
   },
 ];
 

--- a/src/management-system-v2/components/instance-doc-tables/final-variables-table.tsx
+++ b/src/management-system-v2/components/instance-doc-tables/final-variables-table.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
 import { Table } from 'antd';
-import { InstanceInfo } from '@/lib/engines/deployment';
 import { generateDateString } from '@/lib/utils';
 import { ElementInfo } from '@/app/shared-viewer/table-of-content';
 import { getElementTypeLabel } from '@/app/shared-viewer/documentation-page-utils';
+import { ExtendedInstanceInfo } from '@/lib/data/instance';
 
 type VariableLogEntry = {
   changedTime: number;
@@ -18,7 +18,7 @@ type VariableEntry = {
 };
 
 type FinalVariablesTableProps = {
-  instance: InstanceInfo;
+  instance: ExtendedInstanceInfo;
   processHierarchy?: ElementInfo;
 };
 

--- a/src/management-system-v2/lib/data/db/iam/users.ts
+++ b/src/management-system-v2/lib/data/db/iam/users.ts
@@ -41,6 +41,18 @@ export async function getUsers(page: number = 1, pageSize: number = 10) {
   };
 }
 
+export async function getSpaceUsers(spaceId: string, isOrganization: boolean) {
+  // get the users for the current space
+  if (isOrganization) {
+    return db.user.findMany({
+      where: { memberIn: { some: { environmentId: spaceId } } },
+    });
+  } else {
+    const user = await db.user.findUnique({ where: { id: spaceId } });
+    return user ? [user] : [];
+  }
+}
+
 export async function getUserById(
   id: string,
   opts?: { throwIfNotFound?: boolean },

--- a/src/management-system-v2/lib/data/instance.ts
+++ b/src/management-system-v2/lib/data/instance.ts
@@ -18,7 +18,17 @@ import { truthyFilter } from '../typescript-utils';
 
 import { getAllAvailableEngines } from './engines';
 import { getProcessBPMN } from './processes';
-import { getElementById, getMetaDataFromElement, toBpmnObject } from '@proceed/bpmn-helper';
+import {
+  getElementById,
+  getElementsByTagName,
+  getMetaDataFromElement,
+  toBpmnObject,
+} from '@proceed/bpmn-helper';
+import {
+  getPlanDelays,
+  getTimeInfo,
+} from '@/app/(dashboard)/[environmentId]/(automation)/executions/[processId]/instance-helpers';
+import type { ElementLike } from 'diagram-js/lib/core/Types';
 
 type StoredInstance = Omit<ProcessInstance, 'state'> & { state: InstanceInfo; versionId: string };
 
@@ -155,6 +165,36 @@ async function extendInstance(spaceId: string, instance: StoredInstance, ability
     .filter(truthyFilter)
     .reduce(accumulateCosts, [] as { value: number; unit: string }[]);
 
+  function getTimings(
+    log?: (typeof state)['log'][number],
+    token?: (typeof state)['tokens'][number],
+  ) {
+    let element;
+    if (log) element = getElementById(bpmnObject, log.flowElementId) as any;
+    else if (token) element = getElementById(bpmnObject, token.currentFlowElementId) as any;
+    else {
+      [element] = getElementsByTagName(bpmnObject, 'bpmn:Process');
+    }
+
+    if (!element) return;
+
+    const { start, end, duration } = getTimeInfo({
+      element: { type: element.$type } as unknown as ElementLike,
+      logInfo: log as any,
+      token: token as any,
+      instance: state as any,
+    });
+
+    const elementMetaData = getMetaDataFromElement(element);
+    const { plan, delays } = getPlanDelays({ elementMetaData, start, end, duration });
+
+    return {
+      actual: { start, end, duration },
+      plan,
+      delays,
+    };
+  }
+
   return {
     ...instance,
     initiator,
@@ -169,17 +209,20 @@ async function extendInstance(spaceId: string, instance: StoredInstance, ability
         plannedCosts: getPlannedCosts(token.currentFlowElementId),
         actualOwner: mapUsers(token.actualOwner),
         performers: mapPerformers(token.performers),
+        timing: getTimings(undefined, token),
       })),
       log: state.log.map((entry) => ({
         ...entry,
         plannedCosts: getPlannedCosts(entry.flowElementId),
         actualOwner: mapUsers(entry.actualOwner),
         performers: mapPerformers(entry.performers),
+        timing: getTimings(entry, undefined),
       })),
       processInitiator: initiator,
       spaceOfProcessInitiator: initiatorSpace,
       executionCosts,
       plannedCosts: plannedCosts.length ? plannedCosts : undefined,
+      timing: getTimings(),
     },
   };
 }

--- a/src/management-system-v2/lib/data/instance.ts
+++ b/src/management-system-v2/lib/data/instance.ts
@@ -195,6 +195,23 @@ async function extendInstance(spaceId: string, instance: StoredInstance, ability
     };
   }
 
+  let executionStatus: 'Running' | 'Ended' | 'Failed' = 'Ended';
+  const activeStates = ['PAUSED', 'RUNNING', 'READY', 'DEPLOYMENT-WAITING', 'WAITING'];
+  const { instanceState } = state;
+  if (instanceState.some((state) => activeStates.includes(state))) {
+    executionStatus = 'Running';
+  }
+  const failStates = [
+    'FAILED',
+    'ERROR-SEMANTIC',
+    'ERROR-TECHNICAL',
+    'ERROR-CONSTRAINT-UNFULFILLED',
+    'ERROR-UNKNOWN',
+  ];
+  if (executionStatus === 'Ended' && instanceState.some((state) => failStates.includes(state))) {
+    executionStatus = 'Failed';
+  }
+
   return {
     ...instance,
     initiator,
@@ -202,6 +219,10 @@ async function extendInstance(spaceId: string, instance: StoredInstance, ability
       id,
       online: reachableEngines.some((e) => e.id === id),
     })),
+    executionStatus,
+    offline: instance.engineIds.some((id) => !reachableEngines.some((e) => e.id === id)),
+    pausing: instanceState.some((state) => state === 'PAUSING'),
+    paused: instanceState.some((state) => state === 'PAUSED'),
     state: {
       ...state,
       tokens: state.tokens.map((token) => ({

--- a/src/management-system-v2/lib/data/instance.ts
+++ b/src/management-system-v2/lib/data/instance.ts
@@ -4,12 +4,25 @@ import db from '@/lib/data/db';
 
 import { getCurrentEnvironment } from '@/components/auth';
 import { InstanceInput, InstanceInputSchema } from '../instance-schema';
-import { UserErrorType, userError } from '../user-error';
+import { UserErrorType, isUserErrorResponse, userError } from '../user-error';
 import { InstanceInfo } from '../engines/deployment';
 import Ability from '../ability/abilityHelper';
 import { ProcessInstance } from '@prisma/client';
+import { asyncMap } from '../helpers/javascriptHelpers';
 
 type StoredInstance = Omit<ProcessInstance, 'state'> & { state: InstanceInfo; versionId: string };
+
+export async function extendInstanceInfo(instanceInfo: StoredInstance) {
+  return {
+    ...instanceInfo,
+  };
+}
+
+export type ExtendedInstance = Exclude<
+  Awaited<ReturnType<typeof extendInstanceInfo>>,
+  { error: any }
+>;
+export type ExtendedInstanceInfo = ExtendedInstance['state'];
 
 export async function getInstance(spaceId: string, instanceId: string, ability?: Ability) {
   if (!ability) ({ ability } = await getCurrentEnvironment(spaceId));
@@ -24,11 +37,11 @@ export async function getInstance(spaceId: string, instanceId: string, ability?:
 
   if (!instanceInfo) return null;
 
-  return {
+  return extendInstanceInfo({
     ...instanceInfo,
     state: instanceInfo.state as InstanceInfo,
     versionId: instanceInfo.deployment.versionId,
-  } as StoredInstance;
+  });
 }
 
 export async function getInstances(spaceId: string, ability?: Ability) {
@@ -50,11 +63,19 @@ export async function getInstances(spaceId: string, ability?: Ability) {
     include: { deployment: { select: { versionId: true } } },
   });
 
-  return instances.map((i) => ({
-    ...i,
-    state: i.state as InstanceInfo,
-    versionId: i.deployment.versionId,
-  })) as StoredInstance[];
+  const extendedInstances = (await asyncMap(instances, async (i) =>
+    extendInstanceInfo({
+      ...i,
+      state: i.state as InstanceInfo,
+      versionId: i.deployment.versionId,
+    }),
+  )) as ExtendedInstance[];
+
+  const instanceWithError = extendedInstances.find(isUserErrorResponse);
+
+  if (instanceWithError) return instanceWithError;
+
+  return extendedInstances as ExtendedInstance[];
 }
 
 export async function addInstance(

--- a/src/management-system-v2/lib/data/instance.ts
+++ b/src/management-system-v2/lib/data/instance.ts
@@ -4,7 +4,7 @@ import db from '@/lib/data/db';
 
 import { getCurrentEnvironment } from '@/components/auth';
 import { InstanceInput, InstanceInputSchema } from '../instance-schema';
-import { UserErrorType, isUserErrorResponse, userError } from '../user-error';
+import { UserErrorType, userError } from '../user-error';
 import { InstanceInfo } from '../engines/deployment';
 import Ability from '../ability/abilityHelper';
 import { ProcessInstance } from '@prisma/client';
@@ -46,11 +46,7 @@ export async function extendInstance(spaceId: string, instance: StoredInstance) 
     const user = knownUsers[userId];
     if (!user) return undefined;
     return {
-      id: user.id,
-      isGuest: user.isGuest,
-      username: user.username,
-      firstName: user.firstName,
-      lastName: user.lastName,
+      ...pick(user, ['id', 'isGuest', 'username', 'firstName', 'lastName']),
       fullName: `${user.firstName} ${user.lastName}`.trim(),
     };
   };
@@ -77,8 +73,30 @@ export async function extendInstance(spaceId: string, instance: StoredInstance) 
 
   const { state } = instance;
 
+  let initiator: 'Automatic' | 'Unknown' | 'Guest' | NonNullable<ReturnType<typeof mapUser>> =
+    'Automatic';
+  if (instance.initiatorId) {
+    const i = mapUser(instance.initiatorId);
+    if (!i) initiator = 'Unknown';
+    else if (i.isGuest) initiator = 'Guest';
+    else initiator = i;
+  }
+
+  let initiatorSpace: undefined | { id: string; name: string; isOrganization: boolean } = undefined;
+  if (instance.state.spaceIdOfProcessInitiator) {
+    const space = await getSpaceInfo(instance.state.spaceIdOfProcessInitiator);
+    if (space) {
+      if (space.isOrganization) {
+        initiatorSpace = pick(space, ['id', 'name', 'isOrganization']);
+      } else {
+        initiatorSpace = { id: space.id, name: 'Personal Space', isOrganization: false };
+      }
+    }
+  }
+
   return {
     ...instance,
+    initiator,
     state: {
       ...state,
       tokens: state.tokens.map((token) => ({
@@ -91,14 +109,13 @@ export async function extendInstance(spaceId: string, instance: StoredInstance) 
         actualOwner: mapUsers(entry.actualOwner),
         performers: mapPerformers(entry.performers),
       })),
+      processInitiator: initiator,
+      spaceOfProcessInitiator: initiatorSpace,
     },
   };
 }
 
-export type ExtendedInstance = Exclude<
-  Awaited<ReturnType<typeof extendInstanceInfo>>,
-  { error: any }
->;
+export type ExtendedInstance = Exclude<Awaited<ReturnType<typeof extendInstance>>, { error: any }>;
 export type ExtendedInstanceInfo = ExtendedInstance['state'];
 
 export async function getInstance(spaceId: string, instanceId: string, ability?: Ability) {

--- a/src/management-system-v2/lib/data/instance.ts
+++ b/src/management-system-v2/lib/data/instance.ts
@@ -17,9 +17,18 @@ import { getRoles } from './db/iam/roles';
 import { truthyFilter } from '../typescript-utils';
 
 import { getAllAvailableEngines } from './engines';
+import { getProcessBPMN } from './processes';
+import { getElementById, getMetaDataFromElement, toBpmnObject } from '@proceed/bpmn-helper';
 
 type StoredInstance = Omit<ProcessInstance, 'state'> & { state: InstanceInfo; versionId: string };
 
+const getVersionBpmnObject = cache(
+  async (spaceId: string, definitionId: string, versionId: string, ability?: Ability) => {
+    const bpmn = await getProcessBPMN(definitionId, spaceId, versionId, ability);
+    if (isUserErrorResponse(bpmn)) return bpmn;
+    return toBpmnObject(bpmn);
+  },
+);
 const getSpaceInfo = cache(async (spaceId: string) => {
   return await getEnvironmentById(spaceId);
 });
@@ -88,8 +97,8 @@ async function extendInstance(spaceId: string, instance: StoredInstance, ability
   }
 
   let initiatorSpace: undefined | { id: string; name: string; isOrganization: boolean } = undefined;
-  if (instance.state.spaceIdOfProcessInitiator) {
-    const space = await getSpaceInfo(instance.state.spaceIdOfProcessInitiator);
+  if (state.spaceIdOfProcessInitiator) {
+    const space = await getSpaceInfo(state.spaceIdOfProcessInitiator);
     if (space) {
       if (space.isOrganization) {
         initiatorSpace = pick(space, ['id', 'name', 'isOrganization']);
@@ -98,6 +107,53 @@ async function extendInstance(spaceId: string, instance: StoredInstance, ability
       }
     }
   }
+
+  const bpmnObject = await getVersionBpmnObject(
+    spaceId,
+    instance.state.processId,
+    instance.state.processVersion,
+    ability,
+  );
+
+  if (isUserErrorResponse(bpmnObject)) return bpmnObject;
+
+  const getPlannedCosts = (flowNodeId: string) => {
+    const flowNode = getElementById(bpmnObject, flowNodeId);
+    if (!flowNode) return;
+    const metaData = getMetaDataFromElement(flowNode);
+    return metaData.costsPlanned;
+  };
+
+  function accumulateCosts(
+    acc: { value: number; unit: string }[],
+    cost: { value: string; unit: string },
+  ) {
+    try {
+      const value = parseFloat(cost.value);
+      const sameUnit = acc.find((entry) => entry.unit === cost.unit);
+      if (sameUnit) {
+        sameUnit.value += value;
+      } else {
+        acc.push({ value, unit: cost.unit });
+      }
+    } catch (err) {}
+
+    return acc;
+  }
+
+  const fullExecution = [...state.log, ...state.tokens];
+  let executionCosts = fullExecution
+    .map((entry) => entry.costsRealSetByOwner)
+    .filter(truthyFilter)
+    .reduce(accumulateCosts, [] as { value: number; unit: string }[]);
+  let plannedCosts = fullExecution
+    .map((entry) => {
+      const flowNodeId =
+        'flowElementId' in entry ? entry.flowElementId : entry.currentFlowElementId;
+      return getPlannedCosts(flowNodeId);
+    })
+    .filter(truthyFilter)
+    .reduce(accumulateCosts, [] as { value: number; unit: string }[]);
 
   return {
     ...instance,
@@ -110,16 +166,20 @@ async function extendInstance(spaceId: string, instance: StoredInstance, ability
       ...state,
       tokens: state.tokens.map((token) => ({
         ...token,
+        plannedCosts: getPlannedCosts(token.currentFlowElementId),
         actualOwner: mapUsers(token.actualOwner),
         performers: mapPerformers(token.performers),
       })),
       log: state.log.map((entry) => ({
         ...entry,
+        plannedCosts: getPlannedCosts(entry.flowElementId),
         actualOwner: mapUsers(entry.actualOwner),
         performers: mapPerformers(entry.performers),
       })),
       processInitiator: initiator,
       spaceOfProcessInitiator: initiatorSpace,
+      executionCosts,
+      plannedCosts: plannedCosts.length ? plannedCosts : undefined,
     },
   };
 }
@@ -179,6 +239,10 @@ export async function getInstances(spaceId: string, ability: Ability) {
       ability,
     ),
   );
+
+  const engineResWithError = extendedInstances.find(isUserErrorResponse);
+
+  if (!!engineResWithError) return engineResWithError;
 
   return extendedInstances as ExtendedInstance[];
 }

--- a/src/management-system-v2/lib/data/instance.ts
+++ b/src/management-system-v2/lib/data/instance.ts
@@ -8,13 +8,90 @@ import { UserErrorType, isUserErrorResponse, userError } from '../user-error';
 import { InstanceInfo } from '../engines/deployment';
 import Ability from '../ability/abilityHelper';
 import { ProcessInstance } from '@prisma/client';
-import { asyncMap } from '../helpers/javascriptHelpers';
+import { asyncMap, pick } from '../helpers/javascriptHelpers';
+import { cache } from 'react';
+import { getSpaceUsers } from './db/iam/users';
+import { getEnvironmentById } from './db/iam/environments';
+import { Role } from './role-schema';
+import { getRoles } from './db/iam/roles';
+import { truthyFilter } from '../typescript-utils';
 
 type StoredInstance = Omit<ProcessInstance, 'state'> & { state: InstanceInfo; versionId: string };
 
-export async function extendInstanceInfo(instanceInfo: StoredInstance) {
+const getSpaceInfo = cache(async (spaceId: string) => {
+  return await getEnvironmentById(spaceId);
+});
+const getKnownUsers = cache(async (spaceId: string) => {
+  const space = await getSpaceInfo(spaceId);
+  const users = await getSpaceUsers(spaceId, space.isOrganization);
+  return Object.fromEntries(users.map((user) => [user.id, user]));
+});
+const getKnownRoles = cache(async (spaceId: string) => {
+  let knownRoles: Record<string, Role> = {};
+
+  const space = await getSpaceInfo(spaceId);
+  if (space.isOrganization) {
+    const roles = await getRoles(spaceId);
+    knownRoles = Object.fromEntries(roles.map((role) => [role.id, role]));
+  }
+
+  return knownRoles;
+});
+
+export async function extendInstance(spaceId: string, instance: StoredInstance) {
+  const knownUsers = await getKnownUsers(spaceId);
+  const knownRoles = await getKnownRoles(spaceId);
+
+  const mapUser = (userId: string) => {
+    const user = knownUsers[userId];
+    if (!user) return undefined;
+    return {
+      id: user.id,
+      isGuest: user.isGuest,
+      username: user.username,
+      firstName: user.firstName,
+      lastName: user.lastName,
+      fullName: `${user.firstName} ${user.lastName}`.trim(),
+    };
+  };
+
+  const mapUsers = (ownerIds?: string[]) => {
+    return ownerIds?.map(mapUser).filter(truthyFilter);
+  };
+
+  const mapPerformers = (performers?: InstanceInfo['tokens'][number]['performers']) => {
+    if (!performers) return undefined;
+
+    return {
+      user: mapUsers(performers.user),
+      roles: performers.roles
+        .map((roleId) => {
+          const role = knownRoles[roleId];
+          if (!role) return undefined;
+
+          return pick(role, ['id', 'name', 'description']);
+        })
+        .filter(truthyFilter),
+    };
+  };
+
+  const { state } = instance;
+
   return {
-    ...instanceInfo,
+    ...instance,
+    state: {
+      ...state,
+      tokens: state.tokens.map((token) => ({
+        ...token,
+        actualOwner: mapUsers(token.actualOwner),
+        performers: mapPerformers(token.performers),
+      })),
+      log: state.log.map((entry) => ({
+        ...entry,
+        actualOwner: mapUsers(entry.actualOwner),
+        performers: mapPerformers(entry.performers),
+      })),
+    },
   };
 }
 
@@ -37,7 +114,7 @@ export async function getInstance(spaceId: string, instanceId: string, ability?:
 
   if (!instanceInfo) return null;
 
-  return extendInstanceInfo({
+  return extendInstance(spaceId, {
     ...instanceInfo,
     state: instanceInfo.state as InstanceInfo,
     versionId: instanceInfo.deployment.versionId,
@@ -63,17 +140,13 @@ export async function getInstances(spaceId: string, ability?: Ability) {
     include: { deployment: { select: { versionId: true } } },
   });
 
-  const extendedInstances = (await asyncMap(instances, async (i) =>
-    extendInstanceInfo({
+  const extendedInstances = await asyncMap(instances, async (i) =>
+    extendInstance(spaceId, {
       ...i,
       state: i.state as InstanceInfo,
       versionId: i.deployment.versionId,
     }),
-  )) as ExtendedInstance[];
-
-  const instanceWithError = extendedInstances.find(isUserErrorResponse);
-
-  if (instanceWithError) return instanceWithError;
+  );
 
   return extendedInstances as ExtendedInstance[];
 }

--- a/src/management-system-v2/lib/data/instance.ts
+++ b/src/management-system-v2/lib/data/instance.ts
@@ -4,7 +4,7 @@ import db from '@/lib/data/db';
 
 import { getCurrentEnvironment } from '@/components/auth';
 import { InstanceInput, InstanceInputSchema } from '../instance-schema';
-import { UserErrorType, userError } from '../user-error';
+import { UserErrorType, isUserErrorResponse, userError } from '../user-error';
 import { InstanceInfo } from '../engines/deployment';
 import Ability from '../ability/abilityHelper';
 import { ProcessInstance } from '@prisma/client';
@@ -15,6 +15,8 @@ import { getEnvironmentById } from './db/iam/environments';
 import { Role } from './role-schema';
 import { getRoles } from './db/iam/roles';
 import { truthyFilter } from '../typescript-utils';
+
+import { getAllAvailableEngines } from './engines';
 
 type StoredInstance = Omit<ProcessInstance, 'state'> & { state: InstanceInfo; versionId: string };
 
@@ -38,9 +40,12 @@ const getKnownRoles = cache(async (spaceId: string) => {
   return knownRoles;
 });
 
-export async function extendInstance(spaceId: string, instance: StoredInstance) {
+async function extendInstance(spaceId: string, instance: StoredInstance, ability?: Ability) {
   const knownUsers = await getKnownUsers(spaceId);
   const knownRoles = await getKnownRoles(spaceId);
+
+  const reachableEngines = await getAllAvailableEngines(spaceId, ability);
+  if (isUserErrorResponse(reachableEngines)) return reachableEngines;
 
   const mapUser = (userId: string) => {
     const user = knownUsers[userId];
@@ -97,6 +102,10 @@ export async function extendInstance(spaceId: string, instance: StoredInstance) 
   return {
     ...instance,
     initiator,
+    engines: instance.engineIds.map((id) => ({
+      id,
+      online: reachableEngines.some((e) => e.id === id),
+    })),
     state: {
       ...state,
       tokens: state.tokens.map((token) => ({
@@ -131,16 +140,18 @@ export async function getInstance(spaceId: string, instanceId: string, ability?:
 
   if (!instanceInfo) return null;
 
-  return extendInstance(spaceId, {
-    ...instanceInfo,
-    state: instanceInfo.state as InstanceInfo,
-    versionId: instanceInfo.deployment.versionId,
-  });
+  return extendInstance(
+    spaceId,
+    {
+      ...instanceInfo,
+      state: instanceInfo.state as InstanceInfo,
+      versionId: instanceInfo.deployment.versionId,
+    },
+    ability,
+  );
 }
 
-export async function getInstances(spaceId: string, ability?: Ability) {
-  if (!ability) ({ ability } = await getCurrentEnvironment(spaceId));
-
+export async function getInstances(spaceId: string, ability: Ability) {
   if (!ability.can('view', 'Execution'))
     return userError('Invalid Permissions', UserErrorType.PermissionError);
 
@@ -158,11 +169,15 @@ export async function getInstances(spaceId: string, ability?: Ability) {
   });
 
   const extendedInstances = await asyncMap(instances, async (i) =>
-    extendInstance(spaceId, {
-      ...i,
-      state: i.state as InstanceInfo,
-      versionId: i.deployment.versionId,
-    }),
+    extendInstance(
+      spaceId,
+      {
+        ...i,
+        state: i.state as InstanceInfo,
+        versionId: i.deployment.versionId,
+      },
+      ability,
+    ),
   );
 
   return extendedInstances as ExtendedInstance[];

--- a/src/management-system-v2/lib/engines/deployment.ts
+++ b/src/management-system-v2/lib/engines/deployment.ts
@@ -289,7 +289,7 @@ export type InstanceInfo = {
     currentFlowNodeProgress?: { value: number; manual: boolean };
     milestones: { [name: string]: number };
     priority?: number;
-    costsRealSetByOwner?: string;
+    costsRealSetByOwner?: { value: string; unit: string };
     performers?: {
       user: string[];
       roles: string[];
@@ -320,7 +320,7 @@ export type InstanceInfo = {
     };
     executionWasInterrupted?: true;
     priority?: number;
-    costsRealSetByOwner?: string;
+    costsRealSetByOwner?: { value: string; unit: string };
     performers?: {
       user: string[];
       roles: string[];

--- a/src/management-system-v2/lib/executions/instance-server-actions.ts
+++ b/src/management-system-v2/lib/executions/instance-server-actions.ts
@@ -31,10 +31,6 @@ import {
   toBpmnObject,
 } from '@proceed/bpmn-helper';
 import { truthyFilter } from '@/lib/typescript-utils';
-import { getUsersInSpace } from '../data/db/iam/memberships';
-import { getEnvironmentById } from '../data/db/iam/environments';
-import { User } from '@prisma/client';
-import { Environment } from '../data/environment-schema';
 import { getProcessVersion } from '../data/db/process';
 
 export async function getProcessStartForm(
@@ -303,8 +299,6 @@ type VersionCache = Record<
 
 export async function exportInstanceCSV(
   spaceId: string,
-  spaceUsers: User[],
-  space: Environment,
   instanceId: string,
   versionCache: VersionCache,
 ) {
@@ -329,9 +323,29 @@ export async function exportInstanceCSV(
 
   const correspondingVersion = versionCache[instance.versionId];
   const { bpmnObj } = correspondingVersion;
-  const initiator = spaceUsers.find((user) => user.id == instance.initiatorId);
   const definitionInfos = await getDefinitionsInfos(bpmnObj);
-  console.log(correspondingVersion, new Date());
+
+  const { initiator } = instance;
+  let initiatorInfo = {
+    ProcessInstanceInitiatorId: '',
+    ProcessInstanceInitiatorFullName: 'Unknown',
+    ProcessInstanceInitiatorUsername: 'Unknown',
+  };
+  if (initiator) {
+    if (typeof initiator === 'string') {
+      initiatorInfo.ProcessInstanceInitiatorId =
+        initiatorInfo.ProcessInstanceInitiatorUsername =
+        initiatorInfo.ProcessInstanceInitiatorFullName =
+          initiator;
+    } else {
+      (initiatorInfo.ProcessInstanceInitiatorId = initiator.id),
+        (initiatorInfo.ProcessInstanceInitiatorFullName = initiator.fullName);
+      initiatorInfo.ProcessInstanceInitiatorUsername = initiator.username || '';
+    }
+  }
+
+  const initiatorSpace = instance.state.spaceOfProcessInitiator;
+
   return {
     ...instance.state,
     ProcessName: definitionInfos.name,
@@ -340,11 +354,8 @@ export async function exportInstanceCSV(
     ProcessVersionDescription: correspondingVersion.versionDescription,
     ProcessVersionCreatedOn: new Date(correspondingVersion.createdOn).getTime(),
     ProcessVersionBasedOn: correspondingVersion.basedOnVersion,
-    ProcessInstanceInitiatorFullName:
-      initiator && !initiator.isGuest ? `${initiator.firstName} ${initiator.lastName}` : 'Guest',
-    ProcessInstanceInitiatorUsername:
-      initiator && !initiator.isGuest ? initiator.username : 'Guest',
-    ProcessInstanceInitiatorSpaceName: space.isOrganization ? space.name : 'no organization',
+    ...initiatorInfo,
+    ProcessInstanceInitiatorSpaceName: initiatorSpace?.name || 'Unknown',
     ProcessEngineId: instance.state.log[0].machine.id,
     correspondingVersion,
   };
@@ -387,9 +398,6 @@ export async function exportInstanceData(
     Log: null,
   };
 
-  const spaceUsers = await getUsersInSpace(spaceId);
-  const space = await getEnvironmentById(spaceId);
-
   let selectedInstances;
   if (instanceId) {
     selectedInstances = [instanceId];
@@ -404,7 +412,7 @@ export async function exportInstanceData(
   // pasting metadata from VersionInfo
   const instancesWithVersionData = (
     await asyncMap(selectedInstances, async (instanceId) =>
-      exportInstanceCSV(spaceId, spaceUsers, space, instanceId, versionCache),
+      exportInstanceCSV(spaceId, instanceId, versionCache),
     )
   ).filter(truthyFilter);
 
@@ -443,7 +451,6 @@ export async function exportInstanceData(
     processId: 'ProcessId',
     processVersion: 'ProcessVersionId',
     processInstanceId: 'ProcessInstanceId',
-    processInitiator: 'ProcessInstanceInitiatorId',
     spaceIdOfProcessInitiator: 'ProcessInstanceInitiatorSpaceId',
     globalStartTime: 'InstanceStartTime',
     flowElementId: 'ProcessStepId',

--- a/src/management-system-v2/lib/executions/instance-server-actions.ts
+++ b/src/management-system-v2/lib/executions/instance-server-actions.ts
@@ -338,8 +338,8 @@ export async function exportInstanceCSV(
         initiatorInfo.ProcessInstanceInitiatorFullName =
           initiator;
     } else {
-      (initiatorInfo.ProcessInstanceInitiatorId = initiator.id),
-        (initiatorInfo.ProcessInstanceInitiatorFullName = initiator.fullName);
+      initiatorInfo.ProcessInstanceInitiatorId = initiator.id;
+      initiatorInfo.ProcessInstanceInitiatorFullName = initiator.fullName;
       initiatorInfo.ProcessInstanceInitiatorUsername = initiator.username || '';
     }
   }

--- a/src/management-system-v2/lib/executions/instance-server-actions.ts
+++ b/src/management-system-v2/lib/executions/instance-server-actions.ts
@@ -421,16 +421,15 @@ export async function exportInstanceData(
               outgoing?: any;
               incoming?: any;
             };
-            const ActualPerformerId = eventEntry.actualOwner?.[0];
-            const user = spaceUsers.find((user) => user.id == ActualPerformerId);
+            const ActualPerformer = eventEntry.actualOwner?.[0];
             return {
               ...instance,
               ...eventEntry,
               ProcessStepName: eventElement?.name,
               ProcessStepType: eventElement?.$type?.split(':')[1],
-              ActualPerformerId,
-              ActualPerformerName: user ? `${user.firstName} ${user.lastName}` : undefined,
-              ActualPerformerUsername: user ? user.username : undefined,
+              ActualPerformerId: ActualPerformer?.id,
+              ActualPerformerName: ActualPerformer?.fullName,
+              ActualPerformerUsername: ActualPerformer?.username,
               Log: JSON.stringify(eventEntry.variableChanges),
               PreviousProcessStepId: eventElement.incoming?.map((flow: any) => flow.sourceRef.id),
             };

--- a/src/management-system-v2/lib/utils.ts
+++ b/src/management-system-v2/lib/utils.ts
@@ -21,7 +21,7 @@ export function generateDateString(_date?: Date | string, includeTime: boolean =
     return 'Invalid Date';
   }
 
-  return Intl.DateTimeFormat(undefined, options).format();
+  return Intl.DateTimeFormat(undefined, options).format(date);
 }
 
 export function generateNumberString(number?: number, options?: Intl.NumberFormatOptions): string {

--- a/src/management-system-v2/tools/getExecutionInfo.ts
+++ b/src/management-system-v2/tools/getExecutionInfo.ts
@@ -2,9 +2,7 @@ import { z } from 'zod';
 import { type InferSchema } from 'xmcp';
 import { isAccessible, toAuthorizationSchema, verifyCode } from '@/lib/mcp-utils';
 import { isUserErrorResponse } from '@/lib/user-error';
-import { omit, pick } from '@/lib/helpers/javascriptHelpers';
-import { getRoles } from '@/lib/data/roles';
-import { getFullMembersWithRoles } from '@/lib/data/db/iam/memberships';
+import { omit } from '@/lib/helpers/javascriptHelpers';
 import {
   getDefinitionsVersionInformation,
   getElementById,
@@ -65,25 +63,6 @@ export default async function getExecutionInfo({
 
     const instance = storedInstance.state;
 
-    const usersWithRoles = await getFullMembersWithRoles(environmentId, ability);
-
-    let roles = await getRoles(environmentId, ability);
-    if (isUserErrorResponse(roles)) roles = [];
-
-    const users = Object.fromEntries(
-      usersWithRoles.map((user) => [
-        user.id,
-        {
-          ...pick(user, ['id', 'username', 'firstName', 'lastName', 'email']),
-          roles: user.roles.map((r) => pick(r, ['id', 'name', 'description'])),
-        },
-      ]),
-    );
-
-    const idToUser = (id: string) => {
-      if (id in users) return { type: 'user', ...users[id] };
-    };
-
     const versionBpmn = await getProcessBPMN(
       instance.processId,
       environmentId,
@@ -107,7 +86,6 @@ export default async function getExecutionInfo({
     const mappedInstance = {
       // this information is not needed by/already known to the LLM
       ...omit(instance, ['managementSystemLocation', 'spaceIdOfProcessInitiator', 'userTasks']),
-      processInitiator: instance.processInitiator ? idToUser(instance.processInitiator) : undefined,
       tokens: instance.tokens.map((t) => ({
         ...omit(t, ['actualOwner', 'performers']),
         actualPerformers: t.actualOwner,

--- a/src/management-system-v2/tools/getExecutionInfo.ts
+++ b/src/management-system-v2/tools/getExecutionInfo.ts
@@ -87,11 +87,12 @@ export default async function getExecutionInfo({
       // this information is not needed by/already known to the LLM
       ...omit(instance, ['managementSystemLocation', 'spaceIdOfProcessInitiator', 'userTasks']),
       tokens: instance.tokens.map((t) => ({
-        ...omit(t, ['actualOwner', 'performers']),
+        ...omit(t, ['actualOwner', 'performers', 'costsRealSetByOwner']),
         actualPerformers: t.actualOwner,
         potentialPerformers: t.performers,
         // extend with user readable information
         currentFlowElementName: idToName(t.currentFlowElementId),
+        stepExecutionCosts: t.costsRealSetByOwner,
       })),
       variables: Object.fromEntries(
         Object.entries(instance.variables).map(([key, info]) => [
@@ -107,11 +108,12 @@ export default async function getExecutionInfo({
         ]),
       ),
       log: instance.log.map((l) => ({
-        ...omit(l, ['actualOwner', 'performers']),
+        ...omit(l, ['actualOwner', 'performers', 'costsRealSetByOwner']),
         actualPerformers: l.actualOwner,
         potentialPerformers: l.performers,
         // add the name so the llm can show it instead of the id
         flowElementName: idToName(l.flowElementId),
+        stepExecutionCosts: l.costsRealSetByOwner,
       })),
       // remove execution information needed by the engine
       processVersion: versionInfo,

--- a/src/management-system-v2/tools/getExecutionInfo.ts
+++ b/src/management-system-v2/tools/getExecutionInfo.ts
@@ -4,14 +4,13 @@ import { isAccessible, toAuthorizationSchema, verifyCode } from '@/lib/mcp-utils
 import { isUserErrorResponse } from '@/lib/user-error';
 import { omit, pick } from '@/lib/helpers/javascriptHelpers';
 import { getRoles } from '@/lib/data/roles';
-import { truthyFilter } from '@/lib/typescript-utils';
 import { getFullMembersWithRoles } from '@/lib/data/db/iam/memberships';
 import {
   getDefinitionsVersionInformation,
   getElementById,
   toBpmnObject,
 } from '@proceed/bpmn-helper';
-import { ExtendedInstanceInfo, getInstance } from '@/lib/data/instance';
+import { getInstance } from '@/lib/data/instance';
 import { getProcessBPMN } from '@/lib/data/processes';
 import { refetchDeployments } from '@/lib/executions/deployment-server-actions';
 
@@ -80,16 +79,9 @@ export default async function getExecutionInfo({
         },
       ]),
     );
-    const roleMap = Object.fromEntries(
-      roles.map((role) => [role.id, pick(role, ['id', 'name', 'description'])]),
-    );
 
     const idToUser = (id: string) => {
       if (id in users) return { type: 'user', ...users[id] };
-    };
-
-    const idToRole = (id: string) => {
-      if (id in roleMap) return { type: 'role', ...roleMap[id] };
     };
 
     const versionBpmn = await getProcessBPMN(
@@ -109,38 +101,17 @@ export default async function getExecutionInfo({
     };
 
     const versionInfo = await getDefinitionsVersionInformation(bpmnObj);
-
-    const transformPerformerInfo = <
-      T extends {
-        actualOwner?: string[];
-        performers?: ExtendedInstanceInfo['tokens'][number]['performers'];
-      },
-    >(
-      input: T,
-    ) => {
-      return {
-        ...omit(input, ['actualOwner', 'performers']),
-        actualPerformers: input.actualOwner
-          ? input.actualOwner.map(idToUser).filter(truthyFilter)
-          : undefined,
-        potentialPerformers: input.performers
-          ? {
-              user: input.performers.user.map(idToUser).filter(truthyFilter),
-              roles: input.performers.roles.map(idToRole).filter(truthyFilter),
-            }
-          : undefined,
-      };
-    };
-
     // extend the instance information object with data that might be useful to the user and the LLM
     // the most significant changes are mapping from user/role ids to actual user/role information
     // insertions of process element names alongside process element ids
     const mappedInstance = {
       // this information is not needed by/already known to the LLM
-      ...omit(instance, ['managementSystemLocation', 'spaceIdOfProcessInitiator']),
+      ...omit(instance, ['managementSystemLocation', 'spaceIdOfProcessInitiator', 'userTasks']),
       processInitiator: instance.processInitiator ? idToUser(instance.processInitiator) : undefined,
       tokens: instance.tokens.map((t) => ({
-        ...transformPerformerInfo(t),
+        ...omit(t, ['actualOwner', 'performers']),
+        actualPerformers: t.actualOwner,
+        potentialPerformers: t.performers,
         // extend with user readable information
         currentFlowElementName: idToName(t.currentFlowElementId),
       })),
@@ -158,43 +129,14 @@ export default async function getExecutionInfo({
         ]),
       ),
       log: instance.log.map((l) => ({
-        ...transformPerformerInfo(l),
+        ...omit(l, ['actualOwner', 'performers']),
+        actualPerformers: l.actualOwner,
+        potentialPerformers: l.performers,
         // add the name so the llm can show it instead of the id
         flowElementName: idToName(l.flowElementId),
-        actualPerformers: l.actualOwner ? l.actualOwner.map(idToUser) : undefined,
-        potentialPerformers: l.performers
-          ? {
-              user: l.performers.user.map(idToUser),
-              roles: l.performers.roles.map(idToRole),
-            }
-          : undefined,
       })),
       // remove execution information needed by the engine
       processVersion: versionInfo,
-      userTasks: instance.userTasks?.map((uT) => ({
-        // remove execution information needed by the engine
-        ...omit(transformPerformerInfo(uT), [
-          'processInstance',
-          'definitionVersion',
-          '$type',
-          'implementation',
-          'attrs',
-          'resources',
-        ]),
-        // unwrap the name of the file in which the html for the user task is saved
-        fileName: uT.attrs?.['proceed:fileName'],
-        // map engine internal information about potential owners to user readable information
-        potentialPerformers: uT.resources
-          ?.flatMap((r: any) => {
-            try {
-              const { user, roles } = JSON.parse(r.resourceAssignmentExpression.expression.body);
-              return [...user.map(idToUser), ...roles.map(idToRole)];
-            } catch (err) {}
-
-            return undefined;
-          })
-          .filter(truthyFilter),
-      })),
     };
 
     return {

--- a/src/management-system-v2/tools/getExecutionInfo.ts
+++ b/src/management-system-v2/tools/getExecutionInfo.ts
@@ -11,8 +11,7 @@ import {
   getElementById,
   toBpmnObject,
 } from '@proceed/bpmn-helper';
-import { InstanceInfo } from '@/lib/engines/deployment';
-import { getInstance } from '@/lib/data/instance';
+import { ExtendedInstanceInfo, getInstance } from '@/lib/data/instance';
 import { getProcessBPMN } from '@/lib/data/processes';
 import { refetchDeployments } from '@/lib/executions/deployment-server-actions';
 
@@ -114,7 +113,7 @@ export default async function getExecutionInfo({
     const transformPerformerInfo = <
       T extends {
         actualOwner?: string[];
-        performers?: InstanceInfo['tokens'][number]['performers'];
+        performers?: ExtendedInstanceInfo['tokens'][number]['performers'];
       },
     >(
       input: T,


### PR DESCRIPTION
## Summary

Changed the functions that return the instance data from the database to extend the returned information with useful data that would otherwise have to be fetched in addition in many places.

## Details

- the functions "getInstance" and "getInstances" return extended instance objects with information that is useful in multiple places and would otherwise have to be recomputed/fetched in those places
  - the entries that contain user references (in form of ids) now contain the data of the respective users instead (e.g. initiator, "performers", "actualOwner")
  - the entry for the MS space from which an instance was triggered is now mapped from the space's id to an object containing information about the space
  - the array that contained the ids of the engines the instance is executed on is now mapped to an array that contains an object with the id and information if the engine is currently reachable
    - if some engines are not reachable the user is notified in the frontend
  - the planned and actual costs of the process steps are accumulated for the whole instance and added to the instance state
  - timing information was added to the overall instance, token and log entries (planned execution times, actual execution times, potential delays)
  - added a new entry to the instance state that gives concise information about the current execution status ('Running', 'Ended', 'Failed')
  - added a few flags that indicate if the instance is pausing or already paused
