### PR TITLE
MS: Store Engine Data In Database

### DIFF
--- a/src/management-system-v2/app/layout.tsx
+++ b/src/management-system-v2/app/layout.tsx
@@ -9,6 +9,7 @@ import App from '@/components/app';
 import classNames from 'classnames';
 import { getPublicMSConfig } from '@/lib/ms-config/ms-config';
 import DeploymentRefetchBoundary from './deployment-refetch-boundary';
+import EngineRefetchBoundary from './transfer-processes/engine-refetch-boundary';
 
 const inter = Inter({ subsets: ['latin'], variable: '--inter' });
 
@@ -26,12 +27,17 @@ const RootLayout: FC<RootLayoutProps> = async ({ children }) => {
   return (
     <html lang="en">
       <body className={classNames(inter.variable, myFont.variable)}>
-        <DeploymentRefetchBoundary
+        <EngineRefetchBoundary
           enabled={publicEnv.PROCEED_PUBLIC_PROCESS_AUTOMATION_ACTIVE}
-          interval={publicEnv.PROCEED_PUBLIC_DEPLOYMENT_REFETCHING_INTERVAL}
+          interval={5}
         >
-          <App env={publicEnv}>{children}</App>
-        </DeploymentRefetchBoundary>
+          <DeploymentRefetchBoundary
+            enabled={publicEnv.PROCEED_PUBLIC_PROCESS_AUTOMATION_ACTIVE}
+            interval={publicEnv.PROCEED_PUBLIC_DEPLOYMENT_REFETCHING_INTERVAL}
+          >
+            <App env={publicEnv}>{children}</App>
+          </DeploymentRefetchBoundary>
+        </EngineRefetchBoundary>
       </body>
     </html>
   );

--- a/src/management-system-v2/app/transfer-processes/engine-refetch-boundary.tsx
+++ b/src/management-system-v2/app/transfer-processes/engine-refetch-boundary.tsx
@@ -1,0 +1,34 @@
+'use client';
+
+import { refetchEngines } from '@/lib/engines/server-actions';
+import { useEffect } from 'react';
+
+const EngineRefetchBoundary: React.FC<
+  React.PropsWithChildren<{ enabled?: boolean; interval: number }>
+> = ({ children, enabled = false, interval }) => {
+  useEffect(() => {
+    // as long as as user is connected they will trigger the backend to keep the engine
+    // information up to date
+    let keepRunning = true;
+    let timeoutId: ReturnType<typeof setTimeout>;
+
+    async function refetchCycle() {
+      if (!keepRunning) return;
+      await refetchEngines();
+
+      // the user sets the interval in seconds so we have to convert to milliseconds
+      timeoutId = setTimeout(refetchCycle, interval * 1000);
+    }
+
+    if (enabled && interval) refetchCycle();
+
+    return () => {
+      keepRunning = false;
+      clearTimeout(timeoutId);
+    };
+  }, [enabled, interval]);
+
+  return children;
+};
+
+export default EngineRefetchBoundary;

--- a/src/management-system-v2/components/engine-connections-list.tsx
+++ b/src/management-system-v2/components/engine-connections-list.tsx
@@ -12,7 +12,7 @@ import {
 import ConnectionsModal from './engines-modal';
 import {
   updateEngineConnection,
-  addEngineConnections,
+  addEngineConnection,
   deleteEngineConnection,
 } from '@/lib/data/engines';
 import { useEnvironment } from '@/components/auth-can';
@@ -84,7 +84,7 @@ const EngineConnectionsList = ({
     await wrapServerCall({
       fn: (): Promise<any> => {
         if (editData) return updateEngineConnection(editData.id, data, spaceId);
-        else return addEngineConnections([data], spaceId);
+        else return addEngineConnection(data, spaceId);
       },
       onSuccess: () => {
         app.message.success({ content: editData ? 'Engine updated' : 'Engine added' });

--- a/src/management-system-v2/lib/data/engines.ts
+++ b/src/management-system-v2/lib/data/engines.ts
@@ -4,6 +4,7 @@ import Ability, { UnauthorizedError } from '@/lib/ability/abilityHelper';
 import { EngineConnectionInput, EngineConnectionInputSchema } from '@/lib/space-engine-schema';
 import { getCurrentEnvironment, getCurrentUser } from '@/components/auth';
 import {
+  UserError,
   getErrorMessage,
   isUserErrorResponse,
   permissionDenied,
@@ -12,7 +13,7 @@ import {
 } from '../user-error';
 import { resolveEngines } from '../engines/engine-connections-helpers';
 import { Engine, SpaceEngine } from '../engines/types';
-import { SystemAdmin } from '@prisma/client';
+import { EngineConnection, Prisma, SystemAdmin } from '@prisma/client';
 
 import db from '@/lib/data/db';
 import { toCaslResource } from '../ability/caslAbility';
@@ -27,7 +28,7 @@ export async function getEngineConnections(
     throw new UnauthorizedError();
 
   const connections = await db.engineConnection.findMany({
-    where: { environmentId: environmentId },
+    where: { environmentId: environmentId, removed: false },
   });
 
   return ability ? ability.filter('view', 'Machine', connections) : connections;
@@ -47,6 +48,7 @@ export async function getEngineConnectionById(
     where: {
       environmentId: environmentId,
       id: connectionId,
+      removed: false,
     },
   });
 
@@ -138,45 +140,107 @@ export async function getEngineIfAvailable(
   return engines.find((e) => e.id === engineId);
 }
 
-const EngineConnectionArraySchema = EngineConnectionInputSchema.array();
-export async function addEngineConnections(
-  connectionsInput: EngineConnectionInput[],
+export async function addEngineConnection(
+  connectionInput: EngineConnectionInput,
   environmentId: string | null,
-) {
-  const newConnections = EngineConnectionArraySchema.safeParse(connectionsInput);
-
-  if (!newConnections.success) {
+  tx?: Prisma.TransactionClient,
+  skipAbilityCheck = false,
+): Promise<void | { error: UserError }> {
+  if (!tx) {
+    return db.$transaction(async (tx) =>
+      addEngineConnection(connectionInput, environmentId, tx, skipAbilityCheck),
+    );
+  }
+  const newConnection = EngineConnectionInputSchema.safeParse(connectionInput);
+  if (!newConnection.success) {
     return schemaValidationError();
   }
 
   const user = await getCurrentUser();
 
-  if (environmentId) {
-    const { ability } = await getCurrentEnvironment(environmentId);
-    if (!ability.can('create', 'Machine')) return permissionDenied();
-  } else if (!user.systemAdmin) {
-    // connections without an environmentId are PROCEED engines
-    return permissionDenied();
+  if (!skipAbilityCheck) {
+    if (environmentId) {
+      const { ability } = await getCurrentEnvironment(environmentId);
+      if (!ability.can('create', 'Machine')) return permissionDenied();
+    } else if (!user.systemAdmin) {
+      // connections without an environmentId are PROCEED engines
+      return permissionDenied();
+    }
   }
 
   try {
-    const res = await db.engineConnection.createMany({
-      data: newConnections.data.map((e) => ({ ...e, environmentId: environmentId ?? null })),
+    const existingConnection = await tx.engineConnection.findFirst({
+      where: { address: newConnection.data.address, environmentId },
     });
 
-    return res;
+    if (existingConnection && !existingConnection.removed) {
+      // we allow only one active connection entry with a specific address in a space
+      return userError('There is already an engine with the same address.');
+    }
+
+    const reachableEngines = await resolveEngines([
+      { ...newConnection.data, environmentId } as EngineConnection,
+    ]);
+
+    const connection = {
+      ...newConnection.data,
+      environmentId,
+      removed: false,
+    };
+
+    if (existingConnection) {
+      // reactivate an older entry if the address was already used before but removed
+      await tx.engineConnection.update({
+        where: { id: existingConnection.id },
+        data: {
+          ...connection,
+          engines: {
+            upsert: reachableEngines.map((engine) => ({
+              where: {
+                engineId_connectionId: { engineId: engine.id, connectionId: existingConnection.id },
+              },
+              update: {},
+              create: {
+                engine: {
+                  connectOrCreate: {
+                    where: { id: engine.id },
+                    create: { id: engine.id, name: engine.name },
+                  },
+                },
+              },
+            })),
+          },
+        },
+      });
+    } else {
+      await tx.engineConnection.create({
+        data: {
+          ...connection,
+          engines: {
+            create: reachableEngines.map((engine) => ({
+              engine: {
+                connectOrCreate: {
+                  where: { id: engine.id },
+                  create: { id: engine.id, name: engine.name },
+                },
+              },
+            })),
+          },
+        },
+      });
+    }
   } catch (e) {
+    console.log(e);
     return userError('Error saving engine connections.');
   }
 }
 
-const PartialEngineConnectionInputSchema = EngineConnectionInputSchema.partial();
 export async function updateEngineConnection(
   connectionId: string,
   connectionInput: Partial<EngineConnectionInput>,
   environmentId: string | null,
 ) {
-  const newConnectionData = PartialEngineConnectionInputSchema.safeParse(connectionInput);
+  const newConnectionData = EngineConnectionInputSchema.partial().safeParse(connectionInput);
 
   if (!newConnectionData.success) {
     return schemaValidationError();
@@ -184,14 +248,21 @@ export async function updateEngineConnection(
 
   const user = await getCurrentUser();
 
+  const connection = await db.engineConnection.findUnique({
+    where: {
+      environmentId: environmentId,
+      id: connectionId,
+    },
+  });
+  if (!connection) return userError('Engine not found');
+
   if (environmentId) {
     const { ability } = await getCurrentEnvironment(environmentId);
 
-    const engine = await getEngineConnectionById(connectionId, environmentId);
-    if (!engine) return userError('Engine not found');
-
     if (
-      !ability.can('update', toCaslResource('Machine', engine), { environmentId: environmentId! })
+      !ability.can('update', toCaslResource('Machine', connection), {
+        environmentId: environmentId!,
+      })
     ) {
       return permissionDenied();
     }
@@ -201,33 +272,55 @@ export async function updateEngineConnection(
   }
 
   try {
-    const res = await db.engineConnection.update({
-      data: newConnectionData.data,
-      where: {
-        environmentId,
-        id: connectionId,
-      },
-    });
-
-    return res;
+    const newAddress = newConnectionData.data.address;
+    if (newAddress && newAddress !== connection.address) {
+      return await db.$transaction(async (tx) => {
+        await deleteEngineConnection(connection.id, environmentId, tx, true);
+        const res = await addEngineConnection(
+          {
+            name: connection.name,
+            ...newConnectionData.data,
+            address: newAddress,
+          },
+          environmentId,
+        );
+        if (isUserErrorResponse(res)) throw res.error;
+      });
+    } else {
+      return await db.engineConnection.update({
+        data: newConnectionData.data,
+        where: {
+          environmentId,
+          id: connectionId,
+        },
+      });
+    }
   } catch (e) {
     return userError('Error updating engine connection.');
   }
 }
 
-export async function deleteEngineConnection(engineId: string, environmentId: string | null) {
+export async function deleteEngineConnection(
+  engineId: string,
+  environmentId: string | null,
+  tx?: Prisma.TransactionClient,
+  skipAbilityCheck = false,
+) {
+  const dbMutator = tx || db;
   const user = await getCurrentUser();
 
   // engines without an environmentId are PROCEED engines
-  if (environmentId === null && !user.systemAdmin) {
+  if (skipAbilityCheck && environmentId === null && !user.systemAdmin) {
     return permissionDenied();
   }
 
-  if (environmentId) {
-    const { ability } = await getCurrentEnvironment(environmentId);
+  const connection = await dbMutator.engineConnection.findUnique({
+    where: { id: engineId, environmentId },
+  });
+  if (!connection) return userError('Engine not found');
 
-    const connection = await getEngineConnectionById(engineId, environmentId);
-    if (!connection) return userError('Engine not found');
+  if (environmentId && !skipAbilityCheck) {
+    const { ability } = await getCurrentEnvironment(environmentId);
 
     if (
       !ability.can('delete', toCaslResource('Machine', connection), {
@@ -239,15 +332,20 @@ export async function deleteEngineConnection(engineId: string, environmentId: st
   }
 
   try {
-    const res = await db.engineConnection.delete({
+    const res = await db.engineConnection.update({
       where: {
         environmentId: environmentId,
         id: engineId,
+      },
+      data: {
+        // mark the connection as removed but keep it for future reference in audit trails
+        removed: true,
       },
     });
 
     return res;
   } catch (e) {
-    return userError('Error getting space engines');
+    console.log(e);
+    return userError('Error deleting engine connection');
   }
 }

--- a/src/management-system-v2/lib/data/engines.ts
+++ b/src/management-system-v2/lib/data/engines.ts
@@ -188,6 +188,8 @@ export async function addEngineConnection(
       removed: false,
     };
 
+    const currentDate = new Date();
+
     if (existingConnection) {
       // reactivate an older entry if the address was already used before but removed
       await tx.engineConnection.update({
@@ -199,8 +201,10 @@ export async function addEngineConnection(
               where: {
                 engineId_connectionId: { engineId: engine.id, connectionId: existingConnection.id },
               },
-              update: {},
+              update: { reachable: true, lastContact: currentDate },
               create: {
+                reachable: true,
+                lastContact: currentDate,
                 engine: {
                   connectOrCreate: {
                     where: { id: engine.id },
@@ -218,6 +222,8 @@ export async function addEngineConnection(
           ...connection,
           engines: {
             create: reachableEngines.map((engine) => ({
+              reachable: true,
+              lastContact: currentDate,
               engine: {
                 connectOrCreate: {
                   where: { id: engine.id },

--- a/src/management-system-v2/lib/data/engines.ts
+++ b/src/management-system-v2/lib/data/engines.ts
@@ -236,7 +236,7 @@ export async function addEngineConnection(
       });
     }
   } catch (e) {
-    console.log(e);
+    console.error(`Failed to add a new engine connection: ${e}`);
     return userError('Error saving engine connections.');
   }
 }
@@ -302,6 +302,7 @@ export async function updateEngineConnection(
       });
     }
   } catch (e) {
+    console.error(`Failed to update an engine connection: ${e}`);
     return userError('Error updating engine connection.');
   }
 }
@@ -351,7 +352,7 @@ export async function deleteEngineConnection(
 
     return res;
   } catch (e) {
-    console.log(e);
+    console.error(`Failed to remove an engine connection: ${e}`);
     return userError('Error deleting engine connection');
   }
 }

--- a/src/management-system-v2/lib/engines/engine-connections-helpers.ts
+++ b/src/management-system-v2/lib/engines/engine-connections-helpers.ts
@@ -7,6 +7,8 @@ import {
 } from './endpoints/mqtt-endpoints';
 import endpointBuilder from './endpoints/endpoint-builder';
 import { httpRequest } from './endpoints/http-endpoints';
+import { asyncMap } from '../helpers/javascriptHelpers';
+import { engineRequest } from './endpoints';
 
 const mqttTimeout = 2000;
 
@@ -34,20 +36,40 @@ async function getMqttEngines(connection: EngineConnection): Promise<MqttEngine[
   // NOTE: not awaiting this could be a problem if hosted on vercel
   client.endAsync();
 
-  return Array.from(engineMap.values())
+  const reachableEngines = Array.from(engineMap.values())
     .filter((v) => v.running)
     .map((e) => ({
       id: e.id,
-      type: 'mqtt',
-      spaceEngine: true,
+      type: 'mqtt' as const,
+      spaceEngine: true as const,
       brokerAddress: connection.address,
     }));
+
+  const extendedEngineData = await asyncMap(reachableEngines, async (e) => {
+    let name;
+
+    try {
+      ({ name } = await engineRequest({
+        engine: e,
+        method: 'get',
+        endpoint: '/machine/:properties',
+        pathParams: { properties: 'name' },
+      }));
+    } catch (err) {}
+
+    return {
+      ...e,
+      name,
+    };
+  });
+
+  return extendedEngineData;
 }
 
 async function getHttpEngine(connection: EngineConnection): Promise<[HttpEngine]> {
-  const { id } = await httpRequest(
+  const { id, name } = await httpRequest(
     connection.address,
-    endpointBuilder('get', '/machine/:properties', { pathParams: { properties: 'id' } }),
+    endpointBuilder('get', '/machine/:properties', { pathParams: { properties: 'id,name' } }),
     'GET',
   );
 
@@ -55,6 +77,7 @@ async function getHttpEngine(connection: EngineConnection): Promise<[HttpEngine]
     {
       type: 'http',
       id,
+      name,
       address: connection.address,
       spaceEngine: true,
     },

--- a/src/management-system-v2/lib/engines/server-actions.ts
+++ b/src/management-system-v2/lib/engines/server-actions.ts
@@ -1,0 +1,75 @@
+'use server';
+
+import db from '@/lib/data/db';
+
+import { getSharedRefetch } from '../shared-refetch';
+import { resolveEngines } from './engine-connections-helpers';
+import { asyncMap } from '../helpers/javascriptHelpers';
+
+async function refetchFn() {
+  try {
+    const connections = await db.engineConnection.findMany({
+      include: { engines: { include: { engine: true } } },
+    });
+
+    const requests = await Promise.allSettled(connections.map(async (c) => resolveEngines([c])));
+
+    const changes = await asyncMap(connections, async (c, index) => {
+      const request = requests[index];
+      const knownEngines = Object.fromEntries(c.engines.map((e) => [e.engineId, true]));
+      type EngineInfo = {
+        id: string;
+        name?: string | null;
+      };
+
+      let becameReachable: EngineInfo[] = [];
+
+      if (request.status === 'fulfilled') {
+        for (const engine of request.value) {
+          if (!knownEngines[engine.id]) {
+            becameReachable.push(engine);
+          }
+        }
+      } else {
+        becameReachable = [];
+      }
+
+      return { becameReachable };
+    });
+
+    await db.$transaction(async (tx) => {
+      await Promise.all([
+        ...connections.flatMap((c, index) => {
+          const { becameReachable } = changes[index];
+
+          return [
+            !!becameReachable.length &&
+              tx.engineConnection.update({
+                where: { id: c.id },
+                data: {
+                  engines: {
+                    create: becameReachable.map(({ id, name }) => ({
+                      engine: {
+                        connectOrCreate: {
+                          where: { id: id },
+                          create: { id: id, name: name },
+                        },
+                      },
+                    })),
+                  },
+                },
+              }),
+          ];
+        }),
+      ]);
+    });
+  } catch (err) {
+    console.error('Error fetching engines: ', err);
+  }
+}
+
+export const refetchEngines = getSharedRefetch({
+  resource: 'Engines',
+  refetchFn,
+  getTimeoutLength: async () => 5000,
+});

--- a/src/management-system-v2/lib/engines/server-actions.ts
+++ b/src/management-system-v2/lib/engines/server-actions.ts
@@ -14,45 +14,76 @@ async function refetchFn() {
 
     const requests = await Promise.allSettled(connections.map(async (c) => resolveEngines([c])));
 
+    const currentDate = new Date();
+
     const changes = await asyncMap(connections, async (c, index) => {
       const request = requests[index];
-      const knownEngines = Object.fromEntries(c.engines.map((e) => [e.engineId, true]));
+      let notReachableAnymore = c.engines.reduce(
+        (acc, { engine, reachable }) => {
+          if (reachable) acc[engine.id] = true;
+          return acc;
+        },
+        {} as Record<string, true>,
+      );
       type EngineInfo = {
         id: string;
         name?: string | null;
       };
 
       let becameReachable: EngineInfo[] = [];
+      let updated: EngineInfo[] = [];
 
       if (request.status === 'fulfilled') {
         for (const engine of request.value) {
-          if (!knownEngines[engine.id]) {
-            becameReachable.push(engine);
+          if (notReachableAnymore[engine.id]) {
+            delete notReachableAnymore[engine.id];
+            updated.push({ ...engine });
+          } else {
+            becameReachable.push({ ...engine });
           }
         }
-      } else {
-        becameReachable = [];
       }
 
-      return { becameReachable };
+      return { notReachableAnymore: Object.keys(notReachableAnymore), becameReachable, updated };
     });
 
     await db.$transaction(async (tx) => {
       await Promise.all([
         ...connections.flatMap((c, index) => {
-          const { becameReachable } = changes[index];
+          const { notReachableAnymore, becameReachable, updated } = changes[index];
 
           return [
-            !!becameReachable.length &&
+            !!notReachableAnymore.length &&
               tx.engineConnection.update({
                 where: { id: c.id },
                 data: {
                   engines: {
-                    create: becameReachable.map(({ id, name }) => ({
-                      engine: {
-                        connectOrCreate: {
-                          where: { id: id },
-                          create: { id: id, name: name },
+                    update: notReachableAnymore.map((engineId) => ({
+                      where: { engineId_connectionId: { engineId, connectionId: c.id } },
+                      data: { reachable: false },
+                    })),
+                  },
+                },
+              }),
+            !!(becameReachable.length || updated.length) &&
+              tx.engineConnection.update({
+                where: { id: c.id },
+                data: {
+                  engines: {
+                    upsert: [...becameReachable, ...updated].map(({ id, name }) => ({
+                      where: { engineId_connectionId: { engineId: id, connectionId: c.id } },
+                      update: {
+                        reachable: true,
+                        lastContact: currentDate,
+                      },
+                      create: {
+                        reachable: true,
+                        lastContact: currentDate,
+                        engine: {
+                          connectOrCreate: {
+                            where: { id: id },
+                            create: { id: id, name: name },
+                          },
                         },
                       },
                     })),

--- a/src/management-system-v2/lib/engines/types.ts
+++ b/src/management-system-v2/lib/engines/types.ts
@@ -1,7 +1,17 @@
 type Discriminator = { spaceEngine?: undefined } | { spaceEngine: true };
 
-export type MqttEngine = { type: 'mqtt'; id: string; brokerAddress: string } & Discriminator;
-export type HttpEngine = { type: 'http'; id: string; address: string } & Discriminator;
+export type MqttEngine = {
+  type: 'mqtt';
+  name?: string;
+  id: string;
+  brokerAddress: string;
+} & Discriminator;
+export type HttpEngine = {
+  type: 'http';
+  name?: string;
+  id: string;
+  address: string;
+} & Discriminator;
 export type Engine = MqttEngine | HttpEngine;
 
 export type SpaceEngine = Extract<Engine, { spaceEngine: true }>;

--- a/src/management-system-v2/lib/executions/deployment-server-actions.ts
+++ b/src/management-system-v2/lib/executions/deployment-server-actions.ts
@@ -30,6 +30,7 @@ import { resolveEngines } from '../engines/engine-connections-helpers';
 import { getMSConfig } from '../ms-config/ms-config';
 import { updateTaskInfo } from '../tasks/server-actions';
 import { engineRequest } from '../engines/endpoints';
+import { getSharedRefetch } from '../shared-refetch';
 
 export async function deployProcess(
   definitionId: string,
@@ -265,259 +266,228 @@ export async function getProcessImage(spaceId: string, definitionId: string, fil
   }
 }
 
-// all connected users are sharing this information
-const global = globalThis as any;
-// flag that indicates if an update triggered by another user is currently running
-global.isRefetchingDeployments =
-  global.isRefetchingDeployments || (global.isRefetchingDeployments = false);
-global.deploymentRefetchDonePromise =
-  global.deploymentRefetchDonePromise || (global.deploymentRefetchDonePromise = Promise.resolve());
-// value that indicates the time the last update finished to ensure that we have the configured timeout
-// between updates
-global.lastDeploymentsRefetchTime =
-  global.lastDeploymentsRefetchTime || (global.lastDeploymentsRefetchTime = 0);
-
-/**
- * Fetches the deployments information from all engine that are expected to have a deployed process
- * from this MS
- **/
-export async function refetchDeployments() {
-  const config = await getMSConfig();
-
-  const interval = config.PROCEED_PUBLIC_DEPLOYMENT_REFETCHING_INTERVAL;
-  if (
-    // if automation is not activated we don't want to do anything here
-    config.PROCEED_PUBLIC_PROCESS_AUTOMATION_ACTIVE &&
-    // if the interval variable is set to 0 we consider this to mean that fetching is deactivated
-    interval &&
-    // the user sets the interval in seconds so we have to convert to milliseconds
-    Date.now() - global.lastDeploymentsRefetchTime >= interval * 1000 &&
-    // allow only one refetch for all users in the configured interval
-    !global.isRefetchingDeployments
-  ) {
-    // prevent other users from triggering concurrent refetching
-    global.isRefetchingDeployments = true;
-    global.deploymentRefetchDonePromise = new Promise(async (resolve) => {
-      try {
-        // get all (non-removed) deployments known to the MS
-        const res = await db.processDeployment.findMany({
-          where: { removeTime: null },
-          select: {
-            id: true,
-            engineId: true,
-            toRemove: true,
-            active: true,
-            version: {
-              select: { id: true, processId: true, process: { select: { environmentId: true } } },
-            },
-            instances: true,
-          },
-        });
-
-        // get unique ids of all known engines that have a deployment from this MS with information
-        // about what we expect to be deployed on those engines
-        const engineIdsWithDeployments = res.reduce(
-          (acc, curr) => {
-            if (!acc[curr.engineId]) acc[curr.engineId] = {};
-            const engineDeploymentMap = acc[curr.engineId];
-            if (!engineDeploymentMap[curr.version.processId]) {
-              engineDeploymentMap[curr.version.processId] = {};
-            }
-            const processMap = engineDeploymentMap[curr.version.processId];
-            processMap[curr.version.id] = curr;
-
-            return acc;
-          },
-          {} as {
-            [engineId: string]: {
-              [definitionId: string]: { [versionId: string]: (typeof res)[number] };
-            };
-          },
-        );
-
-        // get all (reachable) engines known to the MS
-        const connections = await db.engineConnection.findMany();
-        let engines = await resolveEngines(connections);
-        const knownEngines: Record<string, Engine> = {};
-        // deduplicate the engines (an engine might be reachable through multiple connections)
-        engines = engines.filter((engine) => {
-          if (knownEngines[engine.id]) return false;
-          knownEngines[engine.id] = engine;
-          return true;
-        });
-
-        // create a list of all engines we need to fetch new information from
-        const reachableWithDeployments = engines.filter((e) => !!engineIdsWithDeployments[e.id]);
-
-        const newInstances: {
-          id: string;
-          processId: string;
-          environmentId: string;
-          versionId: string;
-          deploymentId: string;
-          initiatorId: null;
-          engineIds: string[];
-          state: InstanceInfo;
-          logs: any[];
-        }[] = [];
-        const instanceUpdates: {
-          id: string;
-          processId: string;
-          environmentId: string;
-          versionId: string;
-          state: InstanceInfo;
-          logs: any[];
-        }[] = [];
-
-        // fetch deployment data from the engines
-        const engineDeployments = Object.fromEntries(
-          await asyncMap(reachableWithDeployments, async (e) => {
-            const res = await fetchDeployments([e]);
-
-            const deployedProcesses = Object.fromEntries(
-              res.map((p) => [
-                p.definitionId,
-                {
-                  versions: Object.fromEntries(p.versions.map((v) => [v.versionId, v])),
-                },
-              ]),
-            );
-
-            await asyncForEach(res, async (p) => {
-              await asyncForEach(p.versions, async (v) => {
-                try {
-                  const deployment =
-                    engineIdsWithDeployments[e.id]?.[p.definitionId]?.[v.versionId];
-                  if (!deployment) return;
-
-                  if (v.active !== deployment.active) {
-                    // mismatch of the active state on the engine and the locally stored active
-                    // state => change the state on the engine
-                    await _changeDeploymentActivation(
-                      e,
-                      p.definitionId,
-                      v.versionId,
-                      deployment.active,
-                    );
-                  }
-                } catch (err) {
-                  console.error(
-                    `Failed to update the active state for the deployment of process (id: ${p.definitionId}) version (id: ${v.versionId}) on engine (id: ${e.id}).`,
-                  );
-                }
-              });
-            });
-
-            // TODO: when we want to handle instances that move to other engines automatically, we
-            // will have to change this logic since it assumes that all available data of the instance
-            // can be found on the engine it was started on
-            await asyncForEach(res, async (p) => {
-              await asyncForEach(p.instances, async (i) => {
-                const deployment =
-                  engineIdsWithDeployments[e.id]?.[p.definitionId]?.[i.processVersion];
-                if (!deployment) return;
-                const existingInstance = deployment.instances.find(
-                  (dI) => dI.id === i.processInstanceId,
-                );
-                const logs = await engineRequest({
-                  engine: e,
-                  method: 'get',
-                  endpoint: '/logging/process/:definitionId/instance/:instanceId',
-                  pathParams: { definitionId: p.definitionId, instanceId: i.processInstanceId },
-                });
-
-                if (!existingInstance) {
-                  newInstances.push({
-                    id: i.processInstanceId,
-                    processId: p.definitionId,
-                    environmentId: deployment.version.process.environmentId,
-                    versionId: deployment.version.id,
-                    deploymentId: deployment.id,
-                    initiatorId: null,
-                    engineIds: [e.id],
-                    state: i,
-                    logs,
-                  });
-                } else if (
-                  !deepEquals(i, existingInstance.state) ||
-                  !deepEquals(logs, existingInstance.logs)
-                ) {
-                  instanceUpdates.push({
-                    id: i.processInstanceId,
-                    processId: p.definitionId,
-                    environmentId: deployment.version.process.environmentId,
-                    versionId: deployment.version.id,
-                    state: i,
-                    logs,
-                  });
-                }
-              });
-            });
-
-            return [e.id, deployedProcesses];
-          }),
-        );
-
-        const removedOnEngine = await asyncFilter(res, async (d) => {
-          // we say the deployment still exists on the engine if the engine cannot be reached to check
-          if (!engineDeployments[d.engineId]) return false;
-
-          if (d.toRemove) {
-            // remove the deployment from the engine if it is marked for automatic removal
-            try {
-              await removeDeploymentFromMachines([knownEngines[d.engineId]], d.version.processId);
-              return true;
-            } catch (err) {}
-            return false;
-          } else {
-            // check if deployment information has been unexpectedly lost on the engine
-            return !engineDeployments[d.engineId][d.version.processId]?.versions[d.version.id];
-          }
-        });
-
-        // update the deployment information in the db
-        await db.$transaction(async (tx) => {
-          await Promise.all([
-            ...removedOnEngine.map(async (deployment) => {
-              await tx.processDeployment.update({
-                where: { id: deployment.id },
-                data: { removeTime: new Date(), toRemove: false, active: false },
-              });
-            }),
-            ...instanceUpdates.map(async ({ id, state, logs }) => {
-              await tx.processInstance.update({
-                where: { id },
-                data: { state, logs },
-              });
-            }),
-            newInstances.length &&
-              tx.processInstance.createMany({
-                data: newInstances.map((i) => ({
-                  ...i,
-                  processId: undefined,
-                  versionId: undefined,
-                  environmentId: undefined,
-                })),
-              }),
-          ]);
-        });
-
-        const knownInstances = Object.fromEntries(
-          instanceUpdates.concat(newInstances).map((i) => [i.id, { ...i, instanceId: i.id }]),
-        );
-
-        await updateTaskInfo(engines, reachableWithDeployments, knownInstances);
-      } catch (err) {
-        console.error('Error fetching deployment information: ', err);
-      }
-
-      // allow the next update to happen after the configured interval has elapsed
-      global.isRefetchingDeployments = false;
-      global.lastDeploymentsRefetchTime = Date.now();
-      resolve({ success: true });
+async function refetchFn() {
+  try {
+    // get all (non-removed) deployments known to the MS
+    const res = await db.processDeployment.findMany({
+      where: { removeTime: null },
+      select: {
+        id: true,
+        engineId: true,
+        toRemove: true,
+        active: true,
+        version: {
+          select: { id: true, processId: true, process: { select: { environmentId: true } } },
+        },
+        instances: true,
+      },
     });
-  }
 
-  // allows the calling function to wait until the already running refetch cycle is finished
-  return global.deploymentRefetchDonePromise;
+    // get unique ids of all known engines that have a deployment from this MS with information
+    // about what we expect to be deployed on those engines
+    const engineIdsWithDeployments = res.reduce(
+      (acc, curr) => {
+        if (!acc[curr.engineId]) acc[curr.engineId] = {};
+        const engineDeploymentMap = acc[curr.engineId];
+        if (!engineDeploymentMap[curr.version.processId]) {
+          engineDeploymentMap[curr.version.processId] = {};
+        }
+        const processMap = engineDeploymentMap[curr.version.processId];
+        processMap[curr.version.id] = curr;
+
+        return acc;
+      },
+      {} as {
+        [engineId: string]: {
+          [definitionId: string]: { [versionId: string]: (typeof res)[number] };
+        };
+      },
+    );
+
+    // get all (reachable) engines known to the MS
+    const connections = await db.engineConnection.findMany();
+    let engines = await resolveEngines(connections);
+    const knownEngines: Record<string, Engine> = {};
+    // deduplicate the engines (an engine might be reachable through multiple connections)
+    engines = engines.filter((engine) => {
+      if (knownEngines[engine.id]) return false;
+      knownEngines[engine.id] = engine;
+      return true;
+    });
+
+    // create a list of all engines we need to fetch new information from
+    const reachableWithDeployments = engines.filter((e) => !!engineIdsWithDeployments[e.id]);
+
+    const newInstances: {
+      id: string;
+      processId: string;
+      environmentId: string;
+      versionId: string;
+      deploymentId: string;
+      initiatorId: null;
+      engineIds: string[];
+      state: InstanceInfo;
+      logs: any[];
+    }[] = [];
+    const instanceUpdates: {
+      id: string;
+      processId: string;
+      environmentId: string;
+      versionId: string;
+      state: InstanceInfo;
+      logs: any[];
+    }[] = [];
+
+    // fetch deployment data from the engines
+    const engineDeployments = Object.fromEntries(
+      await asyncMap(reachableWithDeployments, async (e) => {
+        const res = await fetchDeployments([e]);
+
+        const deployedProcesses = Object.fromEntries(
+          res.map((p) => [
+            p.definitionId,
+            {
+              versions: Object.fromEntries(p.versions.map((v) => [v.versionId, v])),
+            },
+          ]),
+        );
+
+        await asyncForEach(res, async (p) => {
+          await asyncForEach(p.versions, async (v) => {
+            try {
+              const deployment = engineIdsWithDeployments[e.id]?.[p.definitionId]?.[v.versionId];
+              if (!deployment) return;
+
+              if (v.active !== deployment.active) {
+                // mismatch of the active state on the engine and the locally stored active
+                // state => change the state on the engine
+                await _changeDeploymentActivation(
+                  e,
+                  p.definitionId,
+                  v.versionId,
+                  deployment.active,
+                );
+              }
+            } catch (err) {
+              console.error(
+                `Failed to update the active state for the deployment of process (id: ${p.definitionId}) version (id: ${v.versionId}) on engine (id: ${e.id}).`,
+              );
+            }
+          });
+        });
+
+        // TODO: when we want to handle instances that move to other engines automatically, we
+        // will have to change this logic since it assumes that all available data of the instance
+        // can be found on the engine it was started on
+        await asyncForEach(res, async (p) => {
+          await asyncForEach(p.instances, async (i) => {
+            const deployment = engineIdsWithDeployments[e.id]?.[p.definitionId]?.[i.processVersion];
+            if (!deployment) return;
+            const existingInstance = deployment.instances.find(
+              (dI) => dI.id === i.processInstanceId,
+            );
+            const logs = await engineRequest({
+              engine: e,
+              method: 'get',
+              endpoint: '/logging/process/:definitionId/instance/:instanceId',
+              pathParams: { definitionId: p.definitionId, instanceId: i.processInstanceId },
+            });
+
+            if (!existingInstance) {
+              newInstances.push({
+                id: i.processInstanceId,
+                processId: p.definitionId,
+                environmentId: deployment.version.process.environmentId,
+                versionId: deployment.version.id,
+                deploymentId: deployment.id,
+                initiatorId: null,
+                engineIds: [e.id],
+                state: i,
+                logs,
+              });
+            } else if (
+              !deepEquals(i, existingInstance.state) ||
+              !deepEquals(logs, existingInstance.logs)
+            ) {
+              instanceUpdates.push({
+                id: i.processInstanceId,
+                processId: p.definitionId,
+                environmentId: deployment.version.process.environmentId,
+                versionId: deployment.version.id,
+                state: i,
+                logs,
+              });
+            }
+          });
+        });
+
+        return [e.id, deployedProcesses];
+      }),
+    );
+
+    const removedOnEngine = await asyncFilter(res, async (d) => {
+      // we say the deployment still exists on the engine if the engine cannot be reached to check
+      if (!engineDeployments[d.engineId]) return false;
+
+      if (d.toRemove) {
+        // remove the deployment from the engine if it is marked for automatic removal
+        try {
+          await removeDeploymentFromMachines([knownEngines[d.engineId]], d.version.processId);
+          return true;
+        } catch (err) {}
+        return false;
+      } else {
+        // check if deployment information has been unexpectedly lost on the engine
+        return !engineDeployments[d.engineId][d.version.processId]?.versions[d.version.id];
+      }
+    });
+
+    // update the deployment information in the db
+    await db.$transaction(async (tx) => {
+      await Promise.all([
+        ...removedOnEngine.map(async (deployment) => {
+          await tx.processDeployment.update({
+            where: { id: deployment.id },
+            data: { removeTime: new Date(), toRemove: false, active: false },
+          });
+        }),
+        ...instanceUpdates.map(async ({ id, state, logs }) => {
+          await tx.processInstance.update({
+            where: { id },
+            data: { state, logs },
+          });
+        }),
+        newInstances.length &&
+          tx.processInstance.createMany({
+            data: newInstances.map((i) => ({
+              ...i,
+              processId: undefined,
+              versionId: undefined,
+              environmentId: undefined,
+            })),
+          }),
+      ]);
+    });
+
+    const knownInstances = Object.fromEntries(
+      instanceUpdates.concat(newInstances).map((i) => [i.id, { ...i, instanceId: i.id }]),
+    );
+
+    await updateTaskInfo(engines, reachableWithDeployments, knownInstances);
+  } catch (err) {
+    console.error('Error fetching deployment information: ', err);
+  }
 }
+
+export const refetchDeployments = getSharedRefetch({
+  resource: 'Deployments',
+  refetchFn,
+  getTimeoutLength: async () => {
+    const config = await getMSConfig();
+
+    if (!config.PROCEED_PUBLIC_PROCESS_AUTOMATION_ACTIVE) return 0;
+
+    // the user sets the interval in seconds so we have to convert to milliseconds
+    return config.PROCEED_PUBLIC_DEPLOYMENT_REFETCHING_INTERVAL * 1000;
+  },
+});

--- a/src/management-system-v2/lib/shared-refetch.ts
+++ b/src/management-system-v2/lib/shared-refetch.ts
@@ -1,0 +1,56 @@
+/**
+ * Creates a function that executes a given refetch function only once in a given timeout for all
+ * users of the application even if multiple users try to trigger the returned function
+ **/
+export function getSharedRefetch({
+  resource,
+  getTimeoutLength,
+  refetchFn,
+}: {
+  resource: string;
+  // should return the time (in milliseconds) that has to elapse between two activations of the
+  // refetchFn
+  // a value of 0 means that the refetchFn is disabled and will not run until a different timeout is
+  // returned
+  getTimeoutLength: () => Promise<number>;
+  refetchFn: () => {};
+}) {
+  // all connected users are sharing this information
+  const global = globalThis as any;
+  // init the global variables when called the first time across all users
+
+  // flag that indicates if an update triggered by another user is currently running
+  if (global[`isRefetching${resource}`] === undefined) global[`isRefetching${resource}`] = false;
+  if (global[`refetchPromiseFor${resource}`] === undefined) {
+    global[`refetchPromiseFor${resource}`] = Promise.resolve();
+  }
+  // value that indicates the time the last update finished to ensure that we have the configured timeout
+  // between updates
+  if (global[`lastRefetchTimeFor${resource}`] === undefined) {
+    global[`lastRefetchTimeFor${resource}`] = 0;
+  }
+
+  return async () => {
+    const interval = await getTimeoutLength();
+    if (
+      // if the interval variable is set to 0 we consider this to mean that fetching is deactivated
+      interval &&
+      Date.now() - global[`lastRefetchTimeFor${resource}`] >= interval &&
+      // allow only one refetch for all users in the configured interval
+      !global[`isRefetching${resource}`]
+    ) {
+      // prevent other users from triggering concurrent refetching
+      global[`isRefetching${resource}`] = true;
+      // allow other users to wait for the result of the refetch function if they try to run it before
+      // while this one is running or before the timeout has elapsed
+      global[`refetchPromiseFor${resource}`] = refetchFn();
+      await global[`refetchPromiseFor${resource}`];
+      // allow the next update to happen after the configured interval has elapsed
+      global[`isRefetching${resource}`] = false;
+      global[`lastRefetchTimeFor${resource}`] = Date.now();
+    }
+
+    // allows the calling function to wait until the already running refetch cycle is finished
+    return global[`refetchPromiseFor${resource}`];
+  };
+}

--- a/src/management-system-v2/prisma/migrations/20260615144143_engine_data/migration.sql
+++ b/src/management-system-v2/prisma/migrations/20260615144143_engine_data/migration.sql
@@ -1,0 +1,24 @@
+-- AlterTable
+ALTER TABLE "engine-connection" ADD COLUMN     "removed" BOOLEAN NOT NULL DEFAULT false;
+
+-- CreateTable
+CREATE TABLE "engine" (
+    "id" TEXT NOT NULL,
+    "name" TEXT,
+
+    CONSTRAINT "engine_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "ConnectionEngineReachability" (
+    "engineId" TEXT NOT NULL,
+    "connectionId" TEXT NOT NULL,
+
+    CONSTRAINT "ConnectionEngineReachability_pkey" PRIMARY KEY ("engineId","connectionId")
+);
+
+-- AddForeignKey
+ALTER TABLE "ConnectionEngineReachability" ADD CONSTRAINT "ConnectionEngineReachability_engineId_fkey" FOREIGN KEY ("engineId") REFERENCES "engine"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "ConnectionEngineReachability" ADD CONSTRAINT "ConnectionEngineReachability_connectionId_fkey" FOREIGN KEY ("connectionId") REFERENCES "engine-connection"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/src/management-system-v2/prisma/migrations/20260615154244_engine_reachability/migration.sql
+++ b/src/management-system-v2/prisma/migrations/20260615154244_engine_reachability/migration.sql
@@ -1,0 +1,9 @@
+/*
+  Warnings:
+
+  - Added the required column `reachable` to the `ConnectionEngineReachability` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- AlterTable
+ALTER TABLE "ConnectionEngineReachability" ADD COLUMN     "lastContact" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+ADD COLUMN     "reachable" BOOLEAN NOT NULL;

--- a/src/management-system-v2/prisma/schema.prisma
+++ b/src/management-system-v2/prisma/schema.prisma
@@ -271,6 +271,15 @@ model RoleMember {
   @@map("role_member")
 }
 
+model Engine {
+  id            String @id
+  name          String?
+
+  connections   ConnectionEngineReachability[]
+
+  @@map("engine")
+}
+
 model EngineConnection {
   id            String   @id @default(uuid())
   space         Space?   @relation(fields: [environmentId], references: [id], onDelete: Cascade)
@@ -280,7 +289,22 @@ model EngineConnection {
   createdOn     DateTime @default(now())
   lastEditedOn  DateTime @updatedAt
 
+  removed       Boolean  @default(false)
+
+  engines       ConnectionEngineReachability[]
+
   @@map("engine-connection")
+}
+
+model ConnectionEngineReachability {
+  engine        Engine              @relation(fields: [engineId], references: [id])
+  engineId      String
+  connection    EngineConnection    @relation(fields: [connectionId], references: [id])
+  connectionId  String
+
+  // TODO: add entry for current reachability and last time the engine was reached using this connection
+
+  @@id([engineId, connectionId])
 }
 
 model GuestSignin {

--- a/src/management-system-v2/prisma/schema.prisma
+++ b/src/management-system-v2/prisma/schema.prisma
@@ -302,7 +302,8 @@ model ConnectionEngineReachability {
   connection    EngineConnection    @relation(fields: [connectionId], references: [id])
   connectionId  String
 
-  // TODO: add entry for current reachability and last time the engine was reached using this connection
+  reachable     Boolean
+  lastContact   DateTime            @default(now())
 
   @@id([engineId, connectionId])
 }


### PR DESCRIPTION
<!--
  Thank you for your contribution to this project!

  Please provide the following information about your changes,
  in order for us to approve and merge your proposal as quickly as possible.
-->

## Summary

Added a new table for information about engines that have been connected to the Management System. The entries in this table are linked to the EngineConnection table using a relation that contains information about the current reachability of the engine using that connection as well as the last time the engine was reachable using the connection.
The engine data is fetched when a new connection is added as well as when the address of a connection is updated.
There is also a background loop that periodically checks the reachability status for all known connections to check if new engines have become reachable and if some engine is not reachable anymore.

## Details

- added an "Engine" table to the database of the MS that currently only contains the id and name of an engine
- added a "ConnectionEngineReachability" relation that links an engine to a "EngineConnection" and contains additional information about the reachability of this engine using the linked connection
  - the entry "reachable" indicates if the engine could be reached the last time the reachability was checked
  - the entry "lastContact" contains the last time the check for reachability was successful
- added a new "removed" entry to the "EngineConnection" table that indicates if a specific connection (with a specific address) should be hidden from the frontend because a user "removed" it
  - to be able to retrace reachability especially in the context of executions at a later date it might be useful to know which connections might have been used to reach the engine even if the have been "removed"
- changed that connection are not actually removed anymore, their "removed" flag is set to true instead 
- changed that we do not allow two connections with the same address in the same space anymore (the user will see an error when they try to add a new connection with an address already used by another connection)
- changed that changing the address of a connection will now actually "remove" the old connection and add a new connection
  - this way we keep the fact that we can retrace the reachability using the connection with the old address while still allowing the user to change to a new connection with a new address
  - we can reuse the existing "remove" and "add" logic for connections
- when a connection is added we fetch all currently reachable engines for this connection and add them to the database if they are not known
- when a connection is "added" but a "removed" connectionwith the same address already exists the "removed" flag of that connection is set to false and its metadata (name) is set to the one the user selected
- generalized the logic for periodic background refetching of data that was used for deployments to reuse it for engines
- added a refetch loop for engines that is triggered by users connected to the frontend but can only be triggered once in a 5 second interval
  - it checks which engines are reachable for the known connections and updates the database