### PR TITLE
Routing Fixes

### DIFF
--- a/src/management-system-v2/app/(auth)/signin/page.tsx
+++ b/src/management-system-v2/app/(auth)/signin/page.tsx
@@ -3,10 +3,10 @@ import { getCurrentUser } from '@/components/auth';
 import { redirect } from 'next/navigation';
 import SignIn from './signin';
 import { generateGuestReferenceToken } from '@/lib/reference-guest-user-token';
-import { env } from '@/lib/ms-config/env-vars';
 import db from '@/lib/data/db';
 import { connection } from 'next/server';
 import { Suspense } from 'react';
+import { getMSConfig } from '@/lib/ms-config/ms-config';
 
 const dayInMS = 1000 * 60 * 60 * 24;
 
@@ -60,7 +60,8 @@ const Deferred: React.FC<{}> = async ({}) => {
   else userType = isGuest ? ('guest' as const) : ('user' as const);
 
   let logoUrl;
-  if (env.PROCEED_PUBLIC_IAM_ONLY_ONE_ORGANIZATIONAL_SPACE) {
+  const config = await getMSConfig();
+  if (config.PROCEED_PUBLIC_IAM_ONLY_ONE_ORGANIZATIONAL_SPACE) {
     const org = await db.space.findFirst({
       where: {
         isOrganization: true,

--- a/src/management-system-v2/app/(dashboard)/[environmentId]/layout.tsx
+++ b/src/management-system-v2/app/(dashboard)/[environmentId]/layout.tsx
@@ -2,7 +2,7 @@ import { PropsWithChildren } from 'react';
 import { getCurrentEnvironment, getCurrentUser, getSystemAdminRules } from '@/components/auth';
 import { SetAbility } from '@/lib/abilityStore';
 import Layout, { ExtendedMenuItems } from './layout-client';
-import { getUserOrganizationEnvironments } from '@/lib/data/db/iam/memberships';
+import { getUserOrganizationEnvironments, isMember } from '@/lib/data/db/iam/memberships';
 import { MenuProps } from 'antd';
 
 import {
@@ -48,6 +48,7 @@ import { env } from '@/lib/ms-config/env-vars';
 import { getUserPassword } from '@/lib/data/db/iam/users';
 import ActiveTasksBadge from '@/components/active-tasks-badge';
 import { syncOrganizationUsers } from '@/lib/data/db/machine-config';
+import { redirect } from 'next/navigation';
 
 const DashboardLayout = async (
   props: PropsWithChildren<{ params: Promise<{ environmentId: string }> }>,
@@ -57,6 +58,14 @@ const DashboardLayout = async (
   const { children } = props;
 
   const { session, userId, systemAdmin, user } = await getCurrentUser();
+
+  let spaceId = decodeURIComponent(params.environmentId);
+  if (spaceId === 'my') spaceId = userId;
+  const isMemberInSpace = await isMember(spaceId, userId);
+
+  if (!isMemberInSpace) {
+    return redirect('/start');
+  }
 
   const { activeEnvironment, ability } = await getCurrentEnvironment(params.environmentId);
   const can = ability.can.bind(ability);

--- a/src/management-system-v2/app/(dashboard)/[environmentId]/machine-config/page.tsx
+++ b/src/management-system-v2/app/(dashboard)/[environmentId]/machine-config/page.tsx
@@ -22,12 +22,12 @@ const MachineConfigPage = async ({
 }: {
   params: Promise<{ environmentId: string; folderId?: string }>;
 }) => {
+  const { environmentId } = await params;
+  const { ability, activeEnvironment } = await getCurrentEnvironment(environmentId);
+
   if (!env.PROCEED_PUBLIC_CONFIG_SERVER_ACTIVE) {
     return notFound();
   }
-  const { environmentId } = await params;
-
-  const { ability, activeEnvironment } = await getCurrentEnvironment(environmentId);
 
   if (!ability.can('view', 'MachineConfig')) return <UnauthorizedFallback />;
 

--- a/src/management-system-v2/app/(dashboard)/[environmentId]/machine-config/page.tsx
+++ b/src/management-system-v2/app/(dashboard)/[environmentId]/machine-config/page.tsx
@@ -13,8 +13,8 @@ import {
 } from '@/lib/data/db/machine-config';
 import ParentConfigList from './parent-config-list';
 import { Config } from '@/lib/data/machine-config-schema';
-import { env } from '@/lib/ms-config/env-vars';
 import UnauthorizedFallback from '@/components/unauthorized-fallback';
+import { getMSConfig } from '@/lib/ms-config/ms-config';
 export type ListItem = Config;
 
 const MachineConfigPage = async ({
@@ -22,12 +22,13 @@ const MachineConfigPage = async ({
 }: {
   params: Promise<{ environmentId: string; folderId?: string }>;
 }) => {
-  const { environmentId } = await params;
-  const { ability, activeEnvironment } = await getCurrentEnvironment(environmentId);
-
-  if (!env.PROCEED_PUBLIC_CONFIG_SERVER_ACTIVE) {
+  const config = await getMSConfig();
+  if (!config.PROCEED_PUBLIC_CONFIG_SERVER_ACTIVE) {
     return notFound();
   }
+
+  const { environmentId } = await params;
+  const { ability, activeEnvironment } = await getCurrentEnvironment(environmentId);
 
   if (!ability.can('view', 'MachineConfig')) return <UnauthorizedFallback />;
 

--- a/src/management-system-v2/app/admin/users/page.tsx
+++ b/src/management-system-v2/app/admin/users/page.tsx
@@ -7,7 +7,7 @@ import UserTable from './user-table';
 import { UserErrorType, userError } from '@/lib/user-error';
 import Content from '@/components/content';
 import { UserHasToDeleteOrganizationsError } from '@/lib/data/db/iam/users';
-import { env } from '@/lib/ms-config/env-vars';
+import { getMSConfig } from '@/lib/ms-config/ms-config';
 
 async function deleteUsers(userIds: string[]) {
   'use server';
@@ -27,7 +27,8 @@ async function deleteUsers(userIds: string[]) {
 export type deleteUsers = typeof deleteUsers;
 
 export default async function UsersPage() {
-  if (!env.PROCEED_PUBLIC_IAM_ACTIVE) return notFound();
+  const msConfig = await getMSConfig();
+  if (!msConfig.PROCEED_PUBLIC_IAM_ACTIVE) return notFound();
 
   const user = await getCurrentUser();
   if (!user.session) redirect('/');

--- a/src/management-system-v2/app/api/register-new-user/route.ts
+++ b/src/management-system-v2/app/api/register-new-user/route.ts
@@ -6,7 +6,7 @@ import {
 import db from '@/lib/data/db';
 import { addUser, setUserPassword } from '@/lib/data/db/iam/users';
 import { getTokenHash, notExpired } from '@/lib/email-verification-tokens/utils';
-import { env } from '@/lib/ms-config/env-vars';
+import { getMSConfig } from '@/lib/ms-config/ms-config';
 
 // TODO: maybe add PRETTIER error handling
 
@@ -65,12 +65,13 @@ export const GET = async (req: Request) => {
 
     // NOTE: if the id of the email provider is changed, it also has to be changed in the
     // signinUrl
-    const nextAuthEmailRedirect = new URL('/api/auth/callback/email', env.NEXTAUTH_URL!);
+    const config = await getMSConfig();
+    const nextAuthEmailRedirect = new URL('/api/auth/callback/email', config.NEXTAUTH_URL!);
     nextAuthEmailRedirect.searchParams.set('token', token);
     nextAuthEmailRedirect.searchParams.set('email', identifier);
     nextAuthEmailRedirect.searchParams.set(
       'callbackUrl',
-      searchParams.get('callbackUrl') ?? env.NEXTAUTH_URL!,
+      searchParams.get('callbackUrl') ?? config.NEXTAUTH_URL!,
     );
 
     redirectUrl = nextAuthEmailRedirect.toString();

--- a/src/management-system-v2/app/api/spaces/[spaceId]/route.ts
+++ b/src/management-system-v2/app/api/spaces/[spaceId]/route.ts
@@ -1,5 +1,5 @@
 import db from '@/lib/data/db';
-import { env } from '@/lib/ms-config/env-vars';
+import { getMSConfig } from '@/lib/ms-config/ms-config';
 import { NextRequest, NextResponse } from 'next/server';
 
 export async function GET(request: NextRequest, props: { params: Promise<{ spaceId: string }> }) {
@@ -7,7 +7,8 @@ export async function GET(request: NextRequest, props: { params: Promise<{ space
 
   const { spaceId } = params;
 
-  if (!env.PROCEED_PUBLIC_IAM_ACTIVE) {
+  const config = await getMSConfig();
+  if (!config.PROCEED_PUBLIC_IAM_ACTIVE) {
     return NextResponse.json({
       id: 'proceed-default-no-iam-user',
       type: 'personal',

--- a/src/management-system-v2/app/api/spaces/route.ts
+++ b/src/management-system-v2/app/api/spaces/route.ts
@@ -1,9 +1,10 @@
 import { NextRequest, NextResponse } from 'next/server';
 import db from '@/lib/data/db';
-import { env } from '@/lib/ms-config/env-vars';
+import { getMSConfig } from '@/lib/ms-config/ms-config';
 
 export async function GET(request: NextRequest) {
-  if (!env.PROCEED_PUBLIC_IAM_ACTIVE) {
+  const config = await getMSConfig();
+  if (!config.PROCEED_PUBLIC_IAM_ACTIVE) {
     return NextResponse.json([
       { id: 'proceed-default-no-iam-user', type: 'personal', name: 'Default User' },
     ]);

--- a/src/management-system-v2/app/create-organization/page.tsx
+++ b/src/management-system-v2/app/create-organization/page.tsx
@@ -26,10 +26,8 @@ export type createInactiveEnvironment = typeof createInactiveEnvironment;
 const unallowedProviders = ['guest-signin', 'development-users'];
 
 const Page = async () => {
-  if (
-    !env.PROCEED_PUBLIC_IAM_ACTIVE ||
-    (await getMSConfig()).PROCEED_PUBLIC_IAM_ONLY_ONE_ORGANIZATIONAL_SPACE
-  ) {
+  const config = await getMSConfig();
+  if (!env.PROCEED_PUBLIC_IAM_ACTIVE || config.PROCEED_PUBLIC_IAM_ONLY_ONE_ORGANIZATIONAL_SPACE) {
     return notFound();
   }
 

--- a/src/management-system-v2/app/create-organization/page.tsx
+++ b/src/management-system-v2/app/create-organization/page.tsx
@@ -6,7 +6,6 @@ import { addEnvironment } from '@/lib/data/db/iam/environments';
 import { getErrorMessage, userError } from '@/lib/user-error';
 import { getMSConfig } from '@/lib/ms-config/ms-config';
 import { notFound } from 'next/navigation';
-import { env } from '@/lib/ms-config/env-vars';
 
 async function createInactiveEnvironment(data: UserOrganizationEnvironmentInput) {
   'use server';
@@ -27,7 +26,10 @@ const unallowedProviders = ['guest-signin', 'development-users'];
 
 const Page = async () => {
   const config = await getMSConfig();
-  if (!env.PROCEED_PUBLIC_IAM_ACTIVE || config.PROCEED_PUBLIC_IAM_ONLY_ONE_ORGANIZATIONAL_SPACE) {
+  if (
+    !config.PROCEED_PUBLIC_IAM_ACTIVE ||
+    config.PROCEED_PUBLIC_IAM_ONLY_ONE_ORGANIZATIONAL_SPACE
+  ) {
     return notFound();
   }
 

--- a/src/management-system-v2/app/shared-viewer/page.tsx
+++ b/src/management-system-v2/app/shared-viewer/page.tsx
@@ -20,7 +20,6 @@ import { getDefinitionsAndProcessIdForEveryCallActivity } from '@proceed/bpmn-he
 
 import { SettingsOption } from './settings-modal';
 import { asyncMap } from '@/lib/helpers/javascriptHelpers';
-import { env } from '@/lib/ms-config/env-vars';
 import { ColorOptions } from '../(dashboard)/[environmentId]/(automation)/executions/[processId]/instance-coloring';
 import InstanceDocumentationPage from './instance-documentation-page';
 import { Metadata } from 'next';
@@ -30,6 +29,7 @@ import db from '@/lib/data/db';
 import { isUserErrorResponse } from '@/lib/user-error';
 import { getInstance } from '@/lib/data/instance';
 import { refetchDeployments } from '@/lib/executions/deployment-server-actions';
+import { getMSConfig } from '@/lib/ms-config/ms-config';
 
 interface PageProps {
   searchParams: Promise<{
@@ -152,7 +152,8 @@ export async function generateMetadata(props: PageProps): Promise<Metadata> {
   if (typeof token !== 'string') return {};
 
   try {
-    const key = env.SHARING_ENCRYPTION_SECRET;
+    const config = await getMSConfig();
+    const key = config.SHARING_ENCRYPTION_SECRET;
     const { processId, timestamp, embeddedMode } = jwt.verify(token, key!) as TokenPayload;
     const versionId = version as string | undefined;
     const versionLabel = versionId ?? 'Latest';
@@ -221,7 +222,8 @@ const SharedViewer = async (props: PageProps) => {
   let activeSpaceId = userId || '';
   let activeIsOrg = false;
 
-  const key = env.SHARING_ENCRYPTION_SECRET;
+  const config = await getMSConfig();
+  const key = config.SHARING_ENCRYPTION_SECRET;
   let processData: Process | undefined;
   let iframeMode;
   let defaultSettings = settings as SettingsOption;


### PR DESCRIPTION
## Summary

Fixed a few bugs related to navigation and routes.

## Details

- fixed: static rendering leads to some routes not working on the first navigation resulting in a 404 error that can only be resolved with a page refresh
- fixed: when a user logs out inside a space and another user that cannot access that space logs in they are shown an error due to missing access rights
  - the user is navigated to the start page in their personal space instead
- fixed: when a user logs out on the /profile, /start or /spaces routes inside a space and another user that cannot access that space logs in they are still shown the respective routes as if they are inside that space with the unresolved space id in the space selection menu
  - the user is navigated to the start page in their personal space instead 
