### PR TITLE
MS: Persistent Deployment Activation Info

### DIFF
--- a/src/engine/e2e_tests/process/processEndpoint.e2e.test.js
+++ b/src/engine/e2e_tests/process/processEndpoint.e2e.test.js
@@ -42,6 +42,7 @@ describe('Test process endpoints', () => {
               deploymentDate: expect.any(Number),
               needs: { html: ['userTaskFileName'], imports: [], images: [], scripts: [] },
               versionId: '123',
+              active: false,
             },
           ],
           instances: [],
@@ -61,6 +62,7 @@ describe('Test process endpoints', () => {
             definitionName: 'scriptFileRef',
             deploymentMethod: 'dynamic',
             deploymentDate: expect.any(Number),
+            active: false,
             needs: {
               html: [],
               imports: [],
@@ -86,6 +88,7 @@ describe('Test process endpoints', () => {
             definitionName: 'With Image',
             deploymentMethod: 'dynamic',
             deploymentDate: expect.any(Number),
+            active: false,
             needs: {
               html: ['User_Task_1qjpbcl-1671026484009'],
               imports: [],
@@ -113,6 +116,7 @@ describe('Test process endpoints', () => {
               definitionName: 'basicStatic',
               deploymentMethod: 'dynamic',
               deploymentDate: expect.any(Number),
+              active: false,
               needs: { html: ['userTaskFileName'], imports: [], images: [], scripts: [] },
               versionId: '123',
             },
@@ -137,6 +141,7 @@ describe('Test process endpoints', () => {
               definitionName: 'basicStatic',
               deploymentMethod: 'dynamic',
               deploymentDate: expect.any(Number),
+              active: false,
               needs: { html: ['userTaskFileName'], imports: [], images: [], scripts: [] },
               versionId: '123',
             });
@@ -185,6 +190,7 @@ describe('Test process endpoints', () => {
                 definitionName: 'With Image',
                 deploymentMethod: 'dynamic',
                 deploymentDate: expect.any(Number),
+                active: false,
                 needs: {
                   html: ['User_Task_1qjpbcl-1671026484009'],
                   imports: [],

--- a/src/engine/universal/core/src/engine/engine.js
+++ b/src/engine/universal/core/src/engine/engine.js
@@ -252,7 +252,7 @@ class Engine {
    * @param {string} versionId the version of the process to check
    * @returns {boolean} true if the version is deployed, false if it is known but not active
    */
-  async isProcessVersionDeployed(versionId) {
+  isProcessVersionDeployed(versionId) {
     return this._versionProcessMapping[versionId]?.isDeployed() ?? false;
   }
 

--- a/src/engine/universal/distribution/src/routes/ProcessInstanceRoutes.js
+++ b/src/engine/universal/distribution/src/routes/ProcessInstanceRoutes.js
@@ -482,7 +482,7 @@ module.exports = (path, management) => {
       statusCode: 200,
       mimeType: 'application/json',
       response: JSON.stringify({
-        active: engine ? await engine.isProcessVersionDeployed(version) : false,
+        active: engine ? engine.isProcessVersionDeployed(version) : false,
       }),
     };
   });

--- a/src/engine/universal/distribution/src/routes/ProcessStorageRoutes.js
+++ b/src/engine/universal/distribution/src/routes/ProcessStorageRoutes.js
@@ -16,6 +16,12 @@ module.exports = (path, management) => {
 
     process.instances = await getAllInstances(management, definitionId);
 
+    const engine = management.getEngineWithDefinitionId(definitionId);
+    process.versions = process.versions.map((version) => ({
+      ...version,
+      active: engine ? engine.isProcessVersionDeployed(version.versionId) : false,
+    }));
+
     return process;
   }
 

--- a/src/engine/universal/distribution/src/routes/ProcessStorageRoutes.js
+++ b/src/engine/universal/distribution/src/routes/ProcessStorageRoutes.js
@@ -65,10 +65,19 @@ module.exports = (path, management) => {
   });
 
   network.get(`${path}/:definitionId/versions/:version`, { cors: true }, async (req) => {
-    const { definitionId, version } = req.params;
+    const { definitionId, version: versionId } = req.params;
+
+    const engine = management.getEngineWithDefinitionId(definitionId);
+
+    let version = await db.getProcessVersionInfo(definitionId, versionId);
+
+    version = {
+      ...version,
+      active: engine ? engine.isProcessVersionDeployed(version.versionId) : false,
+    };
 
     try {
-      return JSON.stringify(await db.getProcessVersionInfo(definitionId, version));
+      return JSON.stringify(version);
     } catch ({ message }) {
       throw new APIError(404, message);
     }

--- a/src/management-system-v2/app/(dashboard)/[environmentId]/(automation)/executions/[processId]/process-deployment-view.tsx
+++ b/src/management-system-v2/app/(dashboard)/[environmentId]/(automation)/executions/[processId]/process-deployment-view.tsx
@@ -32,10 +32,7 @@ import StartFormModal from './start-form-modal';
 import useInstanceVariables from './use-instance-variables';
 import { inlineScript, inlineUserTaskData } from '@proceed/user-task-helper';
 import { toBpmnObject, getElementsByTagName } from '@proceed/bpmn-helper';
-import {
-  getProcessActivationStatus,
-  changeDeploymentActivation,
-} from '@/lib/executions/deployment-server-actions';
+import { changeDeploymentActivation } from '@/lib/executions/deployment-server-actions';
 import { getGlobalVariablesForHTML } from '@/lib/tasks/server-actions';
 import { useSession } from 'next-auth/react';
 import { useEnvironment } from '@/components/auth-can';
@@ -190,21 +187,6 @@ export default function ProcessDeploymentView({ processId }: { processId: string
     return { instanceIsRunning, instanceIsPausing, instanceIsPaused };
   }, [currentInstance]);
 
-  const {
-    data: isProcessActivated,
-    isFetching: isActivationLoading,
-    refetch: refetchActivation,
-  } = useQuery({
-    queryFn: async () => {
-      if (!currentVersion) return false;
-      const status = await getProcessActivationStatus(processId, spaceId, currentVersion.id);
-
-      if (isUserErrorResponse(status)) return false;
-      return status;
-    },
-    queryKey: ['processActivation', spaceId, processId, currentVersion],
-  });
-
   const { data: selectedBpmn } = useQuery({
     queryFn: async () => {
       const bpmn = await getProcessBPMN(processId, spaceId, currentVersion?.id);
@@ -259,6 +241,11 @@ export default function ProcessDeploymentView({ processId }: { processId: string
     refreshTokens();
     refreshColoring();
   }, [refreshTokens, refreshColoring]);
+
+  const isProcessActivated = useMemo(() => {
+    if (!deployments || !currentVersion) return false;
+    return !!deployments.some((d) => d.versionId === currentVersion.id && d.active);
+  }, [deployments, currentVersion]);
 
   if (!deployments || !selectedBpmn) {
     return (
@@ -446,7 +433,7 @@ export default function ProcessDeploymentView({ processId }: { processId: string
                 >
                   <Button
                     type="text"
-                    loading={togglingActivation || isActivationLoading}
+                    loading={togglingActivation}
                     icon={
                       isProcessActivated ? (
                         <span className={styles.SpinIcon}>
@@ -463,7 +450,7 @@ export default function ProcessDeploymentView({ processId }: { processId: string
                       await wrapServerCall({
                         fn: () =>
                           changeDeploymentActivation(processId, spaceId, versionId, nextState),
-                        onSuccess: () => refetchActivation(),
+                        onSuccess: () => refetchDeployments(),
                       });
                       setTogglingActivation(false);
                     }}

--- a/src/management-system-v2/app/(dashboard)/[environmentId]/(automation)/executions/[processId]/process-deployment-view.tsx
+++ b/src/management-system-v2/app/(dashboard)/[environmentId]/(automation)/executions/[processId]/process-deployment-view.tsx
@@ -205,7 +205,7 @@ export default function ProcessDeploymentView({ processId }: { processId: string
         });
         setHasTimerStartEvents(hasTimer);
         setHasPlainStartEvents(hasPlain);
-      } catch (_) { }
+      } catch (_) {}
     }
 
     initStartEventInfo();
@@ -309,11 +309,11 @@ export default function ProcessDeploymentView({ processId }: { processId: string
                       },
                       ...(selectedVersion
                         ? [
-                          {
-                            label: '<none>',
-                            key: '-2',
-                          },
-                        ]
+                            {
+                              label: '<none>',
+                              key: '-2',
+                            },
+                          ]
                         : []),
                       ...deployments.map(({ version }) => ({
                         label: version.name,

--- a/src/management-system-v2/lib/deployment-schema.ts
+++ b/src/management-system-v2/lib/deployment-schema.ts
@@ -6,6 +6,7 @@ export const DeploymentInputSchema = z.object({
   deployTime: z.date(),
   removeTime: z.date().nullable().default(null),
   toRemove: z.boolean().default(false),
+  active: z.boolean().default(false),
   engineIds: z.string().array(),
 });
 

--- a/src/management-system-v2/lib/engines/deployment.ts
+++ b/src/management-system-v2/lib/engines/deployment.ts
@@ -265,6 +265,7 @@ export type VersionInfo = {
   versionId: string;
   versionName: string;
   versionDescription: string;
+  active: boolean;
 };
 export type InstanceInfo = {
   processId: string;

--- a/src/management-system-v2/lib/executions/deployment-server-actions.ts
+++ b/src/management-system-v2/lib/executions/deployment-server-actions.ts
@@ -43,6 +43,10 @@ export async function deployProcess(
 
     const { userId } = await getCurrentUser();
 
+    const allEngines = await getAllAvailableEngines(spaceId);
+
+    if (isUserErrorResponse(allEngines)) return allEngines;
+
     let engines: Engine[];
     if (_forceEngine === 'PROCEED') {
       // force that only proceed engines are supposed to be used
@@ -52,12 +56,7 @@ export async function deployProcess(
 
       engines = res;
     } else {
-      // get all available engines
-      const res = await getAllAvailableEngines(spaceId);
-
-      if (isUserErrorResponse(res)) return res;
-
-      engines = res;
+      engines = allEngines;
 
       if (_forceEngine) {
         // force a specific engine if it is available
@@ -96,15 +95,20 @@ export async function deployProcess(
       deployerId: userId,
       deployTime: new Date(),
       engineIds: deployedTo.map((engine) => engine.id),
+      active: true,
     });
 
     // deactivate the process on all engines that have a deployment but which were not target of the
     // new deployment
     await Promise.allSettled(
-      processAlreadyDeployedInfo.map(async (deployment) => {
-        // TODO: consider all engines to deactivate deployments on engines that are not "forced" here
-        if (deployment.engine && !deployedTo.some((engine) => engine.id === deployment.engineId)) {
-          await _changeDeploymentActivation(deployment.engine, definitionId, undefined, false);
+      alreadyDeployed.map(async (deployment) => {
+        if (deployment.active && !deployedTo.some((e) => e.id === deployment.engineId)) {
+          await updateDeployment(spaceId, deployment.id, { active: false });
+
+          const engine = allEngines.find((e) => e.id === deployment.engineId);
+          if (engine) {
+            await _changeDeploymentActivation(engine, definitionId, undefined, false);
+          }
         }
       }),
     );
@@ -130,13 +134,13 @@ export async function removeDeployment(definitionId: string, spaceId: string) {
           // engine => we don't need to call this for every version but only once per engine per
           // process
           await removeDeploymentFromMachines([engine], deployment.processId);
-          await updateDeployment(spaceId, deployment.id, { removeTime: new Date() });
+          await updateDeployment(spaceId, deployment.id, { removeTime: new Date(), active: false });
           return;
         }
       } catch (err) {}
 
       // if removing the deployment is currently not possible mark it for automatic removal
-      await updateDeployment(spaceId, deployment.id, { toRemove: true });
+      await updateDeployment(spaceId, deployment.id, { toRemove: true, active: false });
     });
   } catch (e) {
     const message = getErrorMessage(e);
@@ -185,21 +189,59 @@ export async function changeDeploymentActivation(
   try {
     let deployments = await getProcessDeployments(spaceId, definitionId);
     if (isUserErrorResponse(deployments)) return deployments;
+
     const versionDeployments = deployments.filter((deployment) => deployment.versionId === version);
+    if (!versionDeployments.length) return userError('This version is not deployed');
 
-    if (!deployments.length) return userError('This version is not deployed');
+    // exit early if executing the function will/should not change the already existing activation state
+    if (
+      (value === true && versionDeployments.some((d) => d.active === true)) ||
+      (value === false && versionDeployments.every((d) => d.active === false))
+    ) {
+      return;
+    }
 
-    let availableEngines = await getAllAvailableEngines(spaceId);
-    if (isUserErrorResponse(availableEngines)) return availableEngines;
+    let deploymentsToChange = versionDeployments.filter((d) => d.active !== value);
 
-    availableEngines = availableEngines.filter((e) =>
-      versionDeployments.some((d) => d.engineId === e.id),
-    );
+    const engines = await getAllAvailableEngines(spaceId);
 
-    if (!availableEngines.length)
-      throw new Error('There is no available engine with the requested process version.');
+    if (isUserErrorResponse(engines)) return engines;
 
-    await _changeDeploymentActivation(availableEngines[0], definitionId, version, value);
+    if (value === true) {
+      let activated = false;
+      for (const deployment of deploymentsToChange) {
+        const engine = engines.find((e) => e.id === deployment.engineId);
+        if (engine) {
+          try {
+            // activate the process on a single machine so we do not spawn new instances on multiple machines at once
+            await _changeDeploymentActivation(engine, definitionId, version, true);
+            await updateDeployment(spaceId, deployment.id, { active: true });
+            activated = true;
+            break;
+          } catch (err) {}
+        }
+        if (activated) break;
+      }
+
+      if (!activated) return userError('Could not reach any engine to activate the deployment.');
+
+      // if we activate a deployment we need to deactivate all deployments of other versions that are currently
+      // active
+      deploymentsToChange = deployments.filter((d) => d.versionId !== version && d.active);
+    }
+
+    await asyncForEach(deploymentsToChange, async (d) => {
+      // mark the deployment as inactive locally
+      await updateDeployment(spaceId, d.id, { active: false });
+
+      try {
+        // if deactivating the deployment fails the refetch loop should deactivate it due to the
+        // mismatch between the locally stored activation value and the activation value from the
+        // engine
+        const engine = engines.find((e) => e.id === d.engineId);
+        if (engine) await _changeDeploymentActivation(engine, definitionId, version, false);
+      } catch (err) {}
+    });
   } catch (e) {
     const message = getErrorMessage(e);
     return userError(message);
@@ -272,6 +314,7 @@ export async function refetchDeployments() {
             id: true,
             engineId: true,
             toRemove: true,
+            active: true,
             version: {
               select: { id: true, processId: true, process: { select: { environmentId: true } } },
             },
@@ -337,6 +380,32 @@ export async function refetchDeployments() {
               ]),
             );
 
+            await asyncForEach(res, async (p) => {
+              await asyncForEach(p.versions, async (v) => {
+                try {
+                  const deployment =
+                    engineIdsWithDeployments[e.id]?.[p.definitionId]?.[v.versionId];
+                  if (!deployment) return;
+
+                  if (v.active !== deployment.active) {
+                    // mismatch of the active state on the engine and the locally stored active
+                    // state => change the state on the engine
+                    console.log('Mismatch in active state', deployment.active, v.active);
+                    await _changeDeploymentActivation(
+                      e,
+                      p.definitionId,
+                      v.versionId,
+                      deployment.active,
+                    );
+                  }
+                } catch (err) {
+                  console.error(
+                    `Failed to update the active state for the deployment of process (id: ${p.definitionId}) version (id: ${v.versionId}) on engine (id: ${e.id}).`,
+                  );
+                }
+              });
+            });
+
             // TODO: when we want to handle instances that move to other engines automatically, we
             // will have to change this logic since it assumes that all available data of the instance
             // can be found on the engine it was started on
@@ -389,7 +458,7 @@ export async function refetchDeployments() {
             ...removedOnEngine.map(async (deployment) => {
               await tx.processDeployment.update({
                 where: { id: deployment.id },
-                data: { removeTime: new Date(), toRemove: false },
+                data: { removeTime: new Date(), toRemove: false, active: false },
               });
             }),
             ...instanceUpdates.map(async ({ id, state }) => {

--- a/src/management-system-v2/lib/executions/deployment-server-actions.ts
+++ b/src/management-system-v2/lib/executions/deployment-server-actions.ts
@@ -197,7 +197,7 @@ export async function changeDeploymentActivation(
       deploymentsToChange = deployments.filter((d) => d.versionId !== version && d.active);
     }
 
-    await asyncForEach(deploymentsToChange, async (d) => {
+    const res = await asyncMap(deploymentsToChange, async (d) => {
       // mark the deployment as inactive locally
       await updateDeployment(spaceId, d.id, { active: false });
 
@@ -206,9 +206,19 @@ export async function changeDeploymentActivation(
         // mismatch between the locally stored activation value and the activation value from the
         // engine
         const engine = engines.find((e) => e.id === d.engineId);
-        if (engine) await _changeDeploymentActivation(engine, definitionId, version, false);
+        if (engine) {
+          await _changeDeploymentActivation(engine, definitionId, version, false);
+          return true;
+        }
       } catch (err) {}
+      return false;
     });
+
+    if (res.some((success) => !success)) {
+      return userError(
+        `Some deployments of${value ? ' other versions of' : ''} this process could not be deactivated. The system will try to deactivate them as soon as possible but they might spawn new instances in the meantime.`,
+      );
+    }
   } catch (e) {
     const message = getErrorMessage(e);
     return userError(message);

--- a/src/management-system-v2/lib/executions/deployment-server-actions.ts
+++ b/src/management-system-v2/lib/executions/deployment-server-actions.ts
@@ -148,38 +148,6 @@ export async function removeDeployment(definitionId: string, spaceId: string) {
   }
 }
 
-export async function getProcessActivationStatus(
-  definitionId: string,
-  spaceId: string,
-  version: string,
-) {
-  try {
-    let deployments = await getProcessDeployments(spaceId, definitionId);
-    if (isUserErrorResponse(deployments)) return deployments;
-    deployments = deployments.filter((deployment) => deployment.versionId === version);
-
-    const availableEngines = await getAllAvailableEngines(spaceId);
-    if (isUserErrorResponse(availableEngines)) return availableEngines;
-
-    const res = await asyncMap(deployments, async (deployment) => {
-      try {
-        const engine = availableEngines.find((aE) => aE.id === deployment.engineId);
-
-        if (engine) {
-          return await getDeploymentActivation(engine, definitionId, version);
-        }
-      } catch (err) {}
-
-      return false;
-    });
-
-    return res.some((isActive) => isActive);
-  } catch (e) {
-    const message = getErrorMessage(e);
-    return userError(message);
-  }
-}
-
 export async function changeDeploymentActivation(
   definitionId: string,
   spaceId: string,

--- a/src/management-system-v2/lib/executions/deployment-server-actions.ts
+++ b/src/management-system-v2/lib/executions/deployment-server-actions.ts
@@ -188,7 +188,6 @@ export async function changeDeploymentActivation(
             break;
           } catch (err) {}
         }
-        if (activated) break;
       }
 
       if (!activated) return userError('Could not reach any engine to activate the deployment.');

--- a/src/management-system-v2/prisma/migrations/20260528143105_persistent_deployment_activation_information/migration.sql
+++ b/src/management-system-v2/prisma/migrations/20260528143105_persistent_deployment_activation_information/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "process_deployment" ADD COLUMN     "active" BOOLEAN NOT NULL DEFAULT false;

--- a/src/management-system-v2/prisma/schema.prisma
+++ b/src/management-system-v2/prisma/schema.prisma
@@ -449,6 +449,10 @@ model ProcessDeployment {
   // when the engine becomes available again the deployment should be removed from it and then the "removeTime" entry should be set
   toRemove      Boolean    @default(false)
 
+  // marks a deployment as active if it is allowed to spawn new instances automatically on the engines it is deployed to
+  // this can happen when the bpmn contains typed start events like timer start events
+  active        Boolean    @default(false)
+
   // This is not the "Engine" which we store here in the DB but the actual engine the process is deployed on
   // an "Engine" can represent multiple engines in case it is an "MQTT-Engine"
   engineId      String


### PR DESCRIPTION
## Summary

Storing information about the activation status of a deployment in the deployment table of the database. This way we do not need to query the engine to know if a deployment is allowed to spawn instances automatically.

## Details

-  the deployment information returned by the the engine is extended with a flag in each deployed version that indicates if the version is allowed to spawn new instances automatically
- when a process is deployed or when a deployments' activation status is changed in the MS, the MS will store the value of the activation state in the deployment table in the database
- if the MS recognizes a mismatch in the activation state of a deployment on an engine and its locally stored activation state it will automatically change the activation state on the engine to match that from the MS
  - if a user tries to deactivate a deployment on an engine that is currently not reachable the new state will be written to the database and updated on the engine as soon as it is reachable again
- the deployment view in the frontend of the MS uses the activation information from the deployment data it already has instead of fetching it from the engine
