### PR TITLE
MS: Process Automation Deactivation

### DIFF
--- a/src/management-system-v2/app/(dashboard)/[environmentId]/processes/[mode]/[processId]/is-executable.tsx
+++ b/src/management-system-v2/app/(dashboard)/[environmentId]/processes/[mode]/[processId]/is-executable.tsx
@@ -1,11 +1,14 @@
 import { BPMNCanvasRef } from '@/components/bpmn-canvas';
-import { Checkbox, Divider, Space, Spin } from 'antd';
-import { updateProcessMetaData } from '@/lib/data/processes';
-import { useParams } from 'next/navigation';
+import { Alert, Checkbox, Space, Spin } from 'antd';
+import { getProcessBPMN, updateProcessMetaData } from '@/lib/data/processes';
+import { useParams, useSearchParams } from 'next/navigation';
 import { useEnvironment } from '@/components/auth-can';
 import useModelerStateStore from './use-modeler-state-store';
 import { wrapServerCall } from '@/lib/wrap-server-call';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { getElementsByTagName, toBpmnObject } from '@proceed/bpmn-helper';
+import { isUserErrorResponse } from '@/lib/user-error';
 
 type IsExecutableSectionProps = {
   modeler: BPMNCanvasRef | null;
@@ -17,9 +20,49 @@ const IsExecutableSection: React.FC<IsExecutableSectionProps> = ({ modeler, read
   const setIsExecutable = useModelerStateStore((state) => state.setIsExecutable);
 
   const [loading, setLoading] = useState(false);
+  const [previousVersionId, setPreviousVersionId] = useState('');
 
   const { processId } = useParams();
   const { spaceId } = useEnvironment();
+
+  const query = useSearchParams();
+  const selectedVersionId = query.get('version');
+
+  useEffect(() => {
+    const eventBus = modeler?.getEventBus();
+
+    if (eventBus) {
+      const onImport = async () => {
+        const root = modeler?.getCurrentRoot()?.businessObject.$parent;
+        setPreviousVersionId(root?.processVersionBasedOn || '');
+      };
+
+      onImport();
+
+      eventBus.on('import.done', onImport);
+
+      return () => {
+        eventBus.off('import.done', onImport);
+      };
+    }
+  }, [modeler]);
+
+  const { data: lastVersionWasExecutable } = useQuery({
+    queryFn: async () => {
+      if (previousVersionId) {
+        const versionBpmn = await getProcessBPMN(processId as string, spaceId, previousVersionId);
+        if (isUserErrorResponse(versionBpmn)) return false;
+        const bpmnObj = await toBpmnObject(versionBpmn);
+
+        const [process] = getElementsByTagName(bpmnObj, 'bpmn:Process');
+
+        return !!process.isExecutable;
+      }
+
+      return false;
+    },
+    queryKey: ['get-last-version-executable-state', spaceId, processId, previousVersionId],
+  });
 
   const changeIsExecutable = async (value: boolean) => {
     if (modeler) {
@@ -40,15 +83,23 @@ const IsExecutableSection: React.FC<IsExecutableSectionProps> = ({ modeler, read
         {loading ? (
           <Spin style={{ width: '16px' }} size="small" />
         ) : (
-          <Checkbox
-            disabled={readOnly}
-            title="Toggles if this process is considered to be executable and therefore deployable to the engine."
-            checked={isExecutable}
-            onChange={(e) => changeIsExecutable(e.target.checked)}
-          />
+          <>
+            <Checkbox
+              disabled={readOnly}
+              title="Toggles if this process is considered to be executable and therefore deployable to the engine."
+              checked={isExecutable}
+              onChange={(e) => changeIsExecutable(e.target.checked)}
+            />
+          </>
         )}
         Activate Automation for the entire Process
       </Space>
+      {!selectedVersionId && !isExecutable && lastVersionWasExecutable && (
+        <Alert
+          type="warning"
+          title="Attention: currently, the automation feature has been disabled, even though the previous process version supported automation. This means if you create a new version of the current process, you will no longer be able to start new executions of this process."
+        />
+      )}
     </Space>
   );
 };

--- a/src/management-system-v2/app/(dashboard)/[environmentId]/processes/[mode]/[processId]/modeler.tsx
+++ b/src/management-system-v2/app/(dashboard)/[environmentId]/processes/[mode]/[processId]/modeler.tsx
@@ -58,10 +58,6 @@ const Modeler = ({ versionName, process, folder, inEditing, ...divProps }: Model
   const setFullScreen = useModelerStateStore((state) => state.setFullScreen);
   const setIsExecutable = useModelerStateStore((state) => state.setIsExecutable);
 
-  useEffect(() => {
-    setIsExecutable(process.executable || false);
-  }, [process]);
-
   const { isListView, processContextPath } = useProcessView();
 
   /// Derived State
@@ -289,7 +285,14 @@ const Modeler = ({ versionName, process, folder, inEditing, ...divProps }: Model
         );
       }
     }
-  }, [messageApi, subprocessId]);
+
+    if (modeler.current) {
+      const processes = modeler.current
+        .getAllElements()
+        .filter((el) => el.businessObject.$type === 'bpmn:Process');
+      if (processes.length) setIsExecutable(processes[0].businessObject.isExecutable || false);
+    }
+  }, [messageApi, subprocessId, setIsExecutable]);
 
   const onShapeRemove = useCallback<Required<BPMNCanvasProps>['onShapeRemove']>((element) => {
     if (!element.businessObject) return;

--- a/src/management-system-v2/lib/data/deployment.ts
+++ b/src/management-system-v2/lib/data/deployment.ts
@@ -17,7 +17,7 @@ export async function getDeployedProcesses(environmentId: string) {
     'use cache';
     cacheLife({ revalidate: 10, expire: 15 });
     cacheTag(`space/${environmentId}/deployments`);
-    const deploymentIsNotDeleted = { AND: [{ removeTime: null }, { toRemove: false }] };
+    const deploymentIsNotDeleted = { removeTime: null };
 
     return await db.process.findMany({
       where: {
@@ -81,7 +81,6 @@ export async function getProcessDeployments(
             },
           },
           { removeTime: null },
-          { toRemove: false },
         ],
       },
       include: {

--- a/src/management-system-v2/lib/data/processes.tsx
+++ b/src/management-system-v2/lib/data/processes.tsx
@@ -79,6 +79,7 @@ import { asyncMap } from '../helpers/javascriptHelpers';
 import { isActive } from '@/app/(dashboard)/[environmentId]/(automation)/executions/[processId]/instance-helpers';
 import { InstanceInfo } from '../engines/deployment';
 import { getMSConfig } from '../ms-config/ms-config';
+import { removeDeployment } from '../executions/deployment-server-actions';
 
 // Import necessary functions from processModule
 
@@ -695,10 +696,9 @@ export const createVersion = async (
   const versionedScriptTaskFilenames = await versionScriptTasks(process, versionId, bpmnObj);
 
   const versionedBpmn = await toBpmnXml(bpmnObj);
-
   // if the new version has no changes to the version it is based on don't create a new version and return the previous version
   const basedOnBPMN =
-    versionBasedOn !== undefined ? await getLocalVersionBpmn(process, versionCreatedOn) : undefined;
+    versionBasedOn !== undefined ? await getLocalVersionBpmn(process, versionBasedOn) : undefined;
 
   if (basedOnBPMN && (await areVersionsEqual(versionedBpmn, basedOnBPMN))) {
     return versionBasedOn;
@@ -714,6 +714,20 @@ export const createVersion = async (
   );
 
   await updateProcessVersionBasedOn({ ...process, bpmn }, versionId);
+
+  if (basedOnBPMN) {
+    const config = await getMSConfig();
+    if (config.PROCEED_PUBLIC_PROCESS_AUTOMATION_ACTIVE) {
+      const basedOnBpmnObj = await toBpmnObject(basedOnBPMN);
+      const prevProcesses = getElementsByTagName(basedOnBpmnObj, 'bpmn:Process');
+      const wasExecutable = !!prevProcesses.length && prevProcesses[0].isExecutable;
+      const processes = getElementsByTagName(bpmnObj, 'bpmn:Process');
+      const isExecutable = !!processes.length && processes[0].isExecutable;
+      if (wasExecutable && !isExecutable) {
+        await removeDeployment(processId, spaceId, true);
+      }
+    }
+  }
 
   return versionId;
 };

--- a/src/management-system-v2/lib/data/user-tasks.ts
+++ b/src/management-system-v2/lib/data/user-tasks.ts
@@ -34,10 +34,7 @@ export async function getUserTasks(spaceId: string, ability?: Ability) {
             {
               instance: {
                 deployment: {
-                  AND: [
-                    { version: { process: { environmentId } } },
-                    { removeTime: null, toRemove: false },
-                  ],
+                  AND: [{ version: { process: { environmentId } } }, { removeTime: null }],
                 },
               },
             },

--- a/src/management-system-v2/lib/executions/deployment-server-actions.ts
+++ b/src/management-system-v2/lib/executions/deployment-server-actions.ts
@@ -40,7 +40,6 @@ import Ability from '../ability/abilityHelper';
 import { EngineConnection } from '@prisma/client';
 import { revalidateTag } from 'next/cache';
 import { isActive } from '@/app/(dashboard)/[environmentId]/(automation)/executions/[processId]/instance-helpers';
-import { getDBInstance } from '../data/instance';
 
 export async function deployProcess(
   definitionId: string,
@@ -146,12 +145,14 @@ export async function deployProcess(
   }
 }
 
-export async function removeDeployment(definitionId: string, spaceId: string) {
+export async function removeDeployment(definitionId: string, spaceId: string, force = false) {
   try {
-    const { ability } = await getCurrentEnvironment(spaceId);
+    if (!force) {
+      const { ability } = await getCurrentEnvironment(spaceId);
 
-    if (!ability.can('manage', 'Execution')) {
-      return permissionDenied();
+      if (!ability.can('manage', 'Execution')) {
+        return permissionDenied();
+      }
     }
 
     const deployments = await getProcessDeployments(spaceId, definitionId, undefined, true);
@@ -161,10 +162,11 @@ export async function removeDeployment(definitionId: string, spaceId: string) {
 
     const instances = await db.processInstance.findMany({
       where: { id: { in: instanceIds } },
-      select: { state: true },
+      select: { state: true, engines: { select: { id: true } } },
     });
 
-    if (instances.some(({ state }) => isActive(state as InstanceInfo))) {
+    const activeInstances = instances.filter(({ state }) => isActive(state as InstanceInfo));
+    if (!force && activeInstances.length) {
       return userError(
         'This process has active executions. Please stop all active executions or wait for them to be completed before removing the process from the engines.',
       );
@@ -174,7 +176,10 @@ export async function removeDeployment(definitionId: string, spaceId: string) {
       try {
         const { engine } = deployment;
 
-        if (engine.connections.some((c) => c.reachable)) {
+        const activeInstancesOnThisEngine = activeInstances.filter(({ engines }) =>
+          engines.some(({ id }) => deployment.engineId === id),
+        );
+        if (!activeInstancesOnThisEngine.length && engine.connections.some((c) => c.reachable)) {
           // TODO: we might have deployments of multiple versions of the same process to the same
           // engine => we don't need to call this for every version but only once per engine per
           // process
@@ -485,11 +490,20 @@ async function refetchFn() {
       if (!engineDeployments[d.engine.id]) return false;
 
       if (d.toRemove) {
-        // remove the deployment from the engine if it is marked for automatic removal
-        try {
-          await removeDeploymentFromMachines([d.engine], d.version.processId);
-          return true;
-        } catch (err) {}
+        const activeInstances = d.instances.filter((i) => isActive(i.state as InstanceInfo));
+        if (!activeInstances.length) {
+          // remove the deployment from the engine if it is marked for automatic removal and there are
+          // no active instances left
+          try {
+            await removeDeploymentFromMachines([d.engine], d.version.processId);
+            return true;
+          } catch (err) {}
+        } else if (d.active) {
+          // deactivate the deployment to prevent new instances from being started automatically
+          try {
+            await _changeDeploymentActivation(d.engine, d.version.processId, d.version.id, false);
+          } catch (err) {}
+        }
         return false;
       } else {
         // check if deployment information has been unexpectedly lost on the engine


### PR DESCRIPTION
## Summary

Added handling for situations where a process that has a latest version that was executable gets a new version that is not executable.

## Details

- added a warning for the user that indicates that they won't be able to create new executions of this process when they create a new version with the executable property set to false if the current "latest" version is executable
- added logic that automatically removes existing deployments of the previous version if the new version is not executable anymore
  - if the previous version has deployments with running instances the deployment is not removed but marked for removal and will be removed as soon as all instances have finished
- changed that deployments that are marked for removal can now still be seen in the UI and are only removed after all instances have finished
