### PR TITLE
Improved "Possible Performers" and "Responsible Persons" Selection

### DIFF
--- a/src/management-system-v2/app/(dashboard)/[environmentId]/processes/[mode]/[processId]/potential-owner.tsx
+++ b/src/management-system-v2/app/(dashboard)/[environmentId]/processes/[mode]/[processId]/potential-owner.tsx
@@ -1,6 +1,6 @@
 import React, { FC, useEffect, useState } from 'react';
 import type { ElementLike } from 'diagram-js/lib/core/Types';
-import { Divider, Space, Tooltip, Button, Cascader } from 'antd';
+import { Divider, Space, Tooltip, Button, Cascader, Tag, Select } from 'antd';
 import { UserOutlined, TeamOutlined, QuestionCircleOutlined } from '@ant-design/icons';
 import { BPMNCanvasRef } from '@/components/bpmn-canvas';
 import type { CascaderProps, GetProp } from 'antd';
@@ -105,6 +105,23 @@ function updateResource(
   }
 }
 
+const customTagRender: React.ComponentProps<typeof Cascader>['tagRender'] = ({
+  label,
+  value,
+  ...rest
+}) => {
+  if (value === 'all-user') {
+    label = 'All Users';
+  } else if (value === 'all-roles') {
+    label = 'All Roles';
+  }
+  return (
+    <Tag style={{ marginRight: '5px', backgroundColor: 'rgb(0, 0, 0, 0.06)' }} {...rest}>
+      {label}
+    </Tag>
+  );
+};
+
 const filter = (inputValue: string, path: DefaultOptionType[]) =>
   path.some((option) => `${option?.value}`.toLowerCase().indexOf(inputValue.toLowerCase()) > -1);
 
@@ -165,6 +182,7 @@ export const PotentialOwner: FC<PotentialOwnerProps> = ({
               placeholder="Select User or Roles that can claim this task"
               style={{ width: '100%' }}
               multiple
+              tagRender={customTagRender}
               showSearch={{ filter }}
               // @ts-ignore
               onChange={setPotentialOwner}
@@ -243,6 +261,7 @@ export const ResponsibleParty: FC<ResponsibilityProps> = ({
             placeholder="Select User or Roles responsible"
             style={{ width: '100%' }}
             multiple
+            tagRender={customTagRender}
             showSearch={{ filter }}
             // @ts-ignore
             onChange={setResponsible}

--- a/src/management-system-v2/app/(dashboard)/[environmentId]/processes/[mode]/[processId]/potentialOwner-server-action.ts
+++ b/src/management-system-v2/app/(dashboard)/[environmentId]/processes/[mode]/[processId]/potentialOwner-server-action.ts
@@ -3,6 +3,8 @@
 import { getCurrentEnvironment, getCurrentUser } from '@/components/auth';
 import { getRolesWithMembers } from '@/lib/data/db/iam/roles';
 import { RoleType, UserType } from './use-potentialOwner-store';
+import { getSpaceUsers } from '@/lib/data/users';
+import { isUserErrorResponse } from '@/lib/user-error';
 
 export const fetchPotentialOwner = async (environmentId: string) => {
   const user: UserType = {};
@@ -12,16 +14,19 @@ export const fetchPotentialOwner = async (environmentId: string) => {
 
     if (activeEnvironment.isOrganization) {
       const rawRoles = await getRolesWithMembers(activeEnvironment.spaceId, ability);
+      const users = await getSpaceUsers(activeEnvironment.spaceId);
+
+      if (!isUserErrorResponse(users)) {
+        users.forEach((u) => {
+          user[u.id] = {
+            userName: u.username || undefined,
+            name: (u.firstName + ' ' + u.lastName).trim(),
+          };
+        });
+      }
 
       rawRoles.forEach((role) => {
         roles[role.id] = role.name;
-
-        role.members.forEach((member) => {
-          user[member.id] = {
-            userName: member.username,
-            name: member.firstName + ' ' + member.lastName,
-          };
-        });
       });
     } else {
       // make sure to get the current user that might not be assigned to any role

--- a/src/management-system-v2/lib/data/db/iam/memberships.ts
+++ b/src/management-system-v2/lib/data/db/iam/memberships.ts
@@ -111,24 +111,6 @@ export async function getFullMembersWithRoles(environmentId: string, ability?: A
 /**
  * Returns the users that exist in a specific space
  */
-export async function getUsersInSpace(spaceId: string, ability?: Ability) {
-  //TODO: ability check
-  if (ability) ability;
-
-  const users = await db.user.findMany({
-    where: {
-      memberIn: {
-        some: {
-          space: {
-            id: spaceId,
-          },
-        },
-      },
-    },
-  });
-
-  return users;
-}
 
 export async function isMember(
   environmentId: string,

--- a/src/management-system-v2/lib/data/users.tsx
+++ b/src/management-system-v2/lib/data/users.tsx
@@ -1,7 +1,7 @@
 'use server';
 
 import { getCurrentEnvironment, getCurrentUser } from '@/components/auth';
-import { UserErrorType, getErrorMessage, userError } from '../user-error';
+import { UserErrorType, getErrorMessage, permissionDenied, userError } from '../user-error';
 import { AuthenticatedUserData, AuthenticatedUserDataSchema } from './user-schema';
 import { ReactNode } from 'react';
 import { OrganizationEnvironment } from './environment-schema';
@@ -12,6 +12,7 @@ import {
   updateUser as _updateUser,
   setUserPassword as _setUserPassword,
   getUserById,
+  getSpaceUsers as _getSpaceUsers,
 } from '@/lib/data/db/iam/users';
 import { revalidatePath } from 'next/cache';
 import { getEnvironmentById } from './db/iam/environments';
@@ -19,6 +20,16 @@ import { hashPassword } from '../password-hashes';
 import { getAppliedRolesForUser } from '../authorization/organizationEnvironmentRolesHelper';
 import db from '@/lib/data/db/index';
 import { env } from '../ms-config/env-vars';
+
+export async function getSpaceUsers(spaceId: string) {
+  const { ability, activeEnvironment } = await getCurrentEnvironment(spaceId);
+
+  if (!ability.can('view', 'User')) return permissionDenied();
+
+  const users = await _getSpaceUsers(spaceId, activeEnvironment.isOrganization);
+
+  return ability.filter('view', 'User', users);
+}
 
 export async function deleteUser() {
   const { userId } = await getCurrentUser();


### PR DESCRIPTION
## Summary

Fixed that the inputs for "Possible Performers" and "Responsible Persons" show all users in a space and not only the ones assigned to at least one role.
Slight improvement in what is shown when all users or all roles are selected

## Details

- fixed: when a user is not assigned to a role in a space that user will not be selectable as a "Possible Performer" or "Responsible Person"
- when all users of the space are selected as a "Possible Performer" or "Responsible Person" the selection will show "All Users" instead of "User"
- when all roles of the space are selected as a "Possible Performer" or "Responsible Person" the selection will show "All Roles" instead of "Role"
