### PR TITLE
MS/Bugfix: Prevent Deployment Of Processes Marked As Not Executable

### DIFF
--- a/src/management-system-v2/app/(dashboard)/[environmentId]/(automation)/executions/deployments-modal.tsx
+++ b/src/management-system-v2/app/(dashboard)/[environmentId]/(automation)/executions/deployments-modal.tsx
@@ -30,6 +30,8 @@ import { getAvailableSpaceEngines } from '@/lib/data/engines';
 import { SpaceEngine, isHttpConnection, isMqttConnection } from '@/lib/engines/types';
 import { MdOutlineComputer } from 'react-icons/md';
 import { LeftOutlined } from '@ant-design/icons';
+import { asyncFilter } from '@/lib/helpers/javascriptHelpers';
+import { getLatestVersion } from '@/lib/data/processes';
 
 type InputItem = ProcessMetadata | (Folder & { type: 'folder' });
 export type ProcessListProcess = ReplaceKeysWithHighlighted<InputItem, 'name' | 'description'>;
@@ -236,7 +238,14 @@ const DeploymentsModal = ({
       throw new Error('Failed to fetch folder children');
     }
 
-    folderContents = folderContents.filter((c) => c.type === 'folder' || c.versions.length);
+    folderContents = await asyncFilter(folderContents, async (c) => {
+      if (c.type === 'folder') return true;
+
+      const latestVersion = await getLatestVersion(environment.spaceId, c.id);
+      if (isUserErrorResponse(latestVersion)) return false;
+      console.log(latestVersion);
+      return latestVersion.executable;
+    });
 
     if (folder.parentId) {
       setProcesses([

--- a/src/management-system-v2/app/(dashboard)/[environmentId]/(automation)/executions/deployments-modal.tsx
+++ b/src/management-system-v2/app/(dashboard)/[environmentId]/(automation)/executions/deployments-modal.tsx
@@ -202,16 +202,20 @@ const DeploymentsModal = ({
     ];
 
   const [processes, setProcesses] = useState<InputItem[]>([]);
+  const [loading, setLoading] = useState(true);
   const [folder, setFolder] = useState(initialFolder);
 
   useEffect(() => {
     async function init() {
       const deployable = await asyncFilter(initialProcesses, async (c) => {
+        if (c.type === 'folder') return true;
+
         const latestVersion = await getLatestVersion(environment.spaceId, c.id);
         if (isUserErrorResponse(latestVersion)) return false;
         return latestVersion.executable;
       });
       setProcesses(deployable);
+      setLoading(false);
     }
 
     init();
@@ -241,6 +245,7 @@ const DeploymentsModal = ({
   });
 
   const openFolder = async (id: string) => {
+    setLoading(true);
     const folder = await getFolder(environment.spaceId, id);
     if ('error' in folder) {
       throw new Error('Failed to fetch folder');
@@ -277,6 +282,7 @@ const DeploymentsModal = ({
       setProcesses(folderContents);
     }
     setFolder(folder);
+    setLoading(false);
   };
 
   const dropdownItems: MenuProps['items'] = [
@@ -389,6 +395,7 @@ const DeploymentsModal = ({
             <div style={{ width: 'min-content' }}>
               <ProcessDeploymentList
                 data={filteredData}
+                loading={loading}
                 folder={folder}
                 openFolder={(id) => {
                   openFolder(id);

--- a/src/management-system-v2/app/(dashboard)/[environmentId]/(automation)/executions/deployments-modal.tsx
+++ b/src/management-system-v2/app/(dashboard)/[environmentId]/(automation)/executions/deployments-modal.tsx
@@ -20,7 +20,7 @@ import { ProcessMetadata } from '@/lib/data/process-schema';
 import { Folder } from '@/lib/data/folder-schema';
 import { useInitialiseFavourites } from '@/lib/useFavouriteProcesses';
 import ProcessIconView from './deployment-selection-icon-view';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useEnvironment } from '@/components/auth-can';
 import { getFolder, getFolderContents } from '@/lib/data/folders';
 import { ProcessDeploymentList } from '@/components/process-list';
@@ -201,8 +201,21 @@ const DeploymentsModal = ({
       ...initialProcesses,
     ];
 
-  const [processes, setProcesses] = useState(initialProcesses);
+  const [processes, setProcesses] = useState<InputItem[]>([]);
   const [folder, setFolder] = useState(initialFolder);
+
+  useEffect(() => {
+    async function init() {
+      const deployable = await asyncFilter(initialProcesses, async (c) => {
+        const latestVersion = await getLatestVersion(environment.spaceId, c.id);
+        if (isUserErrorResponse(latestVersion)) return false;
+        return latestVersion.executable;
+      });
+      setProcesses(deployable);
+    }
+
+    init();
+  }, []);
 
   const favs = favourites ?? [];
   useInitialiseFavourites(favs);
@@ -243,7 +256,6 @@ const DeploymentsModal = ({
 
       const latestVersion = await getLatestVersion(environment.spaceId, c.id);
       if (isUserErrorResponse(latestVersion)) return false;
-      console.log(latestVersion);
       return latestVersion.executable;
     });
 

--- a/src/management-system-v2/components/process-list.tsx
+++ b/src/management-system-v2/components/process-list.tsx
@@ -561,6 +561,7 @@ type ProcessDeploymentListProps = PropsWithChildren<{
   openFolder: (id: string) => void;
   deploymentButtons: (additionalProps: { process: ProcessListProcess }) => ReactElement;
   isReadOnly: boolean;
+  loading?: boolean;
 }>;
 
 const ProcessDeploymentList: FC<ProcessDeploymentListProps> = ({
@@ -569,6 +570,7 @@ const ProcessDeploymentList: FC<ProcessDeploymentListProps> = ({
   openFolder,
   deploymentButtons,
   isReadOnly,
+  loading = false,
 }) => {
   const breakpoint = Grid.useBreakpoint();
 
@@ -576,6 +578,7 @@ const ProcessDeploymentList: FC<ProcessDeploymentListProps> = ({
     <BaseProcessList
       data={data}
       folder={folder}
+      tableProps={{ loading }}
       columnCustomRenderer={{
         ['Favorites']: (id) => {
           return id !== folder.parentId ? (

--- a/src/management-system-v2/lib/data/processes.tsx
+++ b/src/management-system-v2/lib/data/processes.tsx
@@ -46,6 +46,7 @@ import {
   checkIfProcessExists,
   copyProcessArtifactReferences,
   copyProcessFiles,
+  getProcessLatestVersion,
 } from './db/process';
 import { v4 } from 'uuid';
 import { toCustomUTCString } from '../helpers/timeHelper';
@@ -724,6 +725,18 @@ export const setVersionAsLatest = async (processId: string, versionId: string, s
   if (error) return error;
 
   await selectAsLatestVersion(processId, versionId);
+};
+
+export const getLatestVersion = async (spaceId: string, processId: string) => {
+  try {
+    const error = await checkValidity(processId, 'view', spaceId);
+
+    if (error) return error;
+
+    return await getProcessLatestVersion(processId);
+  } catch (err) {
+    return internalError();
+  }
 };
 
 export const getFavouritesProcessIds = async () => {


### PR DESCRIPTION
## Summary

Fixed: Currently any process can be deployed when it has at least one version. 
This PR changes that to only allow deployment of processes where the most recent version is marked as executable.

## Details

- processes for which the most recent version is not executable are hidden from the deployment modal => they cannot be deployed
- fixed: the deployment modal does not update after its first load so any changes that would affect which processes are deployable are only applied on a page reload